### PR TITLE
Add Deals API Client reference documentation

### DIFF
--- a/docs/api/deals.md
+++ b/docs/api/deals.md
@@ -1,0 +1,583 @@
+# Deals API Client
+
+The `DealsClient` is the buyer's interface to the seller's **quote-then-book** deal endpoints. Instead of fabricating deal IDs client-side, the buyer requests a non-binding price quote from the seller, optionally negotiates, and then books a deal -- receiving a seller-issued Deal ID with OpenRTB activation parameters.
+
+## Overview
+
+```mermaid
+sequenceDiagram
+    participant Buyer as Buyer Agent
+    participant Client as DealsClient
+    participant Seller as Seller Agent
+    participant Store as DealStore
+
+    Buyer->>Client: Request pricing
+    Client->>Seller: POST /api/v1/quotes
+    Seller-->>Client: QuoteResponse (quote_id, pricing, terms)
+    Client->>Store: Persist quote (status: quoted)
+
+    Buyer->>Client: Book the deal
+    Client->>Seller: POST /api/v1/deals
+    Seller-->>Client: DealResponse (deal_id, openrtb_params)
+    Client->>Store: Persist deal (status: booked)
+
+    Buyer->>Client: Check deal status
+    Client->>Seller: GET /api/v1/deals/{deal_id}
+    Seller-->>Client: DealResponse (current status)
+    Client->>Store: Update stored status
+```
+
+!!! info "Why quote-then-book?"
+    Earlier versions of the buyer generated deal IDs locally and hoped the seller would accept them. The quote-then-book flow ensures the seller validates inventory availability, applies tier-based pricing, and issues the authoritative Deal ID. This matches the IAB OpenDirect pattern where the sell-side is the system of record.
+
+---
+
+## Client Initialization
+
+The `DealsClient` is an async HTTP client backed by [httpx](https://www.python-httpx.org/). It supports API key or bearer token authentication, configurable timeouts, automatic retries for transient failures, and optional local persistence via a `DealStore`.
+
+```python
+from ad_buyer.clients.deals_client import DealsClient
+
+# Minimal — API key auth
+client = DealsClient(
+    seller_url="http://seller.example.com:8001",
+    api_key="your-api-key",
+)
+
+# Full configuration with DealStore
+from ad_buyer.storage.deal_store import DealStore
+
+store = DealStore("sqlite:///./ad_buyer.db")
+store.connect()
+
+client = DealsClient(
+    seller_url="http://seller.example.com:8001",
+    bearer_token="eyJhbGci...",
+    timeout=60.0,
+    max_retries=5,
+    deal_store=store,
+)
+```
+
+### Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `seller_url` | `str` | *required* | Base URL of the seller system |
+| `api_key` | `str` | `None` | API key sent via `X-Api-Key` header |
+| `bearer_token` | `str` | `None` | Bearer token sent via `Authorization` header |
+| `timeout` | `float` | `30.0` | Request timeout in seconds |
+| `max_retries` | `int` | `3` | Max retries for transient failures (502/503/504) |
+| `deal_store` | `DealStore` | `None` | Optional local persistence store |
+
+!!! note "Authentication"
+    Provide either `api_key` **or** `bearer_token`, not both. If an API key is set, it takes precedence as the `X-Api-Key` header. Bearer tokens are sent as `Authorization: Bearer <token>`.
+
+### Async Context Manager
+
+The client implements the async context manager protocol for clean resource management:
+
+```python
+async with DealsClient(seller_url, api_key="key") as client:
+    quote = await client.request_quote(quote_request)
+    deal = await client.book_deal(booking_request)
+# HTTP client is automatically closed
+```
+
+Alternatively, call `await client.close()` manually when done.
+
+---
+
+## Core Methods
+
+### Request a Quote
+
+Request non-binding pricing from the seller for a specific product.
+
+**Endpoint:** `POST /api/v1/quotes`
+
+```python
+from ad_buyer.models.deals import QuoteRequest, BuyerIdentityPayload
+
+quote_request = QuoteRequest(
+    product_id="prod-ctv-sports-001",
+    deal_type="PD",
+    impressions=500_000,
+    flight_start="2026-07-01",
+    flight_end="2026-09-30",
+    target_cpm=12.50,
+    buyer_identity=BuyerIdentityPayload(
+        seat_id="ttd-seat-123",
+        agency_id="omnicom-456",
+        advertiser_id="coca-cola",
+    ),
+)
+
+async with DealsClient(seller_url, api_key="key") as client:
+    quote = await client.request_quote(quote_request)
+
+    print(f"Quote ID: {quote.quote_id}")
+    print(f"Status: {quote.status}")           # "available"
+    print(f"Final CPM: ${quote.pricing.final_cpm}")
+    print(f"Tier: {quote.buyer_tier}")
+    print(f"Expires: {quote.expires_at}")
+```
+
+**curl equivalent:**
+
+```bash
+curl -X POST http://seller.example.com:8001/api/v1/quotes \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: your-api-key" \
+  -d '{
+    "product_id": "prod-ctv-sports-001",
+    "deal_type": "PD",
+    "impressions": 500000,
+    "flight_start": "2026-07-01",
+    "flight_end": "2026-09-30",
+    "target_cpm": 12.50,
+    "buyer_identity": {
+      "seat_id": "ttd-seat-123",
+      "agency_id": "omnicom-456",
+      "advertiser_id": "coca-cola"
+    }
+  }'
+```
+
+If a `DealStore` is attached, the quote is automatically persisted with status `quoted`.
+
+### Retrieve a Quote
+
+Fetch a previously issued quote to check its current status (e.g., whether it has expired).
+
+**Endpoint:** `GET /api/v1/quotes/{quote_id}`
+
+```python
+quote = await client.get_quote("qt-abc123")
+print(f"Status: {quote.status}")  # available, expired, declined, booked
+```
+
+### Book a Deal
+
+Convert a quote into a confirmed deal. The seller validates the quote is still available and issues a Deal ID.
+
+**Endpoint:** `POST /api/v1/deals`
+
+```python
+from ad_buyer.models.deals import DealBookingRequest
+
+booking = DealBookingRequest(
+    quote_id="qt-abc123",
+    buyer_identity=BuyerIdentityPayload(
+        seat_id="ttd-seat-123",
+    ),
+    notes="Q3 CTV campaign for Coca-Cola",
+)
+
+deal = await client.book_deal(booking)
+
+print(f"Deal ID: {deal.deal_id}")
+print(f"Status: {deal.status}")           # "proposed" or "active"
+print(f"CPM: ${deal.pricing.final_cpm}")
+
+# OpenRTB activation parameters for DSP integration
+if deal.openrtb_params:
+    print(f"OpenRTB Deal ID: {deal.openrtb_params.id}")
+    print(f"Bid Floor: ${deal.openrtb_params.bidfloor}")
+```
+
+**curl equivalent:**
+
+```bash
+curl -X POST http://seller.example.com:8001/api/v1/deals \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: your-api-key" \
+  -d '{
+    "quote_id": "qt-abc123",
+    "buyer_identity": {"seat_id": "ttd-seat-123"},
+    "notes": "Q3 CTV campaign for Coca-Cola"
+  }'
+```
+
+If a `DealStore` is attached, the deal is automatically persisted with status `booked`.
+
+### Get Deal Status
+
+Retrieve the current state of a deal. Useful for tracking deals through their lifecycle.
+
+**Endpoint:** `GET /api/v1/deals/{deal_id}`
+
+```python
+deal = await client.get_deal("deal-xyz789")
+
+print(f"Status: {deal.status}")  # proposed, active, rejected, expired, completed
+print(f"Type: {deal.deal_type}")
+print(f"Product: {deal.product.name}")
+```
+
+If a `DealStore` is attached, the stored deal status is updated automatically when the seller reports a new status.
+
+---
+
+## Deal Lifecycle
+
+Quotes and deals move through distinct status flows:
+
+### Quote Statuses
+
+```
+available --> booked
+          \-> expired
+          \-> declined
+```
+
+| Status | Meaning |
+|--------|---------|
+| `available` | Quote is valid and can be booked |
+| `expired` | Quote has passed its `expires_at` time |
+| `declined` | Seller declined the quote |
+| `booked` | Quote was converted into a deal |
+
+### Deal Statuses
+
+```
+proposed --> active --> completed
+         \-> rejected
+         \-> expired
+```
+
+| Status | Meaning |
+|--------|---------|
+| `proposed` | Deal created, awaiting seller activation |
+| `active` | Deal is live and accepting bids |
+| `rejected` | Seller rejected the deal |
+| `expired` | Deal passed its expiration without activation |
+| `completed` | Deal fulfilled its impression target |
+
+---
+
+## Data Models
+
+All models use [Pydantic](https://docs.pydantic.dev/) for validation and serialization.
+
+### Request Models
+
+#### QuoteRequest
+
+Request body for `POST /api/v1/quotes`:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `product_id` | `str` | yes | Product to quote |
+| `deal_type` | `str` | no | `PG` (guaranteed), `PD` (preferred), or `PA` (auction). Default: `PD` |
+| `impressions` | `int` | no | Requested impression volume |
+| `flight_start` | `str` | no | Start date (ISO 8601) |
+| `flight_end` | `str` | no | End date (ISO 8601) |
+| `target_cpm` | `float` | no | Buyer's target CPM (hint for pricing) |
+| `buyer_identity` | `BuyerIdentityPayload` | no | Buyer identity for tier-based pricing |
+| `agent_url` | `str` | no | Callback URL for the buyer agent |
+
+#### DealBookingRequest
+
+Request body for `POST /api/v1/deals`:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `quote_id` | `str` | yes | Quote to convert into a deal |
+| `buyer_identity` | `BuyerIdentityPayload` | no | Buyer identity context |
+| `notes` | `str` | no | Free-text notes for the seller |
+
+#### BuyerIdentityPayload
+
+Buyer identity included in requests for tier resolution:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `seat_id` | `str` | no | DSP seat identifier |
+| `agency_id` | `str` | no | Agency identifier |
+| `advertiser_id` | `str` | no | Advertiser identifier |
+| `dsp_platform` | `str` | no | DSP platform name |
+
+### Response Models
+
+#### QuoteResponse
+
+Response from `GET/POST /api/v1/quotes`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `quote_id` | `str` | Unique quote identifier |
+| `status` | `str` | `available`, `expired`, `declined`, or `booked` |
+| `product` | `ProductInfo` | Product summary |
+| `pricing` | `PricingInfo` | Pricing breakdown |
+| `terms` | `TermsInfo` | Volume, flight dates, guarantee |
+| `availability` | `AvailabilityInfo` | Inventory availability (optional) |
+| `buyer_tier` | `str` | Resolved buyer tier (e.g. `seat`, `agency`) |
+| `expires_at` | `str` | ISO 8601 expiration timestamp |
+| `seller_id` | `str` | Seller identifier (optional) |
+| `created_at` | `str` | ISO 8601 creation timestamp |
+
+#### DealResponse
+
+Response from `GET/POST /api/v1/deals`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `deal_id` | `str` | Seller-issued deal identifier |
+| `deal_type` | `str` | `PG`, `PD`, or `PA` |
+| `status` | `str` | `proposed`, `active`, `rejected`, `expired`, or `completed` |
+| `quote_id` | `str` | Source quote ID |
+| `product` | `ProductInfo` | Product summary |
+| `pricing` | `PricingInfo` | Final pricing breakdown |
+| `terms` | `TermsInfo` | Agreed terms |
+| `buyer_tier` | `str` | Resolved buyer tier |
+| `expires_at` | `str` | ISO 8601 expiration timestamp |
+| `activation_instructions` | `dict` | Key-value pairs for DSP setup |
+| `openrtb_params` | `OpenRTBParams` | OpenRTB deal parameters (optional) |
+| `created_at` | `str` | ISO 8601 creation timestamp |
+
+### Nested Models
+
+#### ProductInfo
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `product_id` | `str` | Product identifier |
+| `name` | `str` | Product name |
+| `inventory_type` | `str` | Inventory type (optional) |
+
+#### PricingInfo
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `base_cpm` | `float` | Pre-discount CPM |
+| `tier_discount_pct` | `float` | Tier-based discount percentage |
+| `volume_discount_pct` | `float` | Volume-based discount percentage |
+| `final_cpm` | `float` | After-discount CPM |
+| `currency` | `str` | ISO 4217 currency code (default: `USD`) |
+| `pricing_model` | `str` | Pricing model (default: `cpm`) |
+| `rationale` | `str` | Pricing explanation from the seller |
+
+#### TermsInfo
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `impressions` | `int` | Contracted impressions (optional) |
+| `flight_start` | `str` | Flight start date (optional) |
+| `flight_end` | `str` | Flight end date (optional) |
+| `guaranteed` | `bool` | Whether impressions are guaranteed |
+
+#### AvailabilityInfo
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `inventory_available` | `bool` | Whether inventory is available |
+| `estimated_fill_rate` | `float` | Estimated fill rate (optional) |
+| `competing_demand` | `str` | Competing demand level (optional) |
+
+#### OpenRTBParams
+
+OpenRTB deal parameters for DSP activation:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `str` | OpenRTB deal ID |
+| `bidfloor` | `float` | Bid floor price |
+| `bidfloorcur` | `str` | Bid floor currency (default: `USD`) |
+| `at` | `int` | Auction type (default: `3` = fixed price) |
+| `wseat` | `list[str]` | Allowed seat IDs |
+| `wadomain` | `list[str]` | Allowed advertiser domains |
+
+---
+
+## DealStore Integration
+
+The `DealStore` provides SQLite-backed local persistence for deals, negotiation history, and booking records. When a `DealStore` is attached to the `DealsClient`, quotes and deals are automatically saved and updated.
+
+### Setup
+
+```python
+from ad_buyer.storage.deal_store import DealStore
+from ad_buyer.clients.deals_client import DealsClient
+
+# Initialize the store
+store = DealStore("sqlite:///./ad_buyer.db")
+store.connect()
+
+# Attach to the client
+client = DealsClient(
+    seller_url="http://seller.example.com:8001",
+    api_key="your-key",
+    deal_store=store,
+)
+```
+
+### Automatic Persistence
+
+The `DealsClient` persists data at three points:
+
+| Method | Action | Stored Status |
+|--------|--------|---------------|
+| `request_quote()` | Saves quote as a deal record | `quoted` |
+| `book_deal()` | Saves deal with seller-issued ID | `booked` |
+| `get_deal()` | Updates stored status to match seller | *current status* |
+
+!!! tip "Non-fatal persistence"
+    DealStore failures are logged but never raised to the caller. The API call succeeds even if local persistence fails.
+
+### Querying the Store Directly
+
+```python
+# List all deals for a seller
+deals = store.list_deals(seller_url="http://seller.example.com:8001")
+
+# Filter by status
+booked = store.list_deals(status="booked")
+
+# Get a specific deal
+deal = store.get_deal("deal-uuid-here")
+
+# View status transition history
+history = store.get_status_history("deal", "deal-uuid-here")
+for transition in history:
+    print(f"{transition['from_status']} -> {transition['to_status']}")
+```
+
+### Negotiation Tracking
+
+The `DealStore` also tracks negotiation rounds:
+
+```python
+store.save_negotiation_round(
+    deal_id="deal-uuid",
+    proposal_id="prop-001",
+    round_number=1,
+    buyer_price=10.0,
+    seller_price=15.0,
+    action="counter",
+    rationale="Countered at $10 CPM based on historical rates",
+)
+
+history = store.get_negotiation_history("deal-uuid")
+```
+
+### Cleanup
+
+```python
+store.disconnect()
+```
+
+---
+
+## Error Handling
+
+The client raises `DealsClientError` on failures. This exception carries structured error information from the seller's response.
+
+```python
+from ad_buyer.clients.deals_client import DealsClientError
+
+try:
+    quote = await client.request_quote(quote_request)
+except DealsClientError as e:
+    print(f"Error: {e}")
+    print(f"HTTP status: {e.status_code}")
+    print(f"Error code: {e.error_code}")
+    print(f"Detail: {e.detail}")
+```
+
+### Error Scenarios
+
+| Scenario | `status_code` | `error_code` | Behavior |
+|----------|--------------|--------------|----------|
+| Seller unreachable | `0` | `connect_error` | Raised immediately, no retry |
+| Request timeout | `0` | `timeout` | Retried up to `max_retries` times |
+| HTTP 4xx (client error) | *status* | *from response* | Raised immediately, no retry |
+| HTTP 502/503/504 | *status* | *from response* | Retried up to `max_retries` times |
+| Other HTTP 5xx | *status* | *from response* | Raised immediately, no retry |
+| Quote expired | `409` | `quote_expired` | Raised immediately |
+| Product not found | `404` | `not_found` | Raised immediately |
+
+!!! warning "Retry behavior"
+    Only 502, 503, and 504 status codes trigger automatic retries. Client errors (4xx) are never retried -- they indicate a problem with the request itself.
+
+### Seller Error Response
+
+When the seller returns a structured error, the client parses it into the exception fields:
+
+```json
+{
+  "error": "quote_expired",
+  "detail": "Quote qt-abc123 expired at 2026-07-01T00:00:00Z"
+}
+```
+
+---
+
+## Full Workflow Example
+
+End-to-end: browse media kit, request a quote, book the deal.
+
+```python
+from ad_buyer.clients.deals_client import DealsClient, DealsClientError
+from ad_buyer.models.deals import (
+    QuoteRequest,
+    DealBookingRequest,
+    BuyerIdentityPayload,
+)
+from ad_buyer.storage.deal_store import DealStore
+
+# Setup
+store = DealStore("sqlite:///./ad_buyer.db")
+store.connect()
+
+seller_url = "http://seller.example.com:8001"
+identity = BuyerIdentityPayload(
+    seat_id="ttd-seat-123",
+    agency_id="omnicom-456",
+    advertiser_id="coca-cola",
+)
+
+async with DealsClient(seller_url, api_key="key", deal_store=store) as client:
+    # 1. Request a quote
+    quote = await client.request_quote(QuoteRequest(
+        product_id="prod-ctv-sports-001",
+        deal_type="PD",
+        impressions=500_000,
+        flight_start="2026-07-01",
+        flight_end="2026-09-30",
+        target_cpm=12.50,
+        buyer_identity=identity,
+    ))
+    print(f"Quote {quote.quote_id}: ${quote.pricing.final_cpm} CPM")
+
+    # 2. Book the deal
+    deal = await client.book_deal(DealBookingRequest(
+        quote_id=quote.quote_id,
+        buyer_identity=identity,
+        notes="Q3 CTV sports campaign",
+    ))
+    print(f"Deal {deal.deal_id} booked at ${deal.pricing.final_cpm} CPM")
+
+    # 3. Activate in DSP via OpenRTB params
+    if deal.openrtb_params:
+        print(f"OpenRTB: id={deal.openrtb_params.id}, "
+              f"floor=${deal.openrtb_params.bidfloor}")
+
+    # 4. Track deal status
+    updated = await client.get_deal(deal.deal_id)
+    print(f"Current status: {updated.status}")
+
+store.disconnect()
+```
+
+---
+
+## Related
+
+- [Seller Quotes API](https://iabtechlab.github.io/seller-agent/api/quotes/) -- Seller-side quote endpoints
+- [Seller Orders API](https://iabtechlab.github.io/seller-agent/api/orders/) -- Seller-side deal/order endpoints
+- [Negotiation Guide](../guides/negotiation.md) -- How to negotiate pricing with sellers
+- [Media Kit Discovery](media-kit.md) -- Browse seller inventory before requesting quotes
+- [Bookings API](bookings.md) -- Campaign booking workflow (brief-based)
+- [Authentication](authentication.md) -- API key and token setup

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
       - A2A Client: api/a2a-client.md
       - Authentication: api/authentication.md
       - Media Kit: api/media-kit.md
+      - Deals: api/deals.md
       - Bookings: api/bookings.md
       - Products: api/products.md
   - Architecture:

--- a/src/ad_buyer/negotiation/client.py
+++ b/src/ad_buyer/negotiation/client.py
@@ -69,6 +69,7 @@ class NegotiationClient:
         proposal_id: str,
         initial_price: float,
         strategy: NegotiationStrategy,
+        negotiation_enabled: bool = True,
     ) -> NegotiationSession:
         """Start a negotiation by sending the first counter-offer.
 
@@ -80,10 +81,21 @@ class NegotiationClient:
             proposal_id: The proposal to negotiate.
             initial_price: Our opening offer.
             strategy: The negotiation strategy (stored for reference).
+            negotiation_enabled: Whether the seller's package allows
+                negotiation.  When False, raises ValueError.
 
         Returns:
             A NegotiationSession tracking the negotiation state.
+
+        Raises:
+            ValueError: If negotiation is not enabled on the package.
         """
+        if not negotiation_enabled:
+            raise ValueError(
+                f"Negotiation is not enabled on package for proposal "
+                f"{proposal_id}. Book at the listed price instead."
+            )
+
         url = f"{seller_url}/proposals/{proposal_id}/counter"
         payload = {"price": initial_price}
 
@@ -222,6 +234,7 @@ class NegotiationClient:
         seller_url: str,
         proposal_id: str,
         strategy: NegotiationStrategy,
+        negotiation_enabled: bool = True,
     ) -> NegotiationResult:
         """Run a full negotiation loop automatically using the strategy.
 
@@ -237,10 +250,26 @@ class NegotiationClient:
             seller_url: Base URL of the seller API.
             proposal_id: The proposal to negotiate.
             strategy: The negotiation strategy to use.
+            negotiation_enabled: Whether the seller's package allows
+                negotiation.  When False, returns DECLINED immediately.
 
         Returns:
             NegotiationResult with the outcome and history.
         """
+        # Guard: reject negotiation when the seller has disabled it (ar-9xi)
+        if not negotiation_enabled:
+            logger.info(
+                "Negotiation not enabled for proposal %s; declining.",
+                proposal_id,
+            )
+            return NegotiationResult(
+                proposal_id=proposal_id,
+                outcome=NegotiationOutcome.DECLINED,
+                final_price=None,
+                rounds_count=0,
+                rounds=[],
+            )
+
         # Build initial context (no prior rounds)
         initial_context = NegotiationContext(
             rounds_completed=0,

--- a/src/ad_buyer/tools/dsp/get_pricing.py
+++ b/src/ad_buyer/tools/dsp/get_pricing.py
@@ -225,8 +225,10 @@ Returns:
         for deal_opt in deal_options:
             output_lines.append(deal_opt)
 
-        # Negotiation availability
-        if self._buyer_context.can_negotiate():
+        # Negotiation availability -- only when BOTH buyer can negotiate
+        # AND the seller's package has negotiation_enabled=True (ar-9xi)
+        package_negotiation_enabled = product.get("negotiation_enabled", False)
+        if self._buyer_context.can_negotiate() and package_negotiation_enabled:
             output_lines.extend([
                 "",
                 "Negotiation",

--- a/src/ad_buyer/tools/dsp/request_deal.py
+++ b/src/ad_buyer/tools/dsp/request_deal.py
@@ -144,7 +144,7 @@ Returns:
             if deal_type_enum == DealType.PROGRAMMATIC_GUARANTEED and not impressions:
                 return "Programmatic Guaranteed (PG) deals require an impressions volume."
 
-            # Check negotiation eligibility
+            # Check negotiation eligibility (buyer tier)
             tier = self._buyer_context.identity.get_access_tier()
             if target_cpm and not self._buyer_context.can_negotiate():
                 return f"Price negotiation requires Agency or Advertiser tier (current: {tier.value})"
@@ -201,9 +201,11 @@ Returns:
             elif impressions >= 5_000_000:
                 tiered_price *= 0.95  # 5% volume discount
 
-        # Handle negotiation
+        # Handle negotiation -- only when BOTH buyer can negotiate AND
+        # the seller's package has negotiation_enabled=True (ar-9xi)
         final_price = tiered_price
-        if target_cpm and self._buyer_context.can_negotiate():
+        package_negotiation_enabled = product.get("negotiation_enabled", False)
+        if target_cpm and self._buyer_context.can_negotiate() and package_negotiation_enabled:
             # Simple negotiation: accept if within 10% of floor
             floor_price = tiered_price * 0.90
             if target_cpm >= floor_price:

--- a/tests/unit/test_dsp_discovery_pricing.py
+++ b/tests/unit/test_dsp_discovery_pricing.py
@@ -519,7 +519,7 @@ class TestGetPricingNegotiationDisplay:
     async def test_agency_sees_negotiation_available(self, mock_client, agency_context):
         """Agency tier should see negotiation as available."""
         mock_client.get_product.return_value = MagicMock(
-            success=True, data=_product()
+            success=True, data=_product(negotiation_enabled=True)
         )
         tool = GetPricingTool(client=mock_client, buyer_context=agency_context)
         result = await tool._arun(product_id="prod_001")
@@ -678,7 +678,7 @@ class TestRequestDealNegotiation:
     async def test_agency_can_negotiate_above_floor(self, mock_client, agency_context):
         """Agency negotiating above floor should get their target price."""
         mock_client.get_product.return_value = MagicMock(
-            success=True, data=_product(base_price=20.0)
+            success=True, data=_product(base_price=20.0, negotiation_enabled=True)
         )
         tool = RequestDealTool(client=mock_client, buyer_context=agency_context)
         # Agency tier: $20 * 0.90 = $18.00 tiered price
@@ -694,7 +694,7 @@ class TestRequestDealNegotiation:
     ):
         """Negotiating below floor should result in floor price counter."""
         mock_client.get_product.return_value = MagicMock(
-            success=True, data=_product(base_price=20.0)
+            success=True, data=_product(base_price=20.0, negotiation_enabled=True)
         )
         tool = RequestDealTool(client=mock_client, buyer_context=advertiser_context)
         # Advertiser tier: $20 * 0.85 = $17.00 tiered price
@@ -708,7 +708,7 @@ class TestRequestDealNegotiation:
     async def test_advertiser_negotiate_at_floor(self, mock_client, advertiser_context):
         """Negotiating exactly at floor should be accepted."""
         mock_client.get_product.return_value = MagicMock(
-            success=True, data=_product(base_price=20.0)
+            success=True, data=_product(base_price=20.0, negotiation_enabled=True)
         )
         tool = RequestDealTool(client=mock_client, buyer_context=advertiser_context)
         # Advertiser tier: $20 * 0.85 = $17.00

--- a/tests/unit/test_negotiation_enabled_flag.py
+++ b/tests/unit/test_negotiation_enabled_flag.py
@@ -1,0 +1,311 @@
+# Tests for seller's negotiation_enabled flag being respected by buyer
+# bead: ar-9xi
+
+"""Test that buyer respects the seller's negotiation_enabled flag on packages.
+
+The buyer must check BOTH:
+1. BuyerContext.can_negotiate() -- buyer tier allows negotiation
+2. PackageDetail.negotiation_enabled -- seller allows negotiation on this package
+
+When negotiation_enabled=False, the buyer should:
+- Skip negotiation in request_deal and book at listed price
+- Hide negotiation info in get_pricing output
+- Reject negotiation attempts in NegotiationClient
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ad_buyer.models.buyer_identity import (
+    AccessTier,
+    BuyerContext,
+    BuyerIdentity,
+    DealType,
+)
+from ad_buyer.negotiation.client import NegotiationClient
+from ad_buyer.negotiation.strategies.simple_threshold import SimpleThresholdStrategy
+from ad_buyer.tools.dsp import GetPricingTool, RequestDealTool
+
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock UnifiedClient."""
+    client = MagicMock()
+    client.get_product = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def agency_context():
+    """Agency-tier buyer that CAN negotiate (by tier)."""
+    identity = BuyerIdentity(
+        seat_id="ttd-seat-123",
+        agency_id="omnicom-456",
+        agency_name="OMD",
+    )
+    return BuyerContext(identity=identity, is_authenticated=True)
+
+
+@pytest.fixture
+def negotiable_product():
+    """Product where the seller has enabled negotiation."""
+    return {
+        "id": "prod_negotiable",
+        "name": "Premium CTV Package",
+        "basePrice": 25.00,
+        "publisherId": "pub_1",
+        "rateType": "CPM",
+        "negotiation_enabled": True,
+    }
+
+
+@pytest.fixture
+def non_negotiable_product():
+    """Product where the seller has DISABLED negotiation."""
+    return {
+        "id": "prod_nonneg",
+        "name": "Standard Display Package",
+        "basePrice": 25.00,
+        "publisherId": "pub_1",
+        "rateType": "CPM",
+        "negotiation_enabled": False,
+    }
+
+
+# -- RequestDealTool tests ---------------------------------------------------
+
+
+class TestRequestDealRespectsNegotiationEnabled:
+    """RequestDealTool must check negotiation_enabled before negotiating."""
+
+    @pytest.mark.asyncio
+    async def test_non_negotiable_package_ignores_target_cpm(
+        self, mock_client, agency_context, non_negotiable_product
+    ):
+        """When negotiation_enabled=False, target_cpm should be ignored
+        and the deal should be booked at the tier-discounted listed price."""
+        mock_client.get_product.return_value = MagicMock(
+            success=True,
+            data=non_negotiable_product,
+        )
+
+        tool = RequestDealTool(
+            client=mock_client,
+            buyer_context=agency_context,
+        )
+
+        result = await tool._arun(
+            product_id="prod_nonneg",
+            deal_type="PD",
+            target_cpm=15.00,  # Agency tries to negotiate down
+        )
+
+        # Deal should be created (no error)
+        assert "DEAL-" in result
+        # Agency tier gets 10% discount: $25 * 0.90 = $22.50
+        # NOT the target_cpm of $15.00
+        assert "$22.50" in result
+
+    @pytest.mark.asyncio
+    async def test_negotiable_package_allows_target_cpm(
+        self, mock_client, agency_context, negotiable_product
+    ):
+        """When negotiation_enabled=True, target_cpm should still work."""
+        mock_client.get_product.return_value = MagicMock(
+            success=True,
+            data=negotiable_product,
+        )
+
+        tool = RequestDealTool(
+            client=mock_client,
+            buyer_context=agency_context,
+        )
+
+        result = await tool._arun(
+            product_id="prod_negotiable",
+            deal_type="PD",
+            target_cpm=21.00,  # Within 10% of floor
+        )
+
+        # Deal should be created with negotiated price
+        assert "DEAL-" in result
+        assert "$21.00" in result
+
+    @pytest.mark.asyncio
+    async def test_non_negotiable_product_without_target_cpm_works(
+        self, mock_client, agency_context, non_negotiable_product
+    ):
+        """Non-negotiable package should still create deals (just no negotiation)."""
+        mock_client.get_product.return_value = MagicMock(
+            success=True,
+            data=non_negotiable_product,
+        )
+
+        tool = RequestDealTool(
+            client=mock_client,
+            buyer_context=agency_context,
+        )
+
+        result = await tool._arun(
+            product_id="prod_nonneg",
+            deal_type="PD",
+        )
+
+        # Should succeed with tier-discounted price
+        assert "DEAL-" in result
+        assert "$22.50" in result
+
+
+# -- GetPricingTool tests ----------------------------------------------------
+
+
+class TestGetPricingRespectsNegotiationEnabled:
+    """GetPricingTool should only show negotiation info when package allows it."""
+
+    @pytest.mark.asyncio
+    async def test_non_negotiable_hides_negotiation_section(
+        self, mock_client, agency_context, non_negotiable_product
+    ):
+        """When negotiation_enabled=False, don't show negotiation availability."""
+        mock_client.get_product.return_value = MagicMock(
+            success=True,
+            data=non_negotiable_product,
+        )
+
+        tool = GetPricingTool(
+            client=mock_client,
+            buyer_context=agency_context,
+        )
+
+        result = await tool._arun(product_id="prod_nonneg")
+
+        # Should NOT show "Price negotiation is available"
+        assert "negotiation is available" not in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_negotiable_shows_negotiation_section(
+        self, mock_client, agency_context, negotiable_product
+    ):
+        """When negotiation_enabled=True AND buyer can negotiate, show it."""
+        mock_client.get_product.return_value = MagicMock(
+            success=True,
+            data=negotiable_product,
+        )
+
+        tool = GetPricingTool(
+            client=mock_client,
+            buyer_context=agency_context,
+        )
+
+        result = await tool._arun(product_id="prod_negotiable")
+
+        # Should show negotiation section
+        assert "negotiation" in result.lower()
+        assert "available" in result.lower()
+
+
+# -- NegotiationClient tests -------------------------------------------------
+
+
+class TestNegotiationClientRespectsNegotiationEnabled:
+    """NegotiationClient should reject negotiation on non-negotiable packages."""
+
+    @pytest.mark.asyncio
+    async def test_auto_negotiate_rejects_non_negotiable(self):
+        """auto_negotiate should reject when negotiation_enabled=False."""
+        client = NegotiationClient()
+        strategy = SimpleThresholdStrategy(
+            target_cpm=20.0,
+            max_cpm=30.0,
+            concession_step=2.0,
+            max_rounds=5,
+        )
+
+        result = await client.auto_negotiate(
+            seller_url="http://localhost:8000",
+            proposal_id="prop-001",
+            strategy=strategy,
+            negotiation_enabled=False,
+        )
+
+        # Should return a result indicating negotiation was rejected
+        from ad_buyer.negotiation.models import NegotiationOutcome
+        assert result.outcome == NegotiationOutcome.DECLINED
+        assert result.rounds_count == 0
+
+    @pytest.mark.asyncio
+    async def test_start_negotiation_rejects_non_negotiable(self):
+        """start_negotiation should raise when negotiation_enabled=False."""
+        client = NegotiationClient()
+        strategy = SimpleThresholdStrategy(
+            target_cpm=20.0,
+            max_cpm=30.0,
+            concession_step=2.0,
+            max_rounds=5,
+        )
+
+        with pytest.raises(ValueError, match="[Nn]egotiation.*not.*enabled|not.*negotiable"):
+            await client.start_negotiation(
+                seller_url="http://localhost:8000",
+                proposal_id="prop-001",
+                initial_price=20.0,
+                strategy=strategy,
+                negotiation_enabled=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_auto_negotiate_works_when_enabled(self):
+        """auto_negotiate should work normally when negotiation_enabled=True."""
+        strategy = SimpleThresholdStrategy(
+            target_cpm=20.0,
+            max_cpm=30.0,
+            concession_step=2.0,
+            max_rounds=5,
+        )
+
+        start_response = MagicMock()
+        start_response.status_code = 200
+        start_response.json.return_value = {
+            "negotiation_id": "neg-abc123",
+            "proposal_id": "prop-001",
+            "status": "active",
+            "current_price": 28.0,
+            "round_number": 1,
+            "action": "counter",
+            "seller_price": 28.0,
+            "buyer_price": 20.0,
+        }
+        start_response.raise_for_status = MagicMock()
+
+        accept_response = MagicMock()
+        accept_response.status_code = 200
+        accept_response.json.return_value = {
+            "status": "accepted",
+            "deal_price": 28.0,
+            "proposal_id": "prop-001",
+        }
+        accept_response.raise_for_status = MagicMock()
+
+        client = NegotiationClient()
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.post.side_effect = [start_response, accept_response]
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+            MockClient.return_value = mock_client_instance
+
+            from ad_buyer.negotiation.models import NegotiationOutcome
+
+            result = await client.auto_negotiate(
+                seller_url="http://localhost:8000",
+                proposal_id="prop-001",
+                strategy=strategy,
+                negotiation_enabled=True,
+            )
+
+            assert result.outcome == NegotiationOutcome.ACCEPTED


### PR DESCRIPTION
## Summary
- New mkdocs page `docs/api/deals.md` covering the DealsClient and quote-then-book flow
- Mermaid diagrams, model tables, DealStore integration, cross-references to seller docs
- Updated mkdocs.yml nav

bead: ar-aaj

🤖 Generated with [Claude Code](https://claude.com/claude-code)