### PR TITLE
Add Linear TV buying support (buyer-6io)

### DIFF
--- a/src/ad_buyer/agents/level2/__init__.py
+++ b/src/ad_buyer/agents/level2/__init__.py
@@ -6,6 +6,7 @@
 from .branding_agent import create_branding_agent
 from .mobile_app_agent import create_mobile_app_agent
 from .ctv_agent import create_ctv_agent
+from .linear_tv_agent import create_linear_tv_agent
 from .performance_agent import create_performance_agent
 from .dsp_agent import create_dsp_agent
 
@@ -13,6 +14,7 @@ __all__ = [
     "create_branding_agent",
     "create_mobile_app_agent",
     "create_ctv_agent",
+    "create_linear_tv_agent",
     "create_performance_agent",
     "create_dsp_agent",
 ]

--- a/src/ad_buyer/agents/level2/linear_tv_agent.py
+++ b/src/ad_buyer/agents/level2/linear_tv_agent.py
@@ -1,0 +1,82 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Linear TV Specialist agent (Level 2).
+
+Handles traditional linear television buying: daypart-based pricing
+(CPP/CPM), DMA/local market targeting, scatter deal structures,
+GRP-based audience guarantees, makegood terms, and commercial pod
+positioning. Maps to seller's 1E (Linear TV Specialist Agent).
+
+Design decisions (from LINEAR_TV_DEAL_FLOW_RESEARCH.md):
+- Scatter-only for v1 (upfronts TBD, bead ar-gh6)
+- Nielsen measurement currency for v1
+- DMA-level granularity (all 210 DMAs)
+- TIP-compatible, not TIP-native
+"""
+
+from typing import Any
+
+from crewai import Agent, LLM
+
+from ...config.settings import settings
+
+
+def create_linear_tv_agent(
+    tools: list[Any] | None = None,
+    verbose: bool = True,
+) -> Agent:
+    """Create the Linear TV Specialist agent.
+
+    The Linear TV Specialist focuses on:
+    - National and local linear TV buying (scatter market)
+    - Daypart-based pricing and inventory selection
+    - GRP-based audience guarantees and CPP negotiation
+    - DMA-level targeting across all 210 Nielsen markets
+    - Post-booking lifecycle: makegoods and cancellations
+    - Cross-media CPM/CPP comparison for unified TV planning
+
+    Args:
+        tools: Optional list of tools for the agent.
+        verbose: Whether to enable verbose logging.
+
+    Returns:
+        Configured Linear TV Specialist Agent.
+    """
+    return Agent(
+        role="Linear TV Specialist",
+        goal="""Secure linear TV inventory that delivers target demographic
+reach through scatter market buying, optimizing CPP across dayparts,
+networks, and DMAs to meet GRP goals within budget.""",
+        backstory="""You are a linear television advertising expert with deep
+knowledge of the traditional TV buying landscape. You understand daypart
+structures (Primetime, Daytime, Late Night, Early Morning, Early Fringe,
+Prime Access, Overnight, Weekend), GRP-based audience measurement, and
+CPP (Cost Per Point) pricing mechanics.
+
+Your expertise includes:
+- National and local scatter market buying
+- All 210 Nielsen DMA (Designated Market Area) targeting
+- CPP negotiation and rate-of-change analysis
+- GRP delivery guarantees and audience deficiency units (ADU/makegoods)
+- Nielsen audience measurement (C3/C7 ratings, live plus same day)
+- Cross-media comparison: CPM to CPP conversion for unified TV planning
+- Daypart mix optimization across broadcast and cable networks
+- Commercial pod positioning (:15, :30, :60 spot lengths)
+- Cancellation window management and notice period compliance
+- Network group buying (broadcast: NBC, CBS, ABC, FOX; cable: ESPN, TNT, etc.)
+- TIP (Television Interface Practices) compatibility for electronic orders
+
+You work with the Research Agent to discover available linear TV inventory
+and the Execution Agent to book placements. You coordinate with the CTV
+Specialist for cross-screen TV strategies and with Branding for cohesive
+video campaigns across linear and streaming.""",
+        llm=LLM(
+            model=settings.default_llm_model,
+            temperature=0.5,
+        ),
+        tools=tools or [],
+        allow_delegation=True,
+        verbose=verbose,
+        memory=True,
+    )

--- a/src/ad_buyer/clients/deals_client.py
+++ b/src/ad_buyer/clients/deals_client.py
@@ -5,10 +5,12 @@
 
 Async HTTP client for the seller's quote-then-book deal endpoints:
 
-- POST /api/v1/quotes     -- request a non-binding price quote
-- GET  /api/v1/quotes/{id} -- retrieve a quote
-- POST /api/v1/deals      -- book a deal from a quote
-- GET  /api/v1/deals/{id}  -- retrieve a deal
+- POST /api/v1/quotes            -- request a non-binding price quote
+- GET  /api/v1/quotes/{id}       -- retrieve a quote
+- POST /api/v1/deals             -- book a deal from a quote
+- GET  /api/v1/deals/{id}        -- retrieve a deal
+- POST /api/v1/deals/{id}/makegoods -- request makegood (linear TV)
+- POST /api/v1/deals/{id}/cancel    -- request cancellation (linear TV)
 
 Follows the API contract defined in docs/api/deal-creation-api-contract.md.
 Uses httpx for async HTTP, with auth header injection, configurable
@@ -29,6 +31,7 @@ from ..models.deals import (
     QuoteResponse,
     SellerErrorResponse,
 )
+from ..models.linear_tv import CancellationRequest, MakegoodRequest
 
 logger = logging.getLogger(__name__)
 
@@ -199,6 +202,65 @@ class DealsClient:
         self._update_stored_deal_status(result)
 
         return result
+
+    # ------------------------------------------------------------------
+    # Linear TV post-booking endpoints
+    # ------------------------------------------------------------------
+
+    async def request_makegood(
+        self, deal_id: str, makegood_request: MakegoodRequest
+    ) -> dict[str, Any]:
+        """Request makegood inventory for a linear TV deal.
+
+        POST /api/v1/deals/{deal_id}/makegoods
+
+        Sent when audience delivery falls short of the guaranteed
+        GRP level. The seller responds with offered replacement
+        inventory.
+
+        Args:
+            deal_id: The deal identifier.
+            makegood_request: Makegood request parameters.
+
+        Returns:
+            Dict with makegood offer details from the seller.
+
+        Raises:
+            DealsClientError: On HTTP or transport errors.
+        """
+        body = makegood_request.model_dump(exclude_none=True)
+        response = await self._request_with_retry(
+            "POST", f"/api/v1/deals/{deal_id}/makegoods", json=body
+        )
+        return response.json()
+
+    async def request_cancellation(
+        self, deal_id: str, cancellation_request: CancellationRequest
+    ) -> dict[str, Any]:
+        """Request cancellation of a linear TV deal.
+
+        POST /api/v1/deals/{deal_id}/cancel
+
+        Supports full and partial cancellation with notice period
+        awareness. The seller validates against the deal's
+        cancellation terms before processing.
+
+        Args:
+            deal_id: The deal identifier.
+            cancellation_request: Cancellation request parameters.
+
+        Returns:
+            Dict with cancellation result from the seller.
+
+        Raises:
+            DealsClientError: On HTTP or transport errors (including
+                422 if cancellation window has expired).
+        """
+        body = cancellation_request.model_dump(exclude_none=True)
+        response = await self._request_with_retry(
+            "POST", f"/api/v1/deals/{deal_id}/cancel", json=body
+        )
+        return response.json()
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/src/ad_buyer/models/__init__.py
+++ b/src/ad_buyer/models/__init__.py
@@ -36,6 +36,15 @@ from .ucp import (
     UCPEmbedding,
     UCPModelDescriptor,
 )
+from .linear_tv import (
+    CancellationRequest,
+    CancellationTerms,
+    LinearTVParams,
+    LinearTVQuoteDetails,
+    MakegoodRequest,
+    cpp_to_cpm,
+    cpm_to_cpp,
+)
 from .deals import (
     AvailabilityInfo,
     BuyerIdentityPayload,
@@ -84,6 +93,14 @@ __all__ = [
     "UCPContextDescriptor",
     "UCPEmbedding",
     "UCPModelDescriptor",
+    # Linear TV models (Option C hybrid)
+    "CancellationRequest",
+    "CancellationTerms",
+    "LinearTVParams",
+    "LinearTVQuoteDetails",
+    "MakegoodRequest",
+    "cpp_to_cpm",
+    "cpm_to_cpp",
     # Deals API v1.0 models (quote-then-book)
     "AvailabilityInfo",
     "BuyerIdentityPayload",

--- a/src/ad_buyer/models/deals.py
+++ b/src/ad_buyer/models/deals.py
@@ -7,11 +7,20 @@ These models match the seller's API contract defined in
 docs/api/deal-creation-api-contract.md. They represent the buyer-side
 view of quotes and deals returned by the seller's /api/v1/quotes and
 /api/v1/deals endpoints.
+
+Extended with linear TV support (Option C hybrid approach, bead buyer-6io):
+- media_type discriminator on QuoteRequest/QuoteResponse
+- LinearTVParams nested object on QuoteRequest
+- LinearTVQuoteDetails nested object on QuoteResponse
+- CPP pricing fields on PricingInfo
+- GRP/demo fields on TermsInfo
 """
 
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field
+
+from .linear_tv import LinearTVParams, LinearTVQuoteDetails
 
 
 # ---------------------------------------------------------------------------
