### PR TITLE
Fix asyncio.run() pattern in all buyer tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "aiosqlite>=0.20.0",
     "pyyaml>=6.0.0",
+    "nest-asyncio>=1.6.0",
 ]
 
 [project.optional-dependencies]

--- a/src/ad_buyer/async_utils.py
+++ b/src/ad_buyer/async_utils.py
@@ -1,0 +1,41 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Safe async execution utilities.
+
+Provides run_async() which works correctly whether or not an asyncio
+event loop is already running. This is needed because CrewAI and FastAPI
+run their own event loops, and calling asyncio.run() from within a
+running loop raises RuntimeError.
+"""
+
+import asyncio
+from typing import Any, Coroutine, TypeVar
+
+import nest_asyncio
+
+T = TypeVar("T")
+
+
+def run_async(coro: Coroutine[Any, Any, T]) -> T:
+    """Run an async coroutine safely from synchronous code.
+
+    Works in both standalone contexts (no running loop) and within
+    already-running event loops (CrewAI, FastAPI, Jupyter, etc.).
+
+    Args:
+        coro: The coroutine to execute.
+
+    Returns:
+        The result of the coroutine.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop -- safe to use asyncio.run()
+        return asyncio.run(coro)
+    else:
+        # Already inside a running loop -- patch it with nest_asyncio
+        # so we can call run_until_complete without RuntimeError.
+        nest_asyncio.apply(loop)
+        return loop.run_until_complete(coro)

--- a/src/ad_buyer/tools/audience/audience_discovery.py
+++ b/src/ad_buyer/tools/audience/audience_discovery.py
@@ -3,12 +3,12 @@
 
 """Audience Discovery Tool - Discover available audience signals from sellers."""
 
-import asyncio
 from typing import Any, Optional, Type
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+from ...async_utils import run_async
 from ...clients.ucp_client import UCPClient
 from ...models.ucp import AudienceCapability, SignalType
 
@@ -52,7 +52,7 @@ class AudienceDiscoveryTool(BaseTool):
         min_coverage: Optional[float] = None,
     ) -> str:
         """Execute the audience discovery."""
-        return asyncio.run(
+        return run_async(
             self._arun(seller_endpoint, signal_types, min_coverage)
         )
 

--- a/src/ad_buyer/tools/audience/audience_matching.py
+++ b/src/ad_buyer/tools/audience/audience_matching.py
@@ -3,12 +3,12 @@
 
 """Audience Matching Tool - Match campaign audiences to inventory via UCP."""
 
-import asyncio
 from typing import Any, Optional, Type
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+from ...async_utils import run_async
 from ...clients.ucp_client import UCPClient
 from ...models.ucp import UCPConsent
 
@@ -66,7 +66,7 @@ class AudienceMatchingTool(BaseTool):
         exclusions: Optional[list[str]] = None,
     ) -> str:
         """Execute the audience matching."""
