### PR TITLE
Extract hardcoded server URLs to Settings config

### DIFF
--- a/src/ad_buyer/clients/a2a_client.py
+++ b/src/ad_buyer/clients/a2a_client.py
@@ -64,7 +64,7 @@ class A2AClient:
 
     def __init__(
         self,
-        base_url: str = "https://agentic-direct-server-hwgrypmndq-uk.a.run.app",
+        base_url: str,
         agent_type: str = "buyer",
         timeout: float = 60.0,
     ):

--- a/src/ad_buyer/clients/mcp_client.py
+++ b/src/ad_buyer/clients/mcp_client.py
@@ -168,7 +168,7 @@ class IABMCPClient:
 
     def __init__(
         self,
-        base_url: str = "https://agentic-direct-server-hwgrypmndq-uk.a.run.app",
+        base_url: str,
     ):
         """Initialize the MCP client.
 

--- a/src/ad_buyer/clients/unified_client.py
+++ b/src/ad_buyer/clients/unified_client.py
@@ -86,7 +86,7 @@ class UnifiedClient:
 
     def __init__(
         self,
-        base_url: str = "https://agentic-direct-server-hwgrypmndq-uk.a.run.app",
+        base_url: str,
         protocol: Protocol = Protocol.MCP,
         a2a_agent_type: str = "buyer",
         buyer_identity: "Optional[BuyerIdentity]" = None,

--- a/src/ad_buyer/config/settings.py
+++ b/src/ad_buyer/config/settings.py
@@ -19,6 +19,10 @@ class Settings(BaseSettings):
     # API Keys
     anthropic_api_key: str = ""
 
+    # IAB agentic-direct server URL (required — no default)
+    # Set via IAB_SERVER_URL env var or .env file
+    iab_server_url: str
+
     # Seller Agent Endpoints (comma-separated list of MCP/A2A server URLs)
     # Each endpoint should implement IAB Tech Lab OpenDirect/AdCOM standards
     seller_endpoints: str = ""

--- a/src/ad_buyer/config/settings.py
+++ b/src/ad_buyer/config/settings.py
@@ -19,9 +19,9 @@ class Settings(BaseSettings):
     # API Keys
     anthropic_api_key: str = ""
 
-    # IAB agentic-direct server URL (required — no default)
-    # Set via IAB_SERVER_URL env var or .env file
-    iab_server_url: str
+    # IAB agentic-direct server URL
+    # Override via IAB_SERVER_URL env var or .env file
+    iab_server_url: str = "http://localhost:8001"
 
     # Seller Agent Endpoints (comma-separated list of MCP/A2A server URLs)
     # Each endpoint should implement IAB Tech Lab OpenDirect/AdCOM standards

--- a/src/ad_buyer/flows/dsp_deal_flow.py
+++ b/src/ad_buyer/flows/dsp_deal_flow.py
@@ -375,7 +375,7 @@ async def run_dsp_deal_flow(
     max_cpm: Optional[float] = None,
     flight_start: Optional[str] = None,
     flight_end: Optional[str] = None,
-    base_url: str = "https://agentic-direct-server-hwgrypmndq-uk.a.run.app",
+    base_url: Optional[str] = None,
 ) -> dict[str, Any]:
     """Convenience function to run the DSP deal flow.
 
@@ -387,11 +387,16 @@ async def run_dsp_deal_flow(
         max_cpm: Maximum CPM budget
         flight_start: Deal start date
         flight_end: Deal end date
-        base_url: Server URL
+        base_url: Server URL (defaults to Settings.iab_server_url)
 
     Returns:
         Flow result with Deal ID and activation instructions
     """
+    # Resolve server URL from Settings if not provided
+    if base_url is None:
+        from ..config.settings import get_settings
+        base_url = get_settings().iab_server_url
+
     # Create buyer context
     buyer_context = BuyerContext(
         identity=buyer_identity,

--- a/tests/unit/test_no_hardcoded_urls.py
+++ b/tests/unit/test_no_hardcoded_urls.py
@@ -1,0 +1,84 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Tests verifying no hardcoded server URLs remain in client code."""
+
+import ast
+import inspect
+import os
+
+import pytest
+
+
+# Source files that must not contain hardcoded Cloud Run URLs
+CLIENT_SOURCE_FILES = [
+    "src/ad_buyer/clients/unified_client.py",
+    "src/ad_buyer/clients/mcp_client.py",
+    "src/ad_buyer/clients/a2a_client.py",
+    "src/ad_buyer/flows/dsp_deal_flow.py",
+]
+
+# The URL pattern that should not appear as a default parameter value
+HARDCODED_URL = "agentic-direct-server"
+
+
+def _repo_root() -> str:
+    """Return the ad_buyer_system repo root."""
+    # Walk up from this test file to find the repo root
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.abspath(os.path.join(here, "..", ".."))
+
+
+class TestNoHardcodedURLs:
+    """Verify that Cloud Run URLs are not hardcoded as default parameters."""
+
+    @pytest.mark.parametrize("rel_path", CLIENT_SOURCE_FILES)
+    def test_no_hardcoded_url_in_source(self, rel_path: str) -> None:
+        """Source files must not contain the Cloud Run URL as a default parameter."""
+        filepath = os.path.join(_repo_root(), rel_path)
+        with open(filepath) as f:
+            source = f.read()
+
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            # Check function/method default argument values
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for default in node.args.defaults + node.args.kw_defaults:
+                    if default is None:
+                        continue
+                    if isinstance(default, ast.Constant) and isinstance(default.value, str):
+                        assert HARDCODED_URL not in default.value, (
+                            f"{rel_path}: function '{node.name}' has hardcoded "
+                            f"server URL as default parameter"
+                        )
+
+
+class TestSettingsHasIABServerURL:
+    """Verify Settings class exposes iab_server_url field."""
+
+    def test_settings_field_exists(self) -> None:
+        """Settings must have an iab_server_url field."""
+        from ad_buyer.config.settings import Settings
+
+        # iab_server_url should be a required field (no default)
+        fields = Settings.model_fields
+        assert "iab_server_url" in fields, "Settings missing iab_server_url field"
+
+    def test_settings_requires_iab_server_url(self) -> None:
+        """Settings must require iab_server_url (no default value)."""
+        from ad_buyer.config.settings import Settings
+
+        field_info = Settings.model_fields["iab_server_url"]
+        assert field_info.is_required(), (
+            "iab_server_url should be required (no default)"
+        )
+
+    def test_settings_loads_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Settings should load iab_server_url from IAB_SERVER_URL env var."""
+        from ad_buyer.config.settings import Settings
+
+        monkeypatch.setenv("IAB_SERVER_URL", "https://test-server.example.com")
+        # Create a fresh instance (bypass lru_cache)
+        s = Settings()
+        assert s.iab_server_url == "https://test-server.example.com"

--- a/tests/unit/test_no_hardcoded_urls.py
+++ b/tests/unit/test_no_hardcoded_urls.py
@@ -65,13 +65,13 @@ class TestSettingsHasIABServerURL:
         fields = Settings.model_fields
         assert "iab_server_url" in fields, "Settings missing iab_server_url field"
 
-    def test_settings_requires_iab_server_url(self) -> None:
-        """Settings must require iab_server_url (no default value)."""
+    def test_settings_has_local_default(self) -> None:
+        """Settings iab_server_url should default to localhost (not a remote URL)."""
         from ad_buyer.config.settings import Settings
 
         field_info = Settings.model_fields["iab_server_url"]
-        assert field_info.is_required(), (
-            "iab_server_url should be required (no default)"
+        assert field_info.default == "http://localhost:8001", (
+            "iab_server_url should default to localhost:8001"
         )
 
     def test_settings_loads_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Remove hardcoded Google Cloud Run URL from 4 source files
- Add `iab_server_url` field to Settings (defaults to localhost:8001)
- All clients now require explicit `base_url` or use Settings

## Test Results
- 90/90 tests pass (7 new AST-based tests)
- Quinn verified

## References
- Karl review M-6, Mel review P0-1/P0-5
- bead: ar-rqb

🤖 Generated with [Claude Code](https://claude.com/claude-code)