@@ -40,24 +49,39 @@ class ProductInfo(BaseModel):
 
 
 class PricingInfo(BaseModel):
-    """Pricing breakdown returned by the seller."""
+    """Pricing breakdown returned by the seller.
+
+    Extended with CPP fields for linear TV (pricing_model "cpp" or "hybrid").
+    """
 
     base_cpm: float
     tier_discount_pct: float = 0.0
     volume_discount_pct: float = 0.0
     final_cpm: float
     currency: str = "USD"
-    pricing_model: str = "cpm"
+    pricing_model: str = "cpm"  # "cpm", "cpp", "unit_rate", "hybrid"
     rationale: str = ""
+
+    # Linear TV CPP pricing (None for digital/CTV)
+    base_cpp: Optional[float] = None
+    final_cpp: Optional[float] = None
 
 
 class TermsInfo(BaseModel):
-    """Deal/quote terms (volume, flight dates, guarantee)."""
+    """Deal/quote terms (volume, flight dates, guarantee).
+
+    Extended with GRP-based fields for linear TV.
+    """
 
     impressions: Optional[int] = None
     flight_start: Optional[str] = None
     flight_end: Optional[str] = None
     guaranteed: bool = False
+
+    # Linear TV GRP-based terms (None for digital/CTV)
+    grps: Optional[int] = None
+    guaranteed_grps: Optional[int] = None
+    target_demo: Optional[str] = None
 
 
 class AvailabilityInfo(BaseModel):
@@ -88,6 +112,7 @@ class QuoteRequest(BaseModel):
     """Request body for POST /api/v1/quotes.
 
     Buyer requests non-binding pricing from a seller.
+    Works for digital, CTV, and linear TV (via media_type discriminator).
     """
 
     product_id: str
@@ -98,6 +123,12 @@ class QuoteRequest(BaseModel):
     target_cpm: Optional[float] = None
     buyer_identity: Optional[BuyerIdentityPayload] = None
     agent_url: Optional[str] = None
+
+    # Media type discriminator (Option C hybrid approach)
+    media_type: str = "digital"  # "digital", "ctv", "linear_tv"
+
+    # Linear TV nested params (None for digital/CTV)
+    linear_tv: Optional[LinearTVParams] = None
 
 
 class DealBookingRequest(BaseModel):
@@ -120,6 +151,7 @@ class QuoteResponse(BaseModel):
     """Response from GET/POST /api/v1/quotes.
 
     Represents a non-binding price quote from the seller.
+    Extended with linear TV details when media_type is "linear_tv".
     """
 
     quote_id: str
@@ -132,6 +164,12 @@ class QuoteResponse(BaseModel):
     expires_at: Optional[str] = None
     seller_id: Optional[str] = None
     created_at: Optional[str] = None
+
+    # Media type (echoes the request)
+    media_type: str = "digital"
+
+    # Linear TV quote details (None for digital/CTV)
+    linear_tv: Optional[LinearTVQuoteDetails] = None
 
 
 class DealResponse(BaseModel):

--- a/src/ad_buyer/models/linear_tv.py
+++ b/src/ad_buyer/models/linear_tv.py
@@ -1,0 +1,256 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Linear TV models for the Option C hybrid approach.
+
+These models extend the existing quote-then-book deal flow with
+linear-TV-specific parameters. They are nested under the `linear_tv`
+field in QuoteRequest and QuoteResponse, activated when
+`media_type == "linear_tv"`.
+
+Design decisions (from LINEAR_TV_DEAL_FLOW_RESEARCH.md):
+- Option C (Hybrid): same endpoints, media_type branching
+- DMA-level granularity (all 210 DMAs)
+- Context-dependent deal_type: linear_tv uses ["upfront", "scatter", "opportunistic"]
+- Scatter-only for v1 (upfronts TBD, separate bead ar-gh6)
+- TIP-compatible, not TIP-native
+- Nielsen measurement currency only for v1
+"""
+
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class LinearTVParams(BaseModel):
+    """Linear-TV-specific parameters, nested under QuoteRequest.linear_tv.
+
+    Used when ``media_type == "linear_tv"`` in the QuoteRequest.
+    Contains all the fields needed for a linear TV quote that have
+    no equivalent in digital/CTV buying.
+    """
+
+    # Required: target demographic for audience measurement
+    target_demo: str = Field(
+        ...,
+        description=(
+            'Target demographic. Standard values: "A18-49", "A25-54", '
+            '"HH" (households), "P2+" (persons 2+), etc.'
+        ),
+    )
+
+    # Volume specification (in GRPs, alternative to impressions)
+    grps_requested: Optional[int] = Field(
+        default=None,
+        description="Requested volume in Gross Rating Points.",
+    )
+
+    # Inventory targeting
+    dayparts: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "Target dayparts. Standard values: "
+            '"primetime", "daytime", "early_morning", "late_night", '
+            '"early_fringe", "prime_access", "overnight", "weekend".'
+        ),
+    )
+    networks: Optional[list[str]] = Field(
+        default=None,
+        description='Target networks (e.g., ["NBC", "CBS", "ESPN"]).',
+    )
+    dmas: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "Nielsen DMA codes for local buying. None means national. "
+            'E.g., ["501"] for New York, ["803"] for Los Angeles.'
+        ),
+    )
+
+    # Spot specification
+    spot_length: int = Field(
+        default=30,
+        description="Spot length in seconds: 15, 30, or 60.",
+    )
+
+    # Pricing target
+    target_cpp: Optional[float] = Field(
+        default=None,
+        description="Buyer's desired Cost Per Point (CPP).",
+    )
+
+    # Measurement
+    measurement_currency: str = Field(
+        default="nielsen",
+        description=(
+            "Audience measurement provider used for billing. "
+            'Values: "nielsen", "comscore", "videoamp".'
+        ),
+    )
+
+    # Rotation type
+    rotation: str = Field(
+        default="ros",
+        description=(
+            "Spot rotation type. "
+            '"ros" (run of schedule), "fixed", "program_specific".'
+        ),
+    )
+
+
+class CancellationTerms(BaseModel):
+    """Cancellation window specification for linear TV deals.
+
+    Linear TV deals have structured cancellation rules that differ
+    from digital (where cancellation is a simple status change).
+    """
+
+    notice_days: int = Field(
+        ...,
+        description="Days of notice required before cancellation.",
+    )
+    cancellable_pct: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Portion of the deal that can be cancelled (0.0 to 1.0).",
+    )
+    deadline: Optional[str] = Field(
+        default=None,
+        description="Absolute deadline for cancellation (ISO date string).",
+    )
+    force_majeure: bool = Field(
+        default=True,
+        description="Whether force majeure exceptions apply.",
+    )
+
+
+class LinearTVQuoteDetails(BaseModel):
+    """Linear-TV-specific quote details, nested under QuoteResponse.linear_tv.
+
+    Populated by the seller when a linear TV quote is generated.
+    Contains audience estimates, inventory details, and deal terms
+    specific to linear TV.
+    """
+
+    target_demo: str
+    estimated_grps: float
+    estimated_rating: float
+    cpp: float = Field(description="Cost Per Point offered by seller.")
+    dayparts: list[str]
+    networks: list[str]
+    spots_per_week: int
+    total_spots: int
+    spot_length: int
+    measurement_currency: str
+    audience_estimate: dict[str, Any] = Field(
+        description=(
+            "Audience size estimates. Expected keys: "
+            '"demo", "universe", "impressions_equiv".'
+        ),
+    )
+    cancellation_terms: Optional[CancellationTerms] = None
+    makegood_policy: Optional[str] = Field(
+        default=None,
+        description=(
+            'Makegood policy: "standard" (ADU), "negotiated", or "none".'
+        ),
+    )
+
+
+class MakegoodRequest(BaseModel):
+    """Request body for POST /api/v1/deals/{deal_id}/makegoods.
+
+    Sent by the buyer when audience delivery falls short of the
+    guaranteed GRP level. The seller responds with offered replacement
+    inventory.
+    """
+
+    shortfall_grps: float = Field(
+        ...,
+        description="GRP shortfall that needs to be made up.",
+    )
+    original_daypart: str = Field(
+        ...,
+        description="Daypart where the underdelivery occurred.",
+    )
+    target_demo: str = Field(
+        ...,
+        description="Target demographic for makegood inventory.",
+    )
+    preferred_dayparts: Optional[list[str]] = Field(
+        default=None,
+        description="Buyer's preferred dayparts for replacement inventory.",
+    )
+    notes: Optional[str] = Field(
+        default=None,
+        description="Additional context about the makegood request.",
+    )
+
+
+class CancellationRequest(BaseModel):
+    """Request body for POST /api/v1/deals/{deal_id}/cancel.
+
+    Supports both full and partial cancellation, with notice period
+    awareness. The seller validates against the deal's cancellation
+    terms before processing.
+    """
+
+    cancel_pct: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Portion to cancel (1.0 = full, 0.3 = 30%).",
+    )
+    reason: str = Field(
+        ...,
+        description="Reason for cancellation.",
+    )
+    effective_date: Optional[str] = Field(
+        default=None,
+        description="Requested effective date for cancellation (ISO date).",
+    )
+
+
+# ---------------------------------------------------------------------------
+# CPM <-> CPP conversion utilities
+# ---------------------------------------------------------------------------
+
+
+def cpp_to_cpm(cpp: float, universe_size: int) -> float:
+    """Convert Cost Per Point to CPM equivalent.
+
+    1 GRP = 1% of the target universe. So 1 GRP reaches
+    ``universe_size * 0.01`` people.
+
+    CPM = cost / (reached people / 1000)
+        = CPP / (universe_size * 0.01 / 1000)
+        = CPP * 100000 / universe_size
+
+    Args:
+        cpp: Cost Per Point.
+        universe_size: Size of the target demographic universe.
+
+    Returns:
+        Equivalent CPM value.
+    """
+    if universe_size <= 0:
+        raise ValueError("universe_size must be positive")
+    return cpp * 100_000 / universe_size
+
+
+def cpm_to_cpp(cpm: float, universe_size: int) -> float:
+    """Convert CPM to Cost Per Point equivalent.
+
+    Inverse of cpp_to_cpm:
+    CPP = CPM * universe_size / 100000
+
+    Args:
+        cpm: Cost Per Thousand impressions.
+        universe_size: Size of the target demographic universe.
+
+    Returns:
+        Equivalent CPP value.
+    """
+    if universe_size <= 0:
+        raise ValueError("universe_size must be positive")
+    return cpm * universe_size / 100_000

--- a/tests/unit/test_linear_tv_agent.py
+++ b/tests/unit/test_linear_tv_agent.py
@@ -1,0 +1,82 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Tests for the Linear TV Specialist agent (Level 2).
+
+Follows the same pattern as test_agents.py for consistency.
+Tests written first (TDD) per bead buyer-6io.
+"""
+
+import os
+
+import pytest
+
+# Set a dummy API key for tests (agents validate on creation)
+os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-for-unit-tests")
+
+from ad_buyer.agents.level2.linear_tv_agent import create_linear_tv_agent
+
+
+class TestLinearTVAgent:
+    """Tests for the Linear TV Specialist agent."""
+
+    def test_linear_tv_agent_creation(self):
+        """Test Linear TV Specialist agent creation."""
+        agent = create_linear_tv_agent(verbose=False)
+
+        assert agent.role == "Linear TV Specialist"
+        # Goal should mention linear TV concepts
+        goal_lower = agent.goal.lower()
+        assert "linear" in goal_lower or "tv" in goal_lower
+        assert agent.allow_delegation is True
+
+    def test_linear_tv_agent_with_no_tools(self):
+        """Test Linear TV agent starts with no tools by default."""
+        agent = create_linear_tv_agent(verbose=False)
+        assert len(agent.tools) == 0
+
+    def test_linear_tv_agent_with_custom_tools(self):
+        """Test Linear TV agent accepts custom tools."""
+        from crewai.tools import BaseTool
+        from pydantic import Field as PydanticField
+
+        class DummyTool(BaseTool):
+            name: str = "dummy"
+            description: str = "A dummy tool"
+            def _run(self, **kwargs):
+                return "ok"
+
+        mock_tools = [DummyTool(), DummyTool()]
+        agent = create_linear_tv_agent(tools=mock_tools, verbose=False)
+        assert len(agent.tools) == 2
+
+    def test_linear_tv_agent_backstory_covers_key_concepts(self):
+        """Agent backstory should cover key linear TV concepts."""
+        agent = create_linear_tv_agent(verbose=False)
+        backstory_lower = agent.backstory.lower()
+
+        # Should mention core linear TV concepts
+        assert "daypart" in backstory_lower
+        assert "grp" in backstory_lower or "gross rating point" in backstory_lower
+        assert "cpp" in backstory_lower or "cost per point" in backstory_lower
+        assert "scatter" in backstory_lower
+        assert "makegood" in backstory_lower or "make good" in backstory_lower
+        assert "dma" in backstory_lower or "designated market" in backstory_lower
+        assert "nielsen" in backstory_lower
+
+    def test_linear_tv_agent_is_level2(self):
+        """Linear TV agent should be Level 2 (can delegate)."""
+        agent = create_linear_tv_agent(verbose=False)
+        assert agent.allow_delegation is True
+
+    def test_linear_tv_agent_has_memory(self):
+        """Linear TV agent should have memory enabled."""
+        agent = create_linear_tv_agent(verbose=False)
+        # crewai converts memory=True to a Memory object
+        assert agent.memory is not None
+
+    def test_linear_tv_agent_in_level2_init(self):
+        """Linear TV agent should be importable from level2 package."""
+        from ad_buyer.agents.level2 import create_linear_tv_agent as imported_fn
+
+        assert imported_fn is create_linear_tv_agent

--- a/tests/unit/test_linear_tv_deals_client.py
+++ b/tests/unit/test_linear_tv_deals_client.py
@@ -1,0 +1,479 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Tests for the DealsClient linear TV extensions.
+
+Covers:
+- request_quote with media_type='linear_tv' and LinearTVParams
+- Makegood client: POST /api/v1/deals/{deal_id}/makegoods
+- Cancellation client: POST /api/v1/deals/{deal_id}/cancel
+
+Tests written first (TDD) per bead buyer-6io.
+"""
+
+import json
+
+import httpx
+import pytest
+
+from ad_buyer.clients.deals_client import DealsClient, DealsClientError
+from ad_buyer.models.deals import (
+    BuyerIdentityPayload,
+    QuoteRequest,
+    QuoteResponse,
+)
+from ad_buyer.models.linear_tv import (
+    CancellationRequest,
+    LinearTVParams,
+    MakegoodRequest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+SELLER_URL = "http://seller.example.com"
+
+
+def _linear_tv_quote_response_json() -> dict:
+    """Minimal valid linear TV QuoteResponse JSON."""
+    return {
+        "quote_id": "qt-ltv-001",
+        "status": "available",
+        "product": {
+            "product_id": "linear-primetime-nbc",
+            "name": "NBC Primetime :30",
+            "inventory_type": "linear_tv",
+        },
+        "pricing": {
+            "base_cpm": 0.0,
+            "final_cpm": 0.0,
+            "pricing_model": "cpp",
+            "base_cpp": 50000.0,
+            "final_cpp": 45000.0,
+            "currency": "USD",
+            "rationale": "Scatter CPP: $50K base, -10% volume => $45K",
+        },
+        "terms": {
+            "grps": 200,
+            "guaranteed_grps": 180,
+            "target_demo": "A18-49",
+            "flight_start": "2026-04-01",
+            "flight_end": "2026-04-30",
+            "guaranteed": True,
+        },
+        "availability": {
+            "inventory_available": True,
+            "estimated_fill_rate": 0.85,
+        },
+        "buyer_tier": "advertiser",
+        "expires_at": "2026-03-15T14:30:00Z",
+        "seller_id": "seller-network-001",
+        "created_at": "2026-03-11T14:30:00Z",
+        "media_type": "linear_tv",
+        "linear_tv": {
+            "target_demo": "A18-49",
+            "estimated_grps": 200.0,
+            "estimated_rating": 5.2,
+            "cpp": 45000.0,
+            "dayparts": ["primetime"],
+            "networks": ["NBC"],
+            "spots_per_week": 10,
+            "total_spots": 40,
+            "spot_length": 30,
+            "measurement_currency": "nielsen",
+            "audience_estimate": {
+                "demo": "A18-49",
+                "universe": 130000000,
+                "impressions_equiv": 65000000,
+            },
+            "cancellation_terms": {
+                "notice_days": 14,
+                "cancellable_pct": 1.0,
+                "force_majeure": True,
+            },
+            "makegood_policy": "standard",
+        },
+    }
+
+
+def _makegood_response_json() -> dict:
+    """Response from POST /api/v1/deals/{deal_id}/makegoods."""
+    return {
+        "makegood_id": "mg-001",
+        "deal_id": "DEAL-LTV-001",
+        "status": "offered",
+        "shortfall_grps": 30.0,
+        "offered_grps": 35.0,
+        "offered_daypart": "late_night",
+        "offered_network": "NBC",
+        "notes": "Replacement inventory in Late Night",
+    }
+
+
+def _cancellation_response_json() -> dict:
+    """Response from POST /api/v1/deals/{deal_id}/cancel."""
+    return {
+        "deal_id": "DEAL-LTV-001",
+        "status": "canceled",
+        "cancel_pct": 1.0,
+        "effective_date": "2026-04-15",
+        "penalty": 0.0,
+        "notes": "Cancellation within notice period, no penalty",
+    }
+
+
+class _RequestCapture:
+    """Helper to capture requests sent through a mock transport."""
+
+    def __init__(self):
+        self.requests: list[httpx.Request] = []
+
+    def capture(self, request: httpx.Request) -> None:
+        self.requests.append(request)
+
+    @property
+    def last(self) -> httpx.Request:
+        return self.requests[-1]
+
+
+def _make_client_with_transport(handler, **kwargs) -> DealsClient:
+    """Create a DealsClient backed by an httpx.MockTransport."""
+    c = DealsClient(
+        seller_url=SELLER_URL,
+        timeout=5.0,
+        **kwargs,
+    )
+    transport = httpx.MockTransport(handler)
+    c._client = httpx.AsyncClient(
+        transport=transport,
+        base_url=SELLER_URL,
+        headers=dict(c._client.headers),
+        timeout=5.0,
+    )
+    return c
+
+
+def _json_response(status_code: int, body: dict) -> httpx.Response:
+    """Build an httpx.Response with JSON content."""
+    return httpx.Response(status_code=status_code, json=body)
+
+
+# ---------------------------------------------------------------------------
+# Linear TV quote request tests
+# ---------------------------------------------------------------------------
+
+
+class TestLinearTVQuoteRequest:
+    """Test requesting a linear TV quote through the client."""
+
+    @pytest.mark.asyncio
+    async def test_linear_tv_quote_request_sends_media_type(self):
+        """Linear TV quote sends media_type and linear_tv params in body."""
+        capture = _RequestCapture()
+
+        def handler(request):
+            capture.capture(request)
+            return _json_response(200, _linear_tv_quote_response_json())
+
+        c = _make_client_with_transport(handler)
+        quote_req = QuoteRequest(
+            product_id="linear-primetime-nbc",
+            deal_type="scatter",
+            media_type="linear_tv",
+            flight_start="2026-04-01",
+            flight_end="2026-04-30",
+            linear_tv=LinearTVParams(
+                target_demo="A18-49",
+                grps_requested=200,
+                dayparts=["primetime"],
+                networks=["NBC"],
+                target_cpp=50000.0,
+            ),
+        )
+        result = await c.request_quote(quote_req)
+
+        body = json.loads(capture.last.content)
+        assert body["media_type"] == "linear_tv"
+        assert body["deal_type"] == "scatter"
+        assert body["linear_tv"]["target_demo"] == "A18-49"
+        assert body["linear_tv"]["grps_requested"] == 200
+        await c.close()
+
+    @pytest.mark.asyncio
+    async def test_linear_tv_quote_response_parsed(self):
+        """Linear TV quote response is parsed with linear_tv details."""
+        def handler(request):
+            return _json_response(200, _linear_tv_quote_response_json())
+
+        c = _make_client_with_transport(handler)
+        quote_req = QuoteRequest(
+            product_id="linear-primetime-nbc",
+            deal_type="scatter",
+            media_type="linear_tv",
+            linear_tv=LinearTVParams(target_demo="A18-49"),
+        )
+        result = await c.request_quote(quote_req)
+
+        assert result.media_type == "linear_tv"
+        assert result.linear_tv is not None
+        assert result.linear_tv.cpp == 45000.0
+        assert result.linear_tv.estimated_grps == 200.0
+        assert result.linear_tv.target_demo == "A18-49"
+        assert result.linear_tv.spots_per_week == 10
+        assert result.linear_tv.cancellation_terms is not None
+        assert result.linear_tv.cancellation_terms.notice_days == 14
+        assert result.linear_tv.makegood_policy == "standard"
+        await c.close()
+
+    @pytest.mark.asyncio
+    async def test_linear_tv_terms_parsed(self):
+        """Linear TV terms include GRP-based fields."""
+        def handler(request):
+            return _json_response(200, _linear_tv_quote_response_json())
+
+        c = _make_client_with_transport(handler)
+        quote_req = QuoteRequest(
+            product_id="linear-primetime-nbc",
+            deal_type="scatter",
+            media_type="linear_tv",
+            linear_tv=LinearTVParams(target_demo="A18-49"),
+        )
+        result = await c.request_quote(quote_req)
+
+        assert result.terms.grps == 200
+        assert result.terms.guaranteed_grps == 180
+        assert result.terms.target_demo == "A18-49"
+        await c.close()
+
+    @pytest.mark.asyncio
+    async def test_linear_tv_pricing_cpp(self):
+        """Linear TV pricing uses CPP model."""
+        def handler(request):
+            return _json_response(200, _linear_tv_quote_response_json())
+
+        c = _make_client_with_transport(handler)
+        quote_req = QuoteRequest(
+            product_id="linear-primetime-nbc",
+            deal_type="scatter",
+            media_type="linear_tv",
+            linear_tv=LinearTVParams(target_demo="A18-49"),
+        )
+        result = await c.request_quote(quote_req)
+
+        assert result.pricing.pricing_model == "cpp"
+        assert result.pricing.base_cpp == 50000.0
+        assert result.pricing.final_cpp == 45000.0
+        await c.close()
+
+
+# ---------------------------------------------------------------------------
+# Makegood client tests
+# ---------------------------------------------------------------------------
+
+
+class TestMakegoodClient:
+    """Test the makegood request method on DealsClient."""
+
+    @pytest.mark.asyncio
+    async def test_request_makegood_success(self):
+        """POST /deals/{id}/makegoods returns makegood response."""
+        def handler(request):
+            return _json_response(200, _makegood_response_json())
+
+        c = _make_client_with_transport(handler)
+        mg_req = MakegoodRequest(
+            shortfall_grps=30.0,
+            original_daypart="primetime",
+            target_demo="A18-49",
+        )
+        result = await c.request_makegood("DEAL-LTV-001", mg_req)
+
+        assert result["makegood_id"] == "mg-001"
+        assert result["status"] == "offered"
+        assert result["shortfall_grps"] == 30.0
+        await c.close()
+
+    @pytest.mark.asyncio
+    async def test_request_makegood_correct_url(self):
+        """POST is sent to /api/v1/deals/{deal_id}/makegoods."""
+        capture = _RequestCapture()
+
+        def handler(request):
+            capture.capture(request)
+            return _json_response(200, _makegood_response_json())
+
+        c = _make_client_with_transport(handler)
+        mg_req = MakegoodRequest(
+            shortfall_grps=30.0,
+            original_daypart="primetime",
+            target_demo="A18-49",
+        )
+        await c.request_makegood("DEAL-LTV-001", mg_req)
+
+        assert capture.last.method == "POST"
+        assert str(capture.last.url).endswith(
+            "/api/v1/deals/DEAL-LTV-001/makegoods"
+        )
+        await c.close()
+
+    @pytest.mark.asyncio
+    async def test_request_makegood_sends_body(self):
+        """Request body contains makegood fields."""
+        capture = _RequestCapture()
+
+        def handler(request):
+            capture.capture(request)
+            return _json_response(200, _makegood_response_json())
+
+        c = _make_client_with_transport(handler)
+        mg_req = MakegoodRequest(
+            shortfall_grps=30.0,
+            original_daypart="primetime",
+            target_demo="A18-49",
+            preferred_dayparts=["primetime", "late_night"],
+            notes="NBC Thursday underdelivery",
+        )
+        await c.request_makegood("DEAL-LTV-001", mg_req)
+
+        body = json.loads(capture.last.content)
+        assert body["shortfall_grps"] == 30.0
+        assert body["original_daypart"] == "primetime"
+        assert body["target_demo"] == "A18-49"
+        assert body["preferred_dayparts"] == ["primetime", "late_night"]
+        await c.close()
+
+    @pytest.mark.asyncio
+    async def test_request_makegood_404(self):
+        """404 for missing deal raises DealsClientError."""
+        def handler(request):
+            return _json_response(
+                404, {"error": "deal_not_found", "detail": "Deal not found"}
+            )
+
+        c = _make_client_with_transport(handler)
+        mg_req = MakegoodRequest(
+            shortfall_grps=30.0,
+            original_daypart="primetime",
+            target_demo="A18-49",
+        )
+        with pytest.raises(DealsClientError) as exc_info:
+            await c.request_makegood("DEAL-NONEXISTENT", mg_req)
+
+        assert exc_info.value.status_code == 404
+        await c.close()
+
+
+# ---------------------------------------------------------------------------
+# Cancellation client tests
+# ---------------------------------------------------------------------------
+
+
+class TestCancellationClient:
+    """Test the cancellation request method on DealsClient."""
+
+    @pytest.mark.asyncio
+    async def test_request_cancellation_success(self):
+        """POST /deals/{id}/cancel returns cancellation response."""
+        def handler(request):
+            return _json_response(200, _cancellation_response_json())
+
+        c = _make_client_with_transport(handler)
+        cancel_req = CancellationRequest(
+            cancel_pct=1.0,
+            reason="Campaign budget cut",
+        )
+        result = await c.request_cancellation("DEAL-LTV-001", cancel_req)
+
+        assert result["deal_id"] == "DEAL-LTV-001"
+        assert result["status"] == "canceled"
+        assert result["cancel_pct"] == 1.0
+        await c.close()
+
+    @pytest.mark.asyncio
+    async def test_request_cancellation_correct_url(self):
+        """POST is sent to /api/v1/deals/{deal_id}/cancel."""
+        capture = _RequestCapture()
+
+        def handler(request):
+            capture.capture(request)
+            return _json_response(200, _cancellation_response_json())
+
+        c = _make_client_with_transport(handler)
+        cancel_req = CancellationRequest(
+            cancel_pct=1.0,
+            reason="Budget cut",
+        )
+        await c.request_cancellation("DEAL-LTV-001", cancel_req)
+
+        assert capture.last.method == "POST"
+        assert str(capture.last.url).endswith(
+            "/api/v1/deals/DEAL-LTV-001/cancel"
+        )
+        await c.close()
+
+    @pytest.mark.asyncio
+    async def test_request_cancellation_sends_body(self):
+        """Request body contains cancellation fields."""
+        capture = _RequestCapture()
+
+        def handler(request):
+            capture.capture(request)
+            return _json_response(200, _cancellation_response_json())
+
+        c = _make_client_with_transport(handler)
+        cancel_req = CancellationRequest(
+            cancel_pct=0.3,
+            reason="Reduced Q2 budget",
+            effective_date="2026-06-01",
+        )
+        await c.request_cancellation("DEAL-LTV-001", cancel_req)
+
+        body = json.loads(capture.last.content)
+        assert body["cancel_pct"] == 0.3
+        assert body["reason"] == "Reduced Q2 budget"
+        assert body["effective_date"] == "2026-06-01"
+        await c.close()
+
+    @pytest.mark.asyncio
+    async def test_request_cancellation_outside_window(self):
+        """422 when cancellation is outside the notice window."""
+        def handler(request):
+            return _json_response(
+                422,
+                {
+                    "error": "cancellation_window_expired",
+                    "detail": "14-day notice period not met",
+                },
+            )
+
+        c = _make_client_with_transport(handler)
+        cancel_req = CancellationRequest(
+            cancel_pct=1.0,
+            reason="Too late",
+        )
+        with pytest.raises(DealsClientError) as exc_info:
+            await c.request_cancellation("DEAL-LTV-001", cancel_req)
+
+        assert exc_info.value.status_code == 422
+        await c.close()
+
+    @pytest.mark.asyncio
+    async def test_request_cancellation_404(self):
+        """404 for missing deal raises DealsClientError."""
+        def handler(request):
+            return _json_response(
+                404, {"error": "deal_not_found", "detail": "Deal not found"}
+            )
+
+        c = _make_client_with_transport(handler)
+        cancel_req = CancellationRequest(
+            cancel_pct=1.0,
+            reason="Cancel",
+        )
+        with pytest.raises(DealsClientError) as exc_info:
+            await c.request_cancellation("DEAL-NONEXISTENT", cancel_req)
+
+        assert exc_info.value.status_code == 404
+        await c.close()

--- a/tests/unit/test_linear_tv_models.py
+++ b/tests/unit/test_linear_tv_models.py
@@ -1,0 +1,540 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Tests for Linear TV models (Option C hybrid approach).
+
+Covers LinearTVParams, LinearTVQuoteDetails, CancellationTerms,
+MakegoodRequest, CancellationRequest, and extensions to
+QuoteRequest/QuoteResponse/PricingInfo/TermsInfo for linear TV support.
+
+Tests written first (TDD) per bead buyer-6io.
+"""
+
+import pytest
+
+from ad_buyer.models.linear_tv import (
+    CancellationRequest,
+    CancellationTerms,
+    LinearTVParams,
+    LinearTVQuoteDetails,
+    MakegoodRequest,
+)
+from ad_buyer.models.deals import (
+    PricingInfo,
+    QuoteRequest,
+    QuoteResponse,
+    TermsInfo,
+)
+
+
+# ---------------------------------------------------------------------------
+# LinearTVParams tests
+# ---------------------------------------------------------------------------
+
+
+class TestLinearTVParams:
+    """Test the LinearTVParams model (nested in QuoteRequest.linear_tv)."""
+
+    def test_minimal_params(self):
+        """LinearTVParams with only required field (target_demo)."""
+        params = LinearTVParams(target_demo="A18-49")
+        assert params.target_demo == "A18-49"
+        assert params.spot_length == 30  # default
+        assert params.measurement_currency == "nielsen"  # default
+        assert params.rotation == "ros"  # default
+        assert params.grps_requested is None
+        assert params.dayparts is None
+        assert params.networks is None
+        assert params.dmas is None
+        assert params.target_cpp is None
+
+    def test_full_params(self):
+        """LinearTVParams with all fields populated."""
+        params = LinearTVParams(
+            target_demo="A25-54",
+            grps_requested=200,
+            dayparts=["primetime", "late_night"],
+            networks=["NBC", "CBS", "ESPN"],
+            dmas=["501", "803"],
+            spot_length=60,
+            target_cpp=45000.0,
+            measurement_currency="comscore",
+            rotation="fixed",
+        )
+        assert params.target_demo == "A25-54"
+        assert params.grps_requested == 200
+        assert params.dayparts == ["primetime", "late_night"]
+        assert params.networks == ["NBC", "CBS", "ESPN"]
+        assert params.dmas == ["501", "803"]
+        assert params.spot_length == 60
+        assert params.target_cpp == 45000.0
+        assert params.measurement_currency == "comscore"
+        assert params.rotation == "fixed"
+
+    def test_national_buy_no_dmas(self):
+        """National buy has no DMAs specified (None means national)."""
+        params = LinearTVParams(target_demo="HH")
+        assert params.dmas is None
+
+    def test_spot_length_options(self):
+        """Spot length accepts standard values: 15, 30, 60."""
+        for length in [15, 30, 60]:
+            params = LinearTVParams(target_demo="A18-49", spot_length=length)
+            assert params.spot_length == length
+
+    def test_rotation_options(self):
+        """Rotation accepts standard values."""
+        for rotation in ["ros", "fixed", "program_specific"]:
+            params = LinearTVParams(target_demo="A18-49", rotation=rotation)
+            assert params.rotation == rotation
+
+    def test_measurement_currency_options(self):
+        """Measurement currency accepts supported values."""
+        for currency in ["nielsen", "comscore", "videoamp"]:
+            params = LinearTVParams(
+                target_demo="A18-49", measurement_currency=currency
+            )
+            assert params.measurement_currency == currency
+
+    def test_serialization_excludes_none(self):
+        """model_dump(exclude_none=True) omits unset optional fields."""
+        params = LinearTVParams(target_demo="A18-49", grps_requested=100)
+        data = params.model_dump(exclude_none=True)
+        assert "target_demo" in data
+        assert "grps_requested" in data
+        assert "dayparts" not in data
+        assert "networks" not in data
+        assert "dmas" not in data
+        assert "target_cpp" not in data
+
+    def test_target_demo_required(self):
+        """target_demo is required."""
+        with pytest.raises(Exception):
+            LinearTVParams()
+
+
+# ---------------------------------------------------------------------------
+# CancellationTerms tests
+# ---------------------------------------------------------------------------
+
+
+class TestCancellationTerms:
+    """Test the CancellationTerms model."""
+
+    def test_basic_cancellation(self):
+        """Basic scatter cancellation terms."""
+        terms = CancellationTerms(
+            notice_days=14,
+            cancellable_pct=1.0,
+        )
+        assert terms.notice_days == 14
+        assert terms.cancellable_pct == 1.0
+        assert terms.deadline is None
+        assert terms.force_majeure is True  # default
+
+    def test_upfront_cancellation(self):
+        """Upfront cancellation with partial cancel and deadline."""
+        terms = CancellationTerms(
+            notice_days=90,
+            cancellable_pct=0.5,
+            deadline="2026-09-30",
+            force_majeure=True,
+        )
+        assert terms.notice_days == 90
+        assert terms.cancellable_pct == 0.5
+        assert terms.deadline == "2026-09-30"
+
+
+# ---------------------------------------------------------------------------
+# LinearTVQuoteDetails tests
+# ---------------------------------------------------------------------------
+
+
+class TestLinearTVQuoteDetails:
+    """Test the LinearTVQuoteDetails model (nested in QuoteResponse.linear_tv)."""
+
+    def test_full_quote_details(self):
+        """LinearTVQuoteDetails with all fields."""
+        details = LinearTVQuoteDetails(
+            target_demo="A18-49",
+            estimated_grps=200.0,
+            estimated_rating=5.2,
+            cpp=45000.0,
+            dayparts=["primetime"],
+            networks=["NBC", "CBS"],
+            spots_per_week=10,
+            total_spots=40,
+            spot_length=30,
+            measurement_currency="nielsen",
+            audience_estimate={
+                "demo": "A18-49",
+                "universe": 130000000,
+                "impressions_equiv": 65000000,
+            },
+        )
+        assert details.target_demo == "A18-49"
+        assert details.estimated_grps == 200.0
+        assert details.estimated_rating == 5.2
+        assert details.cpp == 45000.0
+        assert details.dayparts == ["primetime"]
+        assert details.networks == ["NBC", "CBS"]
+        assert details.spots_per_week == 10
+        assert details.total_spots == 40
+        assert details.spot_length == 30
+        assert details.measurement_currency == "nielsen"
+        assert details.audience_estimate["universe"] == 130000000
+
+    def test_optional_cancellation_terms(self):
+        """Cancellation terms are optional."""
+        details = LinearTVQuoteDetails(
+            target_demo="A18-49",
+            estimated_grps=100.0,
+            estimated_rating=3.0,
+            cpp=30000.0,
+            dayparts=["daytime"],
+            networks=["CBS"],
+            spots_per_week=5,
+            total_spots=20,
+            spot_length=30,
+            measurement_currency="nielsen",
+            audience_estimate={"demo": "A18-49", "universe": 130000000},
+        )
+        assert details.cancellation_terms is None
+        assert details.makegood_policy is None
+
+    def test_with_cancellation_and_makegood(self):
+        """Quote details with cancellation terms and makegood policy."""
+        details = LinearTVQuoteDetails(
+            target_demo="A25-54",
+            estimated_grps=300.0,
+            estimated_rating=6.5,
+            cpp=55000.0,
+            dayparts=["primetime", "late_night"],
+            networks=["NBC"],
+            spots_per_week=15,
+            total_spots=60,
+            spot_length=30,
+            measurement_currency="nielsen",
+            audience_estimate={
+                "demo": "A25-54",
+                "universe": 120000000,
+                "impressions_equiv": 90000000,
+            },
+            cancellation_terms=CancellationTerms(
+                notice_days=14,
+                cancellable_pct=1.0,
+            ),
+            makegood_policy="standard",
+        )
+        assert details.cancellation_terms.notice_days == 14
+        assert details.makegood_policy == "standard"
+
+
+# ---------------------------------------------------------------------------
+# QuoteRequest extensions for linear TV
+# ---------------------------------------------------------------------------
+
+
+class TestQuoteRequestLinearTV:
+    """Test QuoteRequest with media_type and linear_tv extensions."""
+
+    def test_default_media_type_is_digital(self):
+        """Default media_type is 'digital' for backward compat."""
+        req = QuoteRequest(product_id="ctv-premium-sports", deal_type="PD")
+        assert req.media_type == "digital"
+
+    def test_linear_tv_media_type(self):
+        """QuoteRequest with media_type='linear_tv' and linear_tv params."""
+        req = QuoteRequest(
+            product_id="linear-primetime-nbc",
+            deal_type="scatter",
+            media_type="linear_tv",
+            flight_start="2026-04-01",
+            flight_end="2026-04-30",
+            linear_tv=LinearTVParams(
+                target_demo="A18-49",
+                grps_requested=200,
+                dayparts=["primetime"],
+                networks=["NBC"],
+                dmas=["501"],
+                target_cpp=50000.0,
+            ),
+        )
+        assert req.media_type == "linear_tv"
+        assert req.linear_tv is not None
+        assert req.linear_tv.target_demo == "A18-49"
+        assert req.linear_tv.grps_requested == 200
+
+    def test_digital_request_no_linear_tv(self):
+        """Digital request has no linear_tv params."""
+        req = QuoteRequest(
+            product_id="ctv-premium-sports",
+            deal_type="PD",
+            impressions=5000000,
+            target_cpm=28.00,
+        )
+        assert req.linear_tv is None
+        assert req.media_type == "digital"
+
+    def test_linear_tv_serialization(self):
+        """Linear TV request serializes correctly with nested params."""
+        req = QuoteRequest(
+            product_id="linear-primetime-cbs",
+            deal_type="scatter",
+            media_type="linear_tv",
+            linear_tv=LinearTVParams(
+                target_demo="A25-54",
+                grps_requested=150,
+                dayparts=["primetime"],
+            ),
+        )
+        data = req.model_dump(exclude_none=True)
+        assert data["media_type"] == "linear_tv"
+        assert data["linear_tv"]["target_demo"] == "A25-54"
+        assert data["linear_tv"]["grps_requested"] == 150
+
+
+# ---------------------------------------------------------------------------
+# QuoteResponse extensions for linear TV
+# ---------------------------------------------------------------------------
+
+
+class TestQuoteResponseLinearTV:
+    """Test QuoteResponse with media_type and linear_tv extensions."""
+
+    def test_digital_response_backward_compat(self):
+        """Existing digital QuoteResponse still works (backward compat)."""
+        resp = QuoteResponse(
+            quote_id="qt-abc123",
+            status="available",
+            product={"product_id": "ctv-premium", "name": "Premium CTV"},
+            pricing={
+                "base_cpm": 35.0,
+                "final_cpm": 28.26,
+                "pricing_model": "cpm",
+            },
+            terms={"impressions": 5000000},
+        )
+        assert resp.media_type == "digital"
+        assert resp.linear_tv is None
+
+    def test_linear_tv_response(self):
+        """QuoteResponse with linear TV details."""
+        resp = QuoteResponse(
+            quote_id="qt-ltv-001",
+            status="available",
+            product={
+                "product_id": "linear-primetime-nbc",
+                "name": "NBC Primetime",
+            },
+            pricing={
+                "base_cpm": 0.0,
+                "final_cpm": 0.0,
+                "pricing_model": "cpp",
+                "base_cpp": 50000.0,
+                "final_cpp": 45000.0,
+            },
+            terms={
+                "grps": 200,
+                "guaranteed_grps": 180,
+                "target_demo": "A18-49",
+            },
+            media_type="linear_tv",
+            linear_tv={
+                "target_demo": "A18-49",
+                "estimated_grps": 200.0,
+                "estimated_rating": 5.2,
+                "cpp": 45000.0,
+                "dayparts": ["primetime"],
+                "networks": ["NBC"],
+                "spots_per_week": 10,
+                "total_spots": 40,
+                "spot_length": 30,
+                "measurement_currency": "nielsen",
+                "audience_estimate": {
+                    "demo": "A18-49",
+                    "universe": 130000000,
+                },
+            },
+        )
+        assert resp.media_type == "linear_tv"
+        assert resp.linear_tv is not None
+        assert resp.linear_tv.cpp == 45000.0
+        assert resp.linear_tv.estimated_grps == 200.0
+
+
+# ---------------------------------------------------------------------------
+# PricingInfo extensions for CPP
+# ---------------------------------------------------------------------------
+
+
+class TestPricingInfoCPP:
+    """Test PricingInfo with CPP pricing model."""
+
+    def test_existing_cpm_pricing_unchanged(self):
+        """Existing CPM pricing continues to work."""
+        pricing = PricingInfo(base_cpm=35.0, final_cpm=28.26)
+        assert pricing.pricing_model == "cpm"
+        assert pricing.base_cpp is None
+        assert pricing.final_cpp is None
+
+    def test_cpp_pricing(self):
+        """CPP pricing model with base_cpp and final_cpp."""
+        pricing = PricingInfo(
+            base_cpm=0.0,
+            final_cpm=0.0,
+            pricing_model="cpp",
+            base_cpp=50000.0,
+            final_cpp=45000.0,
+        )
+        assert pricing.pricing_model == "cpp"
+        assert pricing.base_cpp == 50000.0
+        assert pricing.final_cpp == 45000.0
+
+    def test_hybrid_pricing(self):
+        """Hybrid pricing with both CPM and CPP."""
+        pricing = PricingInfo(
+            base_cpm=25.0,
+            final_cpm=22.0,
+            pricing_model="hybrid",
+            base_cpp=40000.0,
+            final_cpp=36000.0,
+        )
+        assert pricing.pricing_model == "hybrid"
+        assert pricing.base_cpm == 25.0
+        assert pricing.base_cpp == 40000.0
+
+
+# ---------------------------------------------------------------------------
+# TermsInfo extensions for linear TV
+# ---------------------------------------------------------------------------
+
+
+class TestTermsInfoLinearTV:
+    """Test TermsInfo with linear TV extensions."""
+
+    def test_existing_digital_terms_unchanged(self):
+        """Existing digital terms work without GRP fields."""
+        terms = TermsInfo(impressions=5000000, flight_start="2026-04-01")
+        assert terms.grps is None
+        assert terms.guaranteed_grps is None
+        assert terms.target_demo is None
+
+    def test_linear_tv_terms(self):
+        """Terms with GRP-based volume and audience guarantee."""
+        terms = TermsInfo(
+            grps=200,
+            guaranteed_grps=180,
+            target_demo="A18-49",
+            flight_start="2026-04-01",
+            flight_end="2026-04-30",
+        )
+        assert terms.grps == 200
+        assert terms.guaranteed_grps == 180
+        assert terms.target_demo == "A18-49"
+
+
+# ---------------------------------------------------------------------------
+# MakegoodRequest tests
+# ---------------------------------------------------------------------------
+
+
+class TestMakegoodRequest:
+    """Test the MakegoodRequest model for POST /deals/{id}/makegoods."""
+
+    def test_makegood_request(self):
+        """MakegoodRequest with all fields."""
+        req = MakegoodRequest(
+            shortfall_grps=30.0,
+            original_daypart="primetime",
+            target_demo="A18-49",
+            preferred_dayparts=["primetime", "late_night"],
+            notes="Q1 underdelivery on NBC Thursday",
+        )
+        assert req.shortfall_grps == 30.0
+        assert req.original_daypart == "primetime"
+        assert req.target_demo == "A18-49"
+        assert req.preferred_dayparts == ["primetime", "late_night"]
+        assert req.notes == "Q1 underdelivery on NBC Thursday"
+
+    def test_makegood_request_minimal(self):
+        """MakegoodRequest with only required fields."""
+        req = MakegoodRequest(
+            shortfall_grps=15.0,
+            original_daypart="daytime",
+            target_demo="A25-54",
+        )
+        assert req.preferred_dayparts is None
+        assert req.notes is None
+
+
+# ---------------------------------------------------------------------------
+# CancellationRequest tests
+# ---------------------------------------------------------------------------
+
+
+class TestCancellationRequest:
+    """Test the CancellationRequest for POST /deals/{id}/cancel."""
+
+    def test_full_cancellation(self):
+        """Full cancellation request (100%)."""
+        req = CancellationRequest(
+            cancel_pct=1.0,
+            reason="Campaign budget cut",
+        )
+        assert req.cancel_pct == 1.0
+        assert req.reason == "Campaign budget cut"
+        assert req.effective_date is None
+
+    def test_partial_cancellation(self):
+        """Partial cancellation (30%)."""
+        req = CancellationRequest(
+            cancel_pct=0.3,
+            reason="Reduced Q2 budget",
+            effective_date="2026-06-01",
+        )
+        assert req.cancel_pct == 0.3
+        assert req.effective_date == "2026-06-01"
+
+
+# ---------------------------------------------------------------------------
+# CPM <-> CPP conversion utility tests
+# ---------------------------------------------------------------------------
+
+
+class TestCPMCPPConversion:
+    """Test CPM to CPP conversion for cross-media comparison."""
+
+    def test_cpp_to_cpm(self):
+        """Convert CPP to CPM equivalent.
+
+        Formula: CPM = CPP * 1000 / (universe * target_pct / 1000)
+        Simplified: CPM = (CPP / universe_per_grp) * 1000
+        Where universe_per_grp = universe * 0.01 (1 GRP = 1% of universe)
+        So: CPM = CPP / (universe * 0.01) * 1000 = CPP * 100000 / universe
+        """
+        from ad_buyer.models.linear_tv import cpp_to_cpm
+
+        # A18-49 universe ~130M, CPP = $50,000
+        # 1 GRP reaches 1% of 130M = 1,300,000 people
+        # CPM = $50,000 / 1,300,000 * 1000 = $38.46
+        cpm = cpp_to_cpm(cpp=50000.0, universe_size=130000000)
+        assert abs(cpm - 38.46) < 0.01
+
+    def test_cpm_to_cpp(self):
+        """Convert CPM to CPP equivalent."""
+        from ad_buyer.models.linear_tv import cpm_to_cpp
+
+        # Reverse: CPP = CPM * universe * 0.01 / 1000 = CPM * universe / 100000
+        cpp = cpm_to_cpp(cpm=38.46, universe_size=130000000)
+        assert abs(cpp - 50000.0) < 100  # within $100
+
+    def test_roundtrip_conversion(self):
+        """CPP -> CPM -> CPP should roundtrip."""
+        from ad_buyer.models.linear_tv import cpp_to_cpm, cpm_to_cpp
+
+        original_cpp = 45000.0
+        universe = 120000000
+        cpm = cpp_to_cpm(cpp=original_cpp, universe_size=universe)
+        recovered_cpp = cpm_to_cpp(cpm=cpm, universe_size=universe)
+        assert abs(recovered_cpp - original_cpp) < 0.01


### PR DESCRIPTION
## Summary
- Implements buyer-side Linear TV buying support using Option C hybrid approach (same endpoints, `media_type` branching, `LinearTVParams` nested object)
- Adds Linear TV Specialist agent (Level 2) for scatter market buying with daypart, GRP, CPP, DMA, and Nielsen expertise
- Extends DealsClient with `request_makegood()` and `request_cancellation()` client stubs for post-booking lifecycle
- Adds CPM-to-CPP conversion utilities for cross-media comparison
- All existing models extended backward-compatibly (new optional fields only)

## What's included
| Component | Files |
|-----------|-------|
| Linear TV models | `src/ad_buyer/models/linear_tv.py` (LinearTVParams, LinearTVQuoteDetails, CancellationTerms, MakegoodRequest, CancellationRequest, cpp_to_cpm, cpm_to_cpp) |
| Model extensions | `src/ad_buyer/models/deals.py` (QuoteRequest.media_type/linear_tv, QuoteResponse.media_type/linear_tv, PricingInfo.base_cpp/final_cpp, TermsInfo.grps/guaranteed_grps/target_demo) |
| Linear TV Agent | `src/ad_buyer/agents/level2/linear_tv_agent.py` |
| Client extensions | `src/ad_buyer/clients/deals_client.py` (request_makegood, request_cancellation) |
| Tests | 3 new test files, 51 tests total |

## Design decisions (from research doc)
- **Option C (Hybrid)**: Same quote/deal endpoints, `media_type` branching
- **Scatter-only for v1**: Upfronts TBD (bead ar-gh6)
- **DMA-level granularity**: All 210 Nielsen DMAs
- **Context-dependent deal_type**: `linear_tv` uses `["upfront", "scatter", "opportunistic"]`
- **Nielsen-only for v1**: Comscore/VideoAmp deferred

## Test plan
- [x] 51 new unit tests (models, agent, deals client extensions)
- [x] Full regression suite: 1016 passed, 6 pre-existing known failures (unrelated)
- [x] Backward compatibility: existing digital/CTV QuoteRequest/Response unchanged
- [ ] Integration testing with seller (blocked on seller Phase 1.5)

bead: buyer-6io

🤖 Generated with [Claude Code](https://claude.com/claude-code)