-        return asyncio.run(
+        return run_async(
             self._arun(
                 seller_endpoint,
                 demographics,

--- a/src/ad_buyer/tools/audience/coverage_estimation.py
+++ b/src/ad_buyer/tools/audience/coverage_estimation.py
@@ -3,12 +3,12 @@
 
 """Coverage Estimation Tool - Estimate audience coverage for targeting."""
 
-import asyncio
 from typing import Any, Optional, Type
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+from ...async_utils import run_async
 from ...models.ucp import CoverageEstimate
 
 
@@ -50,7 +50,7 @@ class CoverageEstimationTool(BaseTool):
         total_impressions: Optional[int] = 10000000,
     ) -> str:
         """Execute the coverage estimation."""
-        return asyncio.run(
+        return run_async(
             self._arun(targeting, channel, total_impressions)
         )
 

--- a/src/ad_buyer/tools/dsp/discover_inventory.py
+++ b/src/ad_buyer/tools/dsp/discover_inventory.py
@@ -3,12 +3,12 @@
 
 """Inventory discovery tool for DSP workflows."""
 
-import asyncio
 from typing import Any, Optional
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+from ...async_utils import run_async
 from ...clients.unified_client import Protocol, UnifiedClient
 from ...models.buyer_identity import BuyerContext
 
@@ -102,7 +102,7 @@ Returns:
         publisher: Optional[str] = None,
     ) -> str:
         """Synchronous wrapper for async discovery."""
-        return asyncio.run(
+        return run_async(
             self._arun(
                 query=query,
                 channel=channel,

--- a/src/ad_buyer/tools/dsp/get_pricing.py
+++ b/src/ad_buyer/tools/dsp/get_pricing.py
@@ -3,12 +3,12 @@
 
 """Tiered pricing tool for DSP workflows."""
 
-import asyncio
 from typing import Any, Optional
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+from ...async_utils import run_async
 from ...clients.unified_client import Protocol, UnifiedClient
 from ...models.buyer_identity import AccessTier, BuyerContext, DealType
 
@@ -96,7 +96,7 @@ Returns:
         flight_end: Optional[str] = None,
     ) -> str:
         """Synchronous wrapper for async pricing."""
-        return asyncio.run(
+        return run_async(
             self._arun(
                 product_id=product_id,
                 volume=volume,

--- a/src/ad_buyer/tools/dsp/request_deal.py
+++ b/src/ad_buyer/tools/dsp/request_deal.py
@@ -3,7 +3,6 @@
 
 """Deal ID request tool for DSP workflows."""
 
-import asyncio
 import hashlib
 from datetime import datetime, timedelta
 from typing import Any, Optional
@@ -11,6 +10,7 @@ from typing import Any, Optional
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+from ...async_utils import run_async
 from ...clients.unified_client import Protocol, UnifiedClient
 from ...models.buyer_identity import (
     AccessTier,
@@ -112,7 +112,7 @@ Returns:
         target_cpm: Optional[float] = None,
     ) -> str:
         """Synchronous wrapper for async deal request."""
-        return asyncio.run(
+        return run_async(
             self._arun(
                 product_id=product_id,
                 deal_type=deal_type,

--- a/src/ad_buyer/tools/execution/line_management.py
+++ b/src/ad_buyer/tools/execution/line_management.py
@@ -3,13 +3,13 @@
 
 """Line item management tools for booking inventory."""
 
-import asyncio
 from datetime import datetime
 from typing import Any, Optional
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+from ...async_utils import run_async
 from ...clients.opendirect_client import OpenDirectClient
 from ...models.opendirect import Line, RateType
 
@@ -80,7 +80,7 @@ Returns:
         targeting: Optional[dict[str, Any]] = None,
     ) -> str:
         """Synchronous wrapper for async line creation."""
-        return asyncio.run(
+        return run_async(
             self._arun(
                 account_id=account_id,
                 order_id=order_id,
@@ -207,7 +207,7 @@ Returns:
         line_id: str,
     ) -> str:
         """Synchronous wrapper for async reserve."""
-        return asyncio.run(
+        return run_async(
             self._arun(
                 account_id=account_id,
                 order_id=order_id,
@@ -278,7 +278,7 @@ Returns:
         line_id: str,
     ) -> str:
         """Synchronous wrapper for async book."""
-        return asyncio.run(
+        return run_async(
             self._arun(
                 account_id=account_id,
                 order_id=order_id,

--- a/src/ad_buyer/tools/execution/order_management.py
+++ b/src/ad_buyer/tools/execution/order_management.py
@@ -3,13 +3,13 @@
 
 """Order management tool for creating advertising orders."""
 
-import asyncio
 from datetime import datetime
 from typing import Any
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+from ...async_utils import run_async
 from ...clients.opendirect_client import OpenDirectClient
 from ...models.opendirect import Order
 
@@ -93,7 +93,7 @@ Returns:
         publisher_id: str | None = None,
     ) -> str:
         """Synchronous wrapper for async order creation."""
-        return asyncio.run(
+        return run_async(
             self._arun(
                 account_id=account_id,
                 order_name=order_name,

--- a/src/ad_buyer/tools/reporting/stats_retrieval.py
+++ b/src/ad_buyer/tools/reporting/stats_retrieval.py
@@ -3,12 +3,12 @@
 
 """Stats retrieval tool for performance reporting."""
 
-import asyncio
 from typing import Any
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+from ...async_utils import run_async
 from ...clients.opendirect_client import OpenDirectClient
 
 
@@ -50,7 +50,7 @@ Returns:
         line_id: str,
     ) -> str:
         """Synchronous wrapper for async stats retrieval."""
-        return asyncio.run(
+        return run_async(
             self._arun(
                 account_id=account_id,
                 order_id=order_id,

--- a/src/ad_buyer/tools/research/avails_check.py
+++ b/src/ad_buyer/tools/research/avails_check.py
@@ -3,13 +3,13 @@
 
 """Availability check tool for inventory pricing."""
 
-import asyncio
 from datetime import datetime
 from typing import Any, Optional
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+from ...async_utils import run_async
 from ...clients.opendirect_client import OpenDirectClient
 from ...models.opendirect import AvailsRequest
 
@@ -74,7 +74,7 @@ Returns:
         budget: Optional[float] = None,
     ) -> str:
         """Synchronous wrapper for async avails check."""
-        return asyncio.run(
+        return run_async(
             self._arun(
                 product_id=product_id,
                 start_date=start_date,

--- a/src/ad_buyer/tools/research/product_search.py
+++ b/src/ad_buyer/tools/research/product_search.py
@@ -3,12 +3,12 @@
 
 """Product search tool for inventory discovery."""
 
-import asyncio
 from typing import Any, Optional
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+from ...async_utils import run_async
 from ...clients.opendirect_client import OpenDirectClient
 
 
@@ -92,7 +92,7 @@ Returns:
         limit: int = 10,
     ) -> str:
         """Synchronous wrapper for async search."""
-        return asyncio.run(
+        return run_async(
             self._arun(
                 channel=channel,
                 format=format,

--- a/tests/unit/test_async_pattern.py
+++ b/tests/unit/test_async_pattern.py
@@ -1,0 +1,58 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Tests for the safe async execution pattern.
+
+Verifies that run_async works both when no event loop is running
+(standalone context) and when called from within an already-running
+event loop (CrewAI/FastAPI context).
+"""
+
+import asyncio
+
+import pytest
+
+from ad_buyer.async_utils import run_async
+
+
+async def _sample_coroutine(value: int) -> int:
+    """Simple coroutine for testing."""
+    await asyncio.sleep(0)  # Yield to event loop
+    return value * 2
+
+
+def test_run_async_no_running_loop():
+    """run_async works when no event loop is running (standalone)."""
+    result = run_async(_sample_coroutine(21))
+    assert result == 42
+
+
+@pytest.mark.asyncio
+async def test_run_async_inside_running_loop():
+    """run_async works when called from within an already-running event loop.
+
+    This is the exact scenario that causes RuntimeError with asyncio.run().
+    CrewAI and FastAPI both run their own event loops, so tools called
+    from those contexts hit this case.
+    """
+    result = run_async(_sample_coroutine(21))
+    assert result == 42
+
+
+def test_run_async_propagates_exceptions():
+    """run_async propagates exceptions from the coroutine."""
+    async def _failing():
+        raise ValueError("test error")
+
+    with pytest.raises(ValueError, match="test error"):
+        run_async(_failing())
+
+
+@pytest.mark.asyncio
+async def test_run_async_propagates_exceptions_in_running_loop():
+    """run_async propagates exceptions even inside a running loop."""
+    async def _failing():
+        raise ValueError("test error")
+
+    with pytest.raises(ValueError, match="test error"):
+        run_async(_failing())


### PR DESCRIPTION
## Summary
- Replace `asyncio.run()` with `run_async()` helper that safely handles already-running event loops (CrewAI/FastAPI contexts)
- Add `nest-asyncio` dependency
- Fix applied across 11 tool files (13 call sites)
- New `src/ad_buyer/async_utils.py` utility module

## Test Results
- 87/87 tests pass (4 new tests for async pattern)
- Quinn verified

## References
- Karl review H-3, Mel review P1-1
- bead: ar-ci3

🤖 Generated with [Claude Code](https://claude.com/claude-code)