### PR TITLE
Add agent hierarchy, tools, DSP deal flow, and config docs

### DIFF
--- a/docs/architecture/agent-hierarchy.md
+++ b/docs/architecture/agent-hierarchy.md
@@ -1,0 +1,375 @@
+# Agent Hierarchy
+
+The buyer agent uses a three-level agent hierarchy powered by [CrewAI](https://www.crewai.com/). Each level has a distinct responsibility: strategic orchestration, channel-specific expertise, and functional execution.
+
+## Overview
+
+```mermaid
+graph TB
+    subgraph Level1["Level 1 — Strategic"]
+        PM["Portfolio Manager<br/>(Claude Opus)"]
+    end
+
+    subgraph Level2["Level 2 — Channel Specialists"]
+        BR["Branding Specialist<br/>(display / video)"]
+        CTV["CTV Specialist<br/>(streaming)"]
+        MOB["Mobile App Specialist<br/>(app install)"]
+        PERF["Performance Specialist<br/>(remarketing)"]
+        DSP["DSP Specialist<br/>(deal discovery)"]
+    end
+
+    subgraph Level3["Level 3 — Functional Agents"]
+        AUD["Audience Planner<br/>(UCP)"]
+        RES["Research Agent<br/>(inventory)"]
+        EXEC["Execution Agent<br/>(orders / lines)"]
+        REP["Reporting Agent<br/>(stats / analysis)"]
+    end
+
+    PM -->|budget allocation| BR
+    PM -->|budget allocation| CTV
+    PM -->|budget allocation| MOB
+    PM -->|budget allocation| PERF
+    PM -.->|deal requests| DSP
+
+    BR --> RES
+    BR --> EXEC
+    BR --> AUD
+    CTV --> RES
+    CTV --> EXEC
+    CTV --> AUD
+    MOB --> RES
+    MOB --> EXEC
+    MOB --> AUD
+    PERF --> RES
+    PERF --> EXEC
+    PERF --> AUD
+    DSP --> RES
+```
+
+---
+
+## Level 1 -- Portfolio Manager
+
+The Portfolio Manager is the top-level orchestrator. It receives a campaign brief and determines how to allocate budget across channels.
+
+**Key file:** `src/ad_buyer/agents/level1/portfolio_manager.py`
+
+| Attribute | Value |
+|-----------|-------|
+| Role | Portfolio Manager |
+| LLM | `anthropic/claude-opus-4-20250514` (configurable via `MANAGER_LLM_MODEL`) |
+| Temperature | 0.3 |
+| Delegation | Enabled -- delegates to Level 2 agents |
+| Memory | Enabled |
+
+**Responsibilities:**
+
+- Analyze campaign briefs and extract objectives, constraints, and KPIs
+- Allocate budget across channels (Branding, CTV, Mobile, Performance)
+- Provide channel-specific guidance to specialists
+- Monitor overall campaign coherence
+
+```python
+from ad_buyer.agents.level1.portfolio_manager import create_portfolio_manager
+
+manager = create_portfolio_manager(
+    tools=[],       # Tools added by crews
+    verbose=True,
+)
+```
+
+!!! note "LLM Selection"
+    The Portfolio Manager uses Opus (the most capable model) because it handles strategic reasoning across the full campaign. Channel specialists use Sonnet for cost-efficient execution of narrower tasks.
+
+---
+
+## Level 2 -- Channel Specialists
+
+Each Level 2 agent owns a specific advertising channel. They receive budget allocations from the Portfolio Manager and coordinate Level 3 agents to research inventory and execute bookings.
+
+**Key directory:** `src/ad_buyer/agents/level2/`
+
+All channel specialists share these defaults:
+
+| Attribute | Value |
+|-----------|-------|
+| LLM | `anthropic/claude-sonnet-4-5-20250929` (configurable via `DEFAULT_LLM_MODEL`) |
+| Temperature | 0.5 |
+| Delegation | Enabled -- delegates to Level 3 agents |
+| Memory | Enabled |
+
+### Branding Specialist
+
+**File:** `src/ad_buyer/agents/level2/branding_agent.py`
+
+Focuses on premium display and video placements for upper-funnel brand awareness.
+
+| Area | Focus |
+|------|-------|
+| Formats | Homepage takeovers, roadblocks, premium video (in-stream, outstream) |
+| Metrics | Viewability (70%+ target), brand recall, engagement |
+| Safety | Brand safety verification, contextual relevance |
+| Reach | Cross-device frequency management |
+
+```python
+from ad_buyer.agents.level2 import create_branding_agent
+
+agent = create_branding_agent(tools=[...])
+```
+
+### CTV Specialist
+
+**File:** `src/ad_buyer/agents/level2/ctv_agent.py`
+
+Expert in Connected TV and streaming inventory.
+
+| Area | Focus |
+|------|-------|
+| Platforms | Roku, Fire TV, Apple TV, Samsung TV+ |
+| Content | Hulu, Peacock, Paramount+, Max, FAST channels (Pluto, Tubi) |
+| Targeting | Household-level, device graphs, cross-screen frequency |
+| Standards | VAST/VPAID creative specs, addressable TV |
+
+### Mobile App Specialist
+
+**File:** `src/ad_buyer/agents/level2/mobile_app_agent.py`
+
+Drives efficient app installs and post-install conversions.
+
+| Area | Focus |
+|------|-------|
+| Attribution | MMP integrations (AppsFlyer, Adjust, Branch, Kochava) |
+| Formats | Rewarded video, interstitials, mobile web |
+| Fraud | Click injection detection, install farm prevention |
+| Privacy | SKAdNetwork, attribution windows |
+
+### Performance Specialist
+
+**File:** `src/ad_buyer/agents/level2/performance_agent.py`
+
+Maximizes conversions and ROAS through lower-funnel tactics.
+
+| Area | Focus |
+|------|-------|
+| Strategies | Retargeting, remarketing, lookalike modeling |
+| Optimization | CPA/ROAS targets, bid optimization, pacing |
+| Creative | Dynamic creative optimization, A/B testing |
+| Tracking | Pixel implementation, cross-device attribution |
+
+### DSP Deal Discovery Specialist
+
+**File:** `src/ad_buyer/agents/level2/dsp_agent.py`
+
+Discovers inventory and obtains Deal IDs for activation in traditional DSP platforms.
+
+| Area | Focus |
+|------|-------|
+| Platforms | The Trade Desk, DV360, Amazon DSP, Xandr, Yahoo DSP |
+| Deal types | PG (guaranteed), PD (preferred), PA (private auction) |
+| Pricing | Identity-based tiered pricing, volume discounts |
+| Negotiation | Price negotiation for agency/advertiser tiers |
+
+!!! tip "DSP vs. other specialists"
+    The DSP Specialist works alongside the channel specialists, not in place of them. Channel specialists decide *what* inventory to buy; the DSP Specialist handles the mechanics of obtaining Deal IDs for programmatic activation. See [DSP Deal Flow](dsp-deal-flow.md) for the full workflow.
+
+---
+
+## Level 3 -- Functional Agents
+
+Level 3 agents are shared across channels. They do not make strategic decisions -- they execute specific functions on behalf of the Level 2 specialists.
+
+**Key directory:** `src/ad_buyer/agents/level3/`
+
+All functional agents share these defaults:
+
+| Attribute | Value |
+|-----------|-------|
+| LLM | `anthropic/claude-sonnet-4-5-20250929` |
+| Delegation | Disabled -- they are leaf-level executors |
+| Memory | Enabled |
+
+### Audience Planner (UCP)
+
+**File:** `src/ad_buyer/agents/level3/audience_planner_agent.py`
+
+Plans and selects audiences using the IAB Tech Lab [User Context Protocol (UCP)](https://iabtechlab.com/ucp) for real-time audience matching with seller inventory.
+
+| Area | Detail |
+|------|--------|
+| Temperature | 0.3 (balanced for strategic audience recommendations) |
+| Signals | Identity (hashed IDs, device graphs), Contextual (page content, keywords), Reinforcement (feedback loops, conversion data) |
+| Embeddings | 256--1024 dimension UCP vectors, cosine similarity |
+| Threshold | Score > 0.7 = strong match |
+
+**Key capabilities:**
+
+- Signal analysis using UCP protocol
+- Audience segment discovery from seller capabilities
+- Coverage estimation for targeting combinations
+- Audience expansion recommendations
+- Gap analysis when requirements cannot be fully met
+
+**Tools used:** `AudienceDiscoveryTool`, `AudienceMatchingTool`, `CoverageEstimationTool`
+
+### Research Agent
+
+**File:** `src/ad_buyer/agents/level3/research_agent.py`
+
+Discovers and evaluates advertising inventory across publishers.
+
+| Area | Detail |
+|------|--------|
+| Temperature | 0.2 (low creativity, high precision for data analysis) |
+| Focus | Product search, availability checks, pricing evaluation, publisher comparison |
+
+**Tools used:** `ProductSearchTool`, `AvailsCheckTool`
+
+### Execution Agent
+
+**File:** `src/ad_buyer/agents/level3/execution_agent.py`
+
+Handles the OpenDirect booking lifecycle.
+
+| Area | Detail |
+|------|--------|
+| Temperature | 0.1 (minimal creativity, precision execution) |
+| Workflow | Draft --> PendingReservation --> Reserved --> PendingBooking --> Booked --> InFlight --> Finished |
+
+**Tools used:** `CreateOrderTool`, `CreateLineTool`, `ReserveLineTool`, `BookLineTool`
+
+### Reporting Agent
+
+**File:** `src/ad_buyer/agents/level3/reporting_agent.py`
+
+Retrieves and analyzes campaign performance data.
+
+| Area | Detail |
+|------|--------|
+| Temperature | 0.2 (analytical, data-focused) |
+| Metrics | Impressions, CPM, CTR, VCR, viewability, pacing, spend |
+
+**Tools used:** `GetStatsTool`
+
+---
+
+## Crew Coordination
+
+Agents are organized into **crews** -- CrewAI constructs that define which agents work together, what tasks they perform, and how authority flows.
+
+### Portfolio Crew
+
+**File:** `src/ad_buyer/crews/portfolio_crew.py`
+
+The top-level crew uses a **hierarchical process** with the Portfolio Manager as the manager agent.
+
+```python
+from ad_buyer.crews.portfolio_crew import create_portfolio_crew
+
+crew = create_portfolio_crew(
+    client=opendirect_client,
+    campaign_brief={
+        "name": "Q3 Awareness Campaign",
+        "objectives": ["brand_awareness", "reach"],
+        "budget": 500_000,
+        "start_date": "2026-07-01",
+        "end_date": "2026-09-30",
+        "target_audience": {"age": "25-54", "interests": ["sports", "news"]},
+        "kpis": {"viewability": 0.70, "reach": 2_000_000},
+    },
+)
+
+result = crew.kickoff()
+```
+
+**Structure:**
+
+| Role | Agent | Process |
+|------|-------|---------|
+| Manager | Portfolio Manager (L1) | Hierarchical -- assigns tasks and reviews output |
+| Workers | Branding, CTV, Mobile, Performance (L2) | Receive budget allocation and channel guidance |
+
+**Tasks:**
+
+1. **Budget Allocation** -- Analyze the brief, determine optimal channel split
+2. **Channel Coordination** -- Provide targeting and quality guidance per channel
+
+### Channel Crews
+
+**File:** `src/ad_buyer/crews/channel_crews.py`
+
+Each channel has its own crew. The channel specialist acts as the manager, with Research and Execution agents as workers.
+
+```python
+from ad_buyer.crews.channel_crews import create_branding_crew
+
+crew = create_branding_crew(
+    client=opendirect_client,
+    channel_brief={
+        "budget": 150_000,
+        "start_date": "2026-07-01",
+        "end_date": "2026-09-30",
+        "target_audience": {"age": "25-54"},
+        "objectives": ["brand_awareness"],
+    },
+    audience_plan={
+        "target_demographics": {"age": "25-54", "gender": "all"},
+        "target_interests": ["sports", "news", "entertainment"],
+    },
+)
+
+result = crew.kickoff()
+```
+
+Four channel crew factory functions are available:
+
+| Function | Manager Agent | Workers |
+|----------|---------------|---------|
+| `create_branding_crew()` | Branding Specialist | Research + Execution |
+| `create_ctv_crew()` | CTV Specialist | Research + Execution |
+| `create_mobile_crew()` | Mobile App Specialist | Research + Execution |
+| `create_performance_crew()` | Performance Specialist | Research + Execution |
+
+All channel crews follow the same two-task pattern:
+
+1. **Research Task** -- The Research Agent searches inventory matching the channel brief and audience plan, using both research and audience tools
+2. **Recommendation Task** -- The channel specialist reviews findings and selects the best inventory
+
+!!! info "Audience context"
+    Channel crews accept an optional `audience_plan` parameter. When provided, the Research Agent incorporates UCP-compatible audience targeting into its inventory search. This plan typically comes from the Audience Planner agent.
+
+---
+
+## Execution Flow
+
+A typical end-to-end campaign follows this pattern:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant PM as Portfolio Manager (L1)
+    participant CS as Channel Specialist (L2)
+    participant RA as Research Agent (L3)
+    participant EA as Execution Agent (L3)
+
+    User->>PM: Campaign brief
+    PM->>PM: Allocate budget across channels
+    PM->>CS: Channel brief + budget
+
+    CS->>RA: Research inventory
+    RA-->>CS: Ranked product recommendations
+    CS->>CS: Select best inventory
+    CS->>EA: Book selected placements
+    EA-->>CS: Booking confirmations
+    CS-->>PM: Channel results
+    PM-->>User: Consolidated plan
+```
+
+---
+
+## Related
+
+- [Architecture Overview](overview.md) -- Full system architecture
+- [Tools Reference](tools.md) -- All CrewAI tools available to agents
+- [DSP Deal Flow](dsp-deal-flow.md) -- DSP-specific deal discovery workflow
+- [Booking Flow](booking-flow.md) -- Detailed booking sequence
+- [Configuration](../guides/configuration.md) -- LLM and agent settings

--- a/docs/architecture/dsp-deal-flow.md
+++ b/docs/architecture/dsp-deal-flow.md
@@ -1,0 +1,286 @@
+# DSP Deal Flow
+
+The `DSPDealFlow` is a CrewAI event-driven flow that discovers seller inventory, evaluates products, and obtains Deal IDs for activation in traditional DSP platforms. It is distinct from the [`DealBookingFlow`](booking-flow.md), which handles the full campaign booking lifecycle through OpenDirect.
+
+**Key file:** `src/ad_buyer/flows/dsp_deal_flow.py`
+
+## When to Use This Flow
+
+| Scenario | Use |
+|----------|-----|
+| Obtain a Deal ID for a DSP platform (TTD, DV360, etc.) | DSP Deal Flow |
+| Book a full campaign with orders and line items | [DealBookingFlow](booking-flow.md) |
+| Negotiate pricing with a seller | [NegotiationClient](../guides/negotiation.md) |
+
+---
+
+## Flow Sequence
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Flow as DSPDealFlow
+    participant Tools as DSP Tools
+    participant Crew as DSP Agent Crew
+    participant Seller as Seller Agent
+
+    Caller->>Flow: kickoff(request, deal_type, ...)
+    Flow->>Flow: receive_request()
+    Note over Flow: Validate input, store buyer context
+
+    Flow->>Tools: DiscoverInventoryTool._run()
+    Tools->>Seller: Search products with identity context
+    Seller-->>Tools: Available inventory with tiered pricing
+    Note over Flow: discover_inventory()
+
+    Flow->>Crew: DSP Agent evaluates products
+    Crew->>Tools: GetPricingTool._run(product_id)
+    Tools->>Seller: Get detailed pricing
+    Seller-->>Tools: Tier-specific pricing breakdown
+    Note over Flow: evaluate_and_select()
+
+    Flow->>Tools: RequestDealTool._run(product_id)
+    Tools->>Seller: Request Deal ID
+    Seller-->>Tools: Deal ID + activation instructions
+    Note over Flow: request_deal_id()
+
+    Flow-->>Caller: Deal ID + status
+```
+
+---
+
+## Flow Steps
+
+### Step 1: Receive Request
+
+The flow entry point validates the deal request and stores buyer context in the flow state.
+
+```python
+@start()
+def receive_request(self) -> dict[str, Any]:
+```
+
+- Validates that a non-empty request string was provided
+- Serializes the buyer context into flow state
+- Persists an initial deal record to the `DealStore` (if attached)
+- Returns the request text and the buyer's access tier
+
+### Step 2: Discover Inventory
+
+Triggered automatically after `receive_request` completes.
+
+```python
+@listen(receive_request)
+def discover_inventory(self, request_result) -> dict[str, Any]:
+```
+
+- Calls `DiscoverInventoryTool` with the natural language request
+- Applies optional filters: `max_cpm`, `min_impressions`
+- Returns raw discovery results for evaluation
+
+### Step 3: Evaluate and Select
+
+A CrewAI crew with the DSP Agent intelligently selects the best product.
+
+```python
+@listen(discover_inventory)
+def evaluate_and_select(self, discovery_result) -> dict[str, Any]:
+```
+
+- Creates a `Crew` with the DSP Agent and the `DiscoverInventoryTool` + `GetPricingTool`
+- The agent analyzes discovery results against the request criteria (deal type, max CPM, volume)
+- Extracts the selected `product_id` from the agent's response
+- Fetches detailed pricing for the selected product via `GetPricingTool`
+- Persists the evaluation status to the `DealStore`
+
+### Step 4: Request Deal ID
+
+Creates the actual deal with the seller.
+
+```python
+@listen(evaluate_and_select)
+def request_deal_id(self, selection_result) -> dict[str, Any]:
+```
+
+- Calls `RequestDealTool` with the selected product, deal type, volume, and flight dates
+- On success, sets status to `DEAL_CREATED` and persists to the store
+- On failure, sets status to `FAILED` with error details
+- Returns the deal result including the Deal ID and activation instructions
+
+---
+
+## Flow State
+
+The `DSPFlowState` Pydantic model tracks the entire lifecycle:
+
+```python
+class DSPFlowState(BaseModel):
+    # Input
+    request: str                          # Natural language deal request
+    deal_type: DealType                   # PG, PD, or PA
+    impressions: Optional[int]            # Requested volume
+    max_cpm: Optional[float]             # Maximum CPM budget
+    flight_start: Optional[str]          # Deal start date
+    flight_end: Optional[str]            # Deal end date
+
+    # Buyer context
+    buyer_context: Optional[dict]         # Serialized BuyerContext
+
+    # Discovery results
+    discovered_products: list[DiscoveredProduct]  # Products found
+    selected_product_id: Optional[str]    # Chosen product
+
+    # Pricing
+    pricing_details: Optional[dict]       # Pricing for selected product
+
+    # Deal result
+    deal_response: Optional[dict]         # Created deal info
+
+    # Execution tracking
+    status: DSPFlowStatus                 # Current flow status
+    errors: list[str]                     # Error messages
+```
+
+### Status Values
+
+| Status | Description |
+|--------|-------------|
+| `INITIALIZED` | Flow created, not yet started |
+| `REQUEST_RECEIVED` | Request validated, buyer context stored |
+| `DISCOVERING_INVENTORY` | Querying sellers for available inventory |
+| `EVALUATING_PRICING` | DSP Agent selecting product and getting pricing |
+| `REQUESTING_DEAL` | Deal ID request sent to seller |
+| `DEAL_CREATED` | Deal ID obtained successfully |
+| `FAILED` | An error occurred at any step |
+
+---
+
+## Usage
+
+### Direct Flow Instantiation
+
+```python
+from ad_buyer.flows.dsp_deal_flow import DSPDealFlow
+from ad_buyer.clients.unified_client import UnifiedClient
+from ad_buyer.models.buyer_identity import (
+    BuyerContext, BuyerIdentity, DealType,
+)
+from ad_buyer.storage.deal_store import DealStore
+
+# Setup
+client = UnifiedClient(base_url="http://seller.example.com:8000")
+buyer_context = BuyerContext(
+    identity=BuyerIdentity(
+        seat_id="ttd-seat-123",
+        agency_id="omnicom-456",
+        advertiser_id="coca-cola",
+    ),
+    is_authenticated=True,
+    preferred_deal_types=[DealType.PREFERRED_DEAL],
+)
+store = DealStore("sqlite:///./ad_buyer.db")
+store.connect()
+
+# Create and configure flow
+flow = DSPDealFlow(
+    client=client,
+    buyer_context=buyer_context,
+    store=store,
+)
+flow.state.request = "Premium CTV sports inventory for Q3 campaign"
+flow.state.deal_type = DealType.PREFERRED_DEAL
+flow.state.impressions = 500_000
+flow.state.max_cpm = 30.0
+flow.state.flight_start = "2026-07-01"
+flow.state.flight_end = "2026-09-30"
+
+# Run
+result = flow.kickoff()
+
+# Check status
+status = flow.get_status()
+print(f"Status: {status['status']}")
+print(f"Deal: {status['deal_response']}")
+```
+
+### Convenience Function
+
+The `run_dsp_deal_flow()` async function handles client setup and flow configuration in a single call:
+
+```python
+from ad_buyer.flows.dsp_deal_flow import run_dsp_deal_flow
+from ad_buyer.models.buyer_identity import BuyerIdentity, DealType
+
+result = await run_dsp_deal_flow(
+    request="Premium CTV sports inventory for Q3",
+    buyer_identity=BuyerIdentity(
+        seat_id="ttd-seat-123",
+        agency_id="omnicom-456",
+    ),
+    deal_type=DealType.PREFERRED_DEAL,
+    impressions=500_000,
+    max_cpm=30.0,
+    flight_start="2026-07-01",
+    flight_end="2026-09-30",
+    base_url="http://seller.example.com:8000",  # defaults to settings.iab_server_url
+)
+
+print(result["status"])
+```
+
+### Convenience Function Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `request` | `str` | yes | -- | Natural language deal request |
+| `buyer_identity` | `BuyerIdentity` | yes | -- | Buyer identity for tiered pricing |
+| `deal_type` | `DealType` | no | `PREFERRED_DEAL` | PG, PD, or PA |
+| `impressions` | `int` | no | `None` | Requested impression volume |
+| `max_cpm` | `float` | no | `None` | Maximum CPM budget |
+| `flight_start` | `str` | no | `None` | Deal start date (YYYY-MM-DD) |
+| `flight_end` | `str` | no | `None` | Deal end date (YYYY-MM-DD) |
+| `base_url` | `str` | no | `settings.iab_server_url` | Seller server URL |
+| `store` | `DealStore` | no | `None` | Optional persistence store |
+
+---
+
+## Persistence
+
+When a `DealStore` is provided, the flow persists deal state at three points:
+
+| Step | Action | Status |
+|------|--------|--------|
+| `receive_request` | Creates initial deal record | `draft` |
+| `evaluate_and_select` | Updates status after product selection | `evaluating_pricing` |
+| `request_deal_id` | Updates with final status | `deal_created` or `failed` |
+
+Persistence is best-effort -- failures are logged but never raise exceptions, so the flow continues even if the store is unavailable.
+
+---
+
+## Error Handling
+
+Each step catches exceptions and records them in `state.errors`. When a step fails:
+
+1. The error message is appended to `state.errors`
+2. The status is set to `FAILED`
+3. Subsequent steps receive the failure result and short-circuit
+
+Check for errors after flow completion:
+
+```python
+status = flow.get_status()
+if status["status"] == "failed":
+    for error in status["errors"]:
+        print(f"Error: {error}")
+```
+
+---
+
+## Related
+
+- [Agent Hierarchy](agent-hierarchy.md) -- DSP Specialist role in the hierarchy
+- [Tools Reference](tools.md) -- DSP tools used by this flow
+- [Deals API](../api/deals.md) -- REST API for quote-then-book deals
+- [Booking Flow](booking-flow.md) -- Alternative flow for full campaign booking
+- [Identity Strategy](../guides/identity.md) -- How buyer identity affects pricing tiers

--- a/docs/architecture/tools.md
+++ b/docs/architecture/tools.md
@@ -1,0 +1,513 @@
+# CrewAI Tools Reference
+
+The buyer agent provides 13 tools that agents use to interact with sellers, plan audiences, execute bookings, and retrieve performance data. All tools extend CrewAI's `BaseTool` and expose both synchronous (`_run`) and asynchronous (`_arun`) interfaces.
+
+## Tool Categories
+
+```mermaid
+graph LR
+    subgraph Audience["Audience Tools"]
+        AD[AudienceDiscoveryTool]
+        AM[AudienceMatchingTool]
+        CE[CoverageEstimationTool]
+    end
+
+    subgraph DSP["DSP Tools"]
+        DI[DiscoverInventoryTool]
+        GP[GetPricingTool]
+        RD[RequestDealTool]
+    end
+
+    subgraph Execution["Execution Tools"]
+        CO[CreateOrderTool]
+        CL[CreateLineTool]
+        RL[ReserveLineTool]
+        BL[BookLineTool]
+    end
+
+    subgraph Research["Research Tools"]
+        PS[ProductSearchTool]
+        AC[AvailsCheckTool]
+    end
+
+    subgraph Reporting["Reporting Tools"]
+        GS[GetStatsTool]
+    end
+```
+
+| Category | Tools | Used By |
+|----------|-------|---------|
+| **Audience** | AudienceDiscovery, AudienceMatching, CoverageEstimation | Audience Planner, Research Agent |
+| **DSP** | DiscoverInventory, GetPricing, RequestDeal | DSP Specialist |
+| **Execution** | CreateOrder, CreateLine, ReserveLine, BookLine | Execution Agent |
+| **Research** | ProductSearch, AvailsCheck | Research Agent |
+| **Reporting** | GetStats | Reporting Agent |
+
+---
+
+## Audience Tools
+
+Audience tools use the IAB Tech Lab [User Context Protocol (UCP)](https://iabtechlab.com/ucp) to discover, match, and estimate audience coverage across seller inventory.
+
+**Package:** `src/ad_buyer/tools/audience/`
+
+### AudienceDiscoveryTool
+
+Discovers available audience signals from a seller endpoint via UCP.
+
+**CrewAI name:** `discover_audience_capabilities`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `seller_endpoint` | `str` | yes | Seller's capability discovery endpoint URL |
+| `signal_types` | `list[str]` | no | Filter by signal type: `identity`, `contextual`, `reinforcement` |
+| `min_coverage` | `float` | no | Minimum coverage percentage (0--100) |
+
+**Returns:** Capabilities grouped by signal type, each with coverage percentage, available segments, and UCP compatibility status.
+
+```python
+from ad_buyer.tools.audience import AudienceDiscoveryTool
+
+tool = AudienceDiscoveryTool()
+result = tool._run(
+    seller_endpoint="http://seller.example.com:8000/ucp/capabilities",
+    signal_types=["contextual", "identity"],
+    min_coverage=50.0,
+)
+```
+
+??? note "Signal types explained"
+    - **Identity**: Hashed user IDs, device graphs, demographic models
+    - **Contextual**: Page content categories, keywords, IAB taxonomy
+    - **Reinforcement**: Purchase intent, past converters, feedback loops
+
+---
+
+### AudienceMatchingTool
+
+Computes a UCP similarity score between the campaign's target audience and a seller's inventory audience characteristics.
+
+**CrewAI name:** `match_audience_to_inventory`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `seller_endpoint` | `str` | yes | Seller's UCP exchange endpoint URL |
+| `demographics` | `dict` | no | Age, gender, income targeting |
+| `interests` | `list[str]` | no | Interest-based categories |
+| `behaviors` | `list[str]` | no | Behavioral targeting segments |
+| `geography` | `str` | no | Country code for geo targeting |
+| `exclusions` | `list[str]` | no | Segments to exclude |
+
+**Returns:** Match quality (STRONG/MODERATE/WEAK/POOR), UCP similarity score (0--1), matched capabilities, gaps, and suggested alternatives.
+
+```python
+from ad_buyer.tools.audience import AudienceMatchingTool
+
+tool = AudienceMatchingTool()
+result = tool._run(
+    seller_endpoint="http://seller.example.com:8000/ucp/exchange",
+    demographics={"age": "25-54", "gender": "all"},
+    interests=["sports", "news"],
+    geography="US",
+)
+```
+
+!!! tip "Score thresholds"
+    - **>= 0.7**: Strong match -- proceed with targeting
+    - **0.5 -- 0.7**: Moderate -- proceed with caution, may limit reach
+    - **< 0.5**: Weak -- consider broadening targeting or reviewing alternatives
+
+---
+
+### CoverageEstimationTool
+
+Estimates audience reach for a targeting specification across channels.
+
+**CrewAI name:** `estimate_audience_coverage`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `targeting` | `dict` | yes | Targeting spec with demographics, interests, behaviors, etc. |
+| `channel` | `str` | no | Specific channel: `display`, `video`, `ctv`, `mobile_app` |
+| `total_impressions` | `int` | no | Total available impressions to estimate against (default: 10M) |
+
+**Returns:** Per-channel coverage estimates with impression counts, coverage percentages, confidence levels, and limiting factors.
+
+```python
+from ad_buyer.tools.audience import CoverageEstimationTool
+
+tool = CoverageEstimationTool()
+result = tool._run(
+    targeting={
+        "demographics": {"age": "25-54"},
+        "interests": ["sports"],
+        "geography": "US",
+    },
+    channel="ctv",
+    total_impressions=5_000_000,
+)
+```
+
+**Coverage factors by targeting type:**
+
+| Targeting Type | Base Coverage | Notes |
+|----------------|--------------|-------|
+| Geography | 95% | Nearly all inventory has geo data |
+| Device | 98% | Device data is standard |
+| Interests (contextual) | 90% | Most inventory supports contextual signals |
+| Demographics | 75% | Modeled demographic data |
+| Behaviors | 40% | Limited behavioral data availability |
+
+**Channel modifiers:**
+
+| Channel | Modifier | Notes |
+|---------|----------|-------|
+| Display | 1.0x | Largest inventory pool |
+| Video | 0.85x | Less video inventory available |
+| Mobile App | 0.70x | App inventory varies |
+| CTV | 0.60x | Most limited but growing |
+
+---
+
+## DSP Tools
+
+DSP tools enable programmatic deal workflows where Deal IDs are obtained from sellers and activated in traditional DSP platforms. All three tools require a `UnifiedClient` and `BuyerContext` at initialization.
+
+**Package:** `src/ad_buyer/tools/dsp/`
+
+### DiscoverInventoryTool
+
+Queries sellers for available inventory with identity-based access and tiered pricing.
+
+**CrewAI name:** `discover_inventory`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | `str` | no | Natural language query (e.g., "CTV inventory under $25 CPM") |
+| `channel` | `str` | no | Channel filter: `ctv`, `display`, `video`, `mobile` |
+| `max_cpm` | `float` | no | Maximum CPM price |
+| `min_impressions` | `int` | no | Minimum available impressions |
+| `targeting` | `list[str]` | no | Required targeting capabilities |
+| `publisher` | `str` | no | Specific publisher to search |
+
+**Returns:** List of products with tiered pricing based on buyer identity, availability, and targeting capabilities.
+
+```python
+from ad_buyer.tools.dsp import DiscoverInventoryTool
+from ad_buyer.clients.unified_client import UnifiedClient
+from ad_buyer.models.buyer_identity import BuyerContext, BuyerIdentity
+
+client = UnifiedClient(base_url="http://seller.example.com:8000")
+buyer_context = BuyerContext(
+    identity=BuyerIdentity(seat_id="ttd-123", agency_id="omnicom-456"),
+    is_authenticated=True,
+)
+
+tool = DiscoverInventoryTool(client=client, buyer_context=buyer_context)
+result = tool._run(query="premium CTV sports inventory", max_cpm=30.0)
+```
+
+!!! info "Access tiers"
+    The buyer's identity determines which inventory and pricing they see:
+
+    | Tier | Discount | Access |
+    |------|----------|--------|
+    | Public | 0% | Price ranges, standard catalog |
+    | Seat | 5% | Fixed prices |
+    | Agency | 10% | Premium inventory, negotiation |
+    | Advertiser | 15% | Volume discounts, full negotiation |
+
+---
+
+### GetPricingTool
+
+Retrieves tier-specific pricing for a product, including volume discounts and deal type options.
+
+**CrewAI name:** `get_pricing`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `product_id` | `str` | yes | Product ID to price |
+| `volume` | `int` | no | Requested impressions (may unlock volume discounts) |
+| `deal_type` | `str` | no | `PG`, `PD`, or `PA` |
+| `flight_start` | `str` | no | Start date (YYYY-MM-DD) |
+| `flight_end` | `str` | no | End date (YYYY-MM-DD) |
+
+**Returns:** Full pricing breakdown with base CPM, tier discount, volume discount, final CPM, cost projection, and available deal types.
+
+```python
+from ad_buyer.tools.dsp import GetPricingTool
+
+tool = GetPricingTool(client=client, buyer_context=buyer_context)
+result = tool._run(
+    product_id="prod-ctv-sports-001",
+    volume=10_000_000,
+    deal_type="PD",
+    flight_start="2026-07-01",
+    flight_end="2026-09-30",
+)
+```
+
+**Volume discounts** (agency/advertiser tiers only):
+
+| Volume | Discount |
+|--------|----------|
+| 5M+ impressions | 5% |
+| 10M+ impressions | 10% |
+
+---
+
+### RequestDealTool
+
+Requests a Deal ID from a seller for programmatic activation in a DSP platform.
+
+**CrewAI name:** `request_deal`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `product_id` | `str` | yes | Product ID to create deal for |
+| `deal_type` | `str` | no | `PG`, `PD` (default), or `PA` |
+| `impressions` | `int` | no | Volume (required for PG deals) |
+| `flight_start` | `str` | no | Start date (YYYY-MM-DD) |
+| `flight_end` | `str` | no | End date (YYYY-MM-DD) |
+| `target_cpm` | `float` | no | Target price for negotiation (agency/advertiser only) |
+
+**Returns:** Deal ID, pricing details, and platform-specific activation instructions for The Trade Desk, DV360, Amazon DSP, Xandr, and Yahoo DSP.
+
+```python
+from ad_buyer.tools.dsp import RequestDealTool
+
+tool = RequestDealTool(client=client, buyer_context=buyer_context)
+result = tool._run(
+    product_id="prod-ctv-sports-001",
+    deal_type="PD",
+    impressions=500_000,
+    flight_start="2026-07-01",
+    flight_end="2026-09-30",
+    target_cpm=22.0,
+)
+```
+
+!!! warning "PG requirements"
+    Programmatic Guaranteed (PG) deals require an `impressions` value. The tool will return an error if you request PG without specifying volume.
+
+!!! warning "Negotiation requirements"
+    Setting `target_cpm` requires Agency or Advertiser tier access **and** the product must have `negotiation_enabled=True`. If either condition is not met, the tool will reject the negotiation attempt.
+
+---
+
+## Execution Tools
+
+Execution tools manage the OpenDirect booking lifecycle: creating orders, adding line items, reserving inventory, and confirming bookings. All require an `OpenDirectClient` at initialization.
+
+**Package:** `src/ad_buyer/tools/execution/`
+
+### CreateOrderTool
+
+Creates a new advertising order (IO) in OpenDirect.
+
+**CrewAI name:** `create_advertising_order`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `account_id` | `str` | yes | Account ID |
+| `order_name` | `str` | yes | Name/title for the order |
+| `brand_id` | `str` | yes | Advertiser brand identifier |
+| `start_date` | `str` | yes | Order start date (YYYY-MM-DD) |
+| `end_date` | `str` | yes | Order end date (YYYY-MM-DD) |
+| `budget` | `float` | yes | Total budget in USD |
+| `currency` | `str` | no | ISO 4217 currency code (default: `USD`) |
+| `publisher_id` | `str` | no | Target publisher ID |
+
+**Returns:** Order ID and status confirmation.
+
+---
+
+### CreateLineTool
+
+Creates a line item within an order, defining the actual media purchase.
+
+**CrewAI name:** `create_line_item`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `account_id` | `str` | yes | Account ID |
+| `order_id` | `str` | yes | Order to add line to |
+| `product_id` | `str` | yes | Product ID to book |
+| `line_name` | `str` | yes | Name for the line item |
+| `start_date` | `str` | yes | Start date (YYYY-MM-DD) |
+| `end_date` | `str` | yes | End date (YYYY-MM-DD) |
+| `rate_type` | `str` | no | `CPM`, `CPMV`, `CPC`, `CPD`, `FlatRate` (default: `CPM`) |
+| `rate` | `float` | yes | Rate/price for the line |
+| `quantity` | `int` | yes | Target impressions or units |
+| `targeting` | `dict` | no | Targeting parameters (geo, demographic, etc.) |
+
+**Returns:** Line ID, status, and estimated cost.
+
+---
+
+### ReserveLineTool
+
+Reserves inventory for a line item, transitioning it from Draft to Reserved status.
+
+**CrewAI name:** `reserve_line_item`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `account_id` | `str` | yes | Account ID |
+| `order_id` | `str` | yes | Order ID |
+| `line_id` | `str` | yes | Line ID to reserve |
+
+**Returns:** Updated line status confirmation. The inventory is temporarily held without final commitment.
+
+---
+
+### BookLineTool
+
+Confirms booking for a line item, transitioning from Reserved to Booked.
+
+**CrewAI name:** `book_line_item`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `account_id` | `str` | yes | Account ID |
+| `order_id` | `str` | yes | Order ID |
+| `line_id` | `str` | yes | Line ID to book |
+
+**Returns:** Booking confirmation with guaranteed impressions and total cost.
+
+---
+
+### Booking Lifecycle
+
+The four execution tools move line items through the OpenDirect booking states:
+
+```
+CreateOrder → CreateLine → ReserveLine → BookLine
+                  ↓             ↓            ↓
+                Draft    →  Reserved   →  Booked  →  InFlight  →  Finished
+```
+
+---
+
+## Research Tools
+
+Research tools discover and evaluate advertising inventory via OpenDirect APIs. Both require an `OpenDirectClient` at initialization.
+
+**Package:** `src/ad_buyer/tools/research/`
+
+### ProductSearchTool
+
+Searches for advertising products across publishers.
+
+**CrewAI name:** `search_advertising_products`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `channel` | `str` | no | `display`, `video`, `mobile`, `ctv`, `native` |
+| `format` | `str` | no | `banner`, `video`, `interstitial`, `rewarded` |
+| `min_price` | `float` | no | Minimum CPM in USD |
+| `max_price` | `float` | no | Maximum CPM in USD |
+| `publisher_ids` | `list[str]` | no | Specific publishers to search |
+| `targeting_capabilities` | `list[str]` | no | Required targeting: `geo`, `demographic`, `behavioral`, `contextual` |
+| `delivery_type` | `str` | no | `Exclusive`, `Guaranteed`, `PMP` |
+| `limit` | `int` | no | Max results (default: 10, max: 50) |
+
+**Returns:** Formatted list of matching products with pricing, reach estimates, and targeting capabilities.
+
+---
+
+### AvailsCheckTool
+
+Checks real-time availability and pricing for a specific product during a flight window.
+
+**CrewAI name:** `check_inventory_availability`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `product_id` | `str` | yes | Product ID to check |
+| `start_date` | `str` | yes | Campaign start date (YYYY-MM-DD) |
+| `end_date` | `str` | yes | Campaign end date (YYYY-MM-DD) |
+| `impressions` | `int` | no | Desired impression volume |
+| `budget` | `float` | no | Total budget in USD |
+
+**Returns:** Available impressions, guaranteed delivery, delivery confidence, estimated CPM, and total cost.
+
+---
+
+## Reporting Tools
+
+**Package:** `src/ad_buyer/tools/reporting/`
+
+### GetStatsTool
+
+Retrieves performance statistics for a line item.
+
+**CrewAI name:** `get_line_statistics`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `account_id` | `str` | yes | Account ID |
+| `order_id` | `str` | yes | Order ID |
+| `line_id` | `str` | yes | Line ID to get stats for |
+
+**Returns:** Delivery metrics (impressions, pacing, delivery rate), spend data (amount spent, budget utilization), and performance indicators (effective CPM, VCR, viewability, CTR).
+
+---
+
+## Tool Initialization Patterns
+
+Tools are typically initialized within crew factory functions, not directly by application code. Here is how each crew creates its tool sets:
+
+```python
+# Research tools -- require OpenDirectClient
+from ad_buyer.tools.research import ProductSearchTool, AvailsCheckTool
+
+research_tools = [
+    ProductSearchTool(client),
+    AvailsCheckTool(client),
+]
+
+# Execution tools -- require OpenDirectClient
+from ad_buyer.tools.execution import (
+    CreateOrderTool, CreateLineTool, ReserveLineTool, BookLineTool,
+)
+
+execution_tools = [
+    CreateOrderTool(client),
+    CreateLineTool(client),
+    ReserveLineTool(client),
+    BookLineTool(client),
+]
+
+# Audience tools -- no client required
+from ad_buyer.tools.audience import (
+    AudienceDiscoveryTool, AudienceMatchingTool, CoverageEstimationTool,
+)
+
+audience_tools = [
+    AudienceDiscoveryTool(),
+    AudienceMatchingTool(),
+    CoverageEstimationTool(),
+]
+
+# DSP tools -- require UnifiedClient + BuyerContext
+from ad_buyer.tools.dsp import (
+    DiscoverInventoryTool, GetPricingTool, RequestDealTool,
+)
+
+dsp_tools = [
+    DiscoverInventoryTool(client=unified_client, buyer_context=buyer_ctx),
+    GetPricingTool(client=unified_client, buyer_context=buyer_ctx),
+    RequestDealTool(client=unified_client, buyer_context=buyer_ctx),
+]
+```
+
+---
+
+## Related
+
+- [Agent Hierarchy](agent-hierarchy.md) -- Which agents use which tools
+- [DSP Deal Flow](dsp-deal-flow.md) -- How DSP tools work together in a flow
+- [Booking Flow](booking-flow.md) -- How execution tools drive the booking lifecycle
+- [Configuration](../guides/configuration.md) -- Tool-related settings

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,0 +1,275 @@
+# Configuration Reference
+
+The buyer agent is configured through environment variables loaded via [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/). Settings are defined in a single `Settings` class and can be set via a `.env` file, shell environment variables, or directly in code.
+
+**Key file:** `src/ad_buyer/config/settings.py`
+
+---
+
+## Quick Start
+
+Create a `.env` file in the project root:
+
+```bash
+# Required
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Seller communication
+SELLER_ENDPOINTS=http://localhost:8000
+IAB_SERVER_URL=http://localhost:8001
+
+# Optional overrides
+DEFAULT_LLM_MODEL=anthropic/claude-sonnet-4-5-20250929
+MANAGER_LLM_MODEL=anthropic/claude-opus-4-20250514
+LOG_LEVEL=INFO
+```
+
+Access settings in code:
+
+```python
+from ad_buyer.config.settings import settings
+
+print(settings.default_llm_model)
+print(settings.get_seller_endpoints())
+```
+
+---
+
+## Environment Variables
+
+### API Keys
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `ANTHROPIC_API_KEY` | `str` | `""` | Anthropic API key for Claude models. Required for agent functionality. |
+| `API_KEY` | `str` | `""` | Inbound API key for authenticating requests to this service. When empty, authentication is disabled (development mode). |
+
+!!! warning "Development mode"
+    When `API_KEY` is empty, the buyer agent's API endpoints are unauthenticated. Set a value in production to require `X-Api-Key` headers on incoming requests.
+
+### Seller Endpoints
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `SELLER_ENDPOINTS` | `str` | `""` | Comma-separated list of seller MCP/A2A server URLs. |
+| `IAB_SERVER_URL` | `str` | `http://localhost:8001` | Primary IAB agentic-direct server URL. Used as the default `base_url` for flows and clients. |
+
+Parse seller endpoints as a list:
+
+```python
+endpoints = settings.get_seller_endpoints()
+# ["http://seller1.example.com:8000", "http://seller2.example.com:8000"]
+```
+
+### OpenDirect (Legacy)
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `OPENDIRECT_BASE_URL` | `str` | `http://localhost:3000/api/v2.1` | Base URL for the OpenDirect 2.1 REST API. |
+| `OPENDIRECT_TOKEN` | `str` | `None` | Bearer token for OpenDirect authentication. |
+| `OPENDIRECT_API_KEY` | `str` | `None` | API key for OpenDirect authentication. |
+
+!!! note "Legacy mode"
+    OpenDirect settings support single-server mode for backwards compatibility. For multi-seller workflows, use `SELLER_ENDPOINTS` with the MCP/A2A protocol clients instead.
+
+---
+
+### LLM Configuration
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `DEFAULT_LLM_MODEL` | `str` | `anthropic/claude-sonnet-4-5-20250929` | Model for Level 2 channel specialists and Level 3 functional agents. |
+| `MANAGER_LLM_MODEL` | `str` | `anthropic/claude-opus-4-20250514` | Model for the Level 1 Portfolio Manager. Opus is used for strategic reasoning. |
+| `LLM_TEMPERATURE` | `float` | `0.3` | Default temperature for LLM calls. Individual agents may override this. |
+| `LLM_MAX_TOKENS` | `int` | `4096` | Maximum token output for LLM responses. |
+
+Models are specified in [litellm](https://docs.litellm.ai/) format: `provider/model-name`. This allows swapping providers without code changes.
+
+```bash
+# Use a different model provider
+DEFAULT_LLM_MODEL=openai/gpt-4o
+MANAGER_LLM_MODEL=anthropic/claude-opus-4-20250514
+```
+
+**Agent temperature overrides:**
+
+While `LLM_TEMPERATURE` sets the global default, each agent type uses a tuned temperature:
+
+| Agent | Temperature | Rationale |
+|-------|------------|-----------|
+| Portfolio Manager (L1) | 0.3 | Balanced strategic reasoning |
+| Channel Specialists (L2) | 0.5 | Creative inventory selection |
+| Audience Planner (L3) | 0.3 | Precise audience strategy |
+| Research Agent (L3) | 0.2 | Data-focused, minimal creativity |
+| Reporting Agent (L3) | 0.2 | Analytical precision |
+| Execution Agent (L3) | 0.1 | Precise booking execution |
+
+---
+
+### Database
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `DATABASE_URL` | `str` | `sqlite:///./ad_buyer.db` | SQLAlchemy connection string for the deal store and local persistence. |
+
+Supports any SQLAlchemy-compatible database. SQLite is the default for development; use PostgreSQL or MySQL for production.
+
+```bash
+# PostgreSQL
+DATABASE_URL=postgresql://user:pass@localhost:5432/ad_buyer
+
+# SQLite (default)
+DATABASE_URL=sqlite:///./ad_buyer.db
+```
+
+---
+
+### Redis
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `REDIS_URL` | `str` | `None` | Redis connection URL for caching and session management. Optional. |
+
+When set, Redis is used for CrewAI memory persistence and session caching. When `None`, in-memory storage is used.
+
+```bash
+REDIS_URL=redis://localhost:6379/0
+```
+
+---
+
+### CrewAI Settings
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `CREW_MEMORY_ENABLED` | `bool` | `True` | Enable CrewAI agent memory across tasks. |
+| `CREW_VERBOSE` | `bool` | `True` | Enable verbose logging for crew execution. Set to `False` in production. |
+| `CREW_MAX_ITERATIONS` | `int` | `15` | Maximum iterations per crew task before forced completion. |
+
+```bash
+# Production settings
+CREW_MEMORY_ENABLED=True
+CREW_VERBOSE=False
+CREW_MAX_ITERATIONS=10
+```
+
+---
+
+### CORS
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `CORS_ALLOWED_ORIGINS` | `str` | `http://localhost:3000,http://localhost:8080` | Comma-separated list of allowed CORS origins. |
+
+Parse as a list:
+
+```python
+origins = settings.get_cors_origins()
+# ["http://localhost:3000", "http://localhost:8080"]
+```
+
+```bash
+# Production
+CORS_ALLOWED_ORIGINS=https://dashboard.example.com,https://app.example.com
+```
+
+---
+
+### Environment
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `ENVIRONMENT` | `str` | `development` | Runtime environment identifier. |
+| `LOG_LEVEL` | `str` | `INFO` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. |
+
+---
+
+## Settings Class
+
+The full `Settings` class for reference:
+
+```python
+from ad_buyer.config.settings import Settings, get_settings
+
+# Singleton (cached)
+settings = get_settings()
+
+# Or create a fresh instance (useful for testing)
+test_settings = Settings(
+    anthropic_api_key="test-key",
+    database_url="sqlite:///./test.db",
+    environment="testing",
+)
+```
+
+The `get_settings()` function returns a cached singleton via `@lru_cache`. This means environment variable changes after first access require a process restart.
+
+---
+
+## .env File Resolution
+
+The settings module uses `python-dotenv` to find a `.env` file. It searches upward from the current working directory. This means the `.env` file can live in the project root or any parent directory.
+
+```
+project-root/
+  .env              <-- found automatically
+  src/
+    ad_buyer/
+      config/
+        settings.py  <-- searches upward from cwd
+```
+
+!!! tip "Multiple environments"
+    For different environments, use separate `.env` files and set the working directory accordingly, or override variables directly in the shell environment. Shell variables take precedence over `.env` values.
+
+---
+
+## Example Configurations
+
+### Development (Minimal)
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Everything else uses defaults: local SQLite database, localhost seller, Sonnet for agents, Opus for manager, verbose logging enabled.
+
+### Production
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+API_KEY=your-service-api-key
+
+SELLER_ENDPOINTS=https://seller1.example.com,https://seller2.example.com
+IAB_SERVER_URL=https://primary-seller.example.com
+
+DATABASE_URL=postgresql://buyer:pass@db.example.com:5432/ad_buyer
+REDIS_URL=redis://cache.example.com:6379/0
+
+CREW_VERBOSE=False
+CREW_MAX_ITERATIONS=10
+
+CORS_ALLOWED_ORIGINS=https://dashboard.example.com
+ENVIRONMENT=production
+LOG_LEVEL=WARNING
+```
+
+### Testing
+
+```bash
+ANTHROPIC_API_KEY=test-key
+API_KEY=test-api-key
+DATABASE_URL=sqlite:///./test_ad_buyer.db
+ENVIRONMENT=testing
+LOG_LEVEL=DEBUG
+CREW_VERBOSE=True
+CREW_MAX_ITERATIONS=5
+```
+
+---
+
+## Related
+
+- [Agent Hierarchy](../architecture/agent-hierarchy.md) -- How LLM settings map to agent levels
+- [Architecture Overview](../architecture/overview.md) -- System component overview
+- [Authentication](../api/authentication.md) -- API key setup for inbound requests

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,11 +68,15 @@ nav:
       - Products: api/products.md
       - Sessions: api/sessions.md
   - Architecture:
+      - Agent Hierarchy: architecture/agent-hierarchy.md
       - Overview: architecture/overview.md
       - Booking Flow: architecture/booking-flow.md
+      - DSP Deal Flow: architecture/dsp-deal-flow.md
       - Deal Store: architecture/deal-store.md
       - Models: architecture/models.md
+      - Tools Reference: architecture/tools.md
   - Guides:
+      - Configuration: guides/configuration.md
       - Deal Booking: guides/deal-booking.md
       - Negotiation: guides/negotiation.md
       - Media Kit Browsing: guides/media-kit.md


### PR DESCRIPTION
## Summary
- **Agent Hierarchy** (`docs/architecture/agent-hierarchy.md`): Documents the 3-level agent hierarchy (Portfolio Manager → Channel Specialists → Functional Agents), crew coordination patterns, and execution flow
- **Tools Reference** (`docs/architecture/tools.md`): Documents all 13 CrewAI tools across 5 categories (Audience, DSP, Execution, Research, Reporting) with inputs, outputs, and initialization patterns
- **DSP Deal Flow** (`docs/architecture/dsp-deal-flow.md`): Documents the `DSPDealFlow` event-driven flow for obtaining Deal IDs, including flow steps, state model, persistence, and convenience function
- **Configuration Reference** (`docs/guides/configuration.md`): Documents all environment variables in `settings.py` with defaults, examples for dev/prod/test environments
- Updated `mkdocs.yml` nav to include all 4 new pages in Architecture and Guides sections

## Test plan
- [ ] Verify `mkdocs serve` renders all 4 new pages without errors
- [ ] Confirm mermaid diagrams render correctly in agent-hierarchy and dsp-deal-flow pages
- [ ] Check all cross-references between new and existing pages resolve
- [ ] Review code examples match current source signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)