### PR TITLE
Add GitHub Action to auto-update PROGRESS.md

### DIFF
--- a/.github/workflows/update-progress.yml
+++ b/.github/workflows/update-progress.yml
@@ -1,0 +1,31 @@
+name: Update PROGRESS.md
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  update-progress:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Regenerate PROGRESS.md
+        run: python .beads/generate_progress.py
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .beads/PROGRESS.md
+          if ! git diff --cached --quiet; then
+            git commit -m "Auto-update PROGRESS.md"
+            git push
+          fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/update-progress.yml` that triggers on push to main
- Runs `python .beads/generate_progress.py` to regenerate PROGRESS.md from issues.jsonl
- Only commits and pushes if the file actually changed (no empty commits)
- Uses `github-actions[bot]` identity for the auto-commit

## Details
- No pip install needed -- the script uses only Python stdlib (json, re, datetime, pathlib)
- Uses `actions/checkout@v4` and `actions/setup-python@v5` (Python 3.11, matching existing CI)
- Workflow has `contents: write` permission to allow pushing the commit

## Test plan
- [ ] Merge this PR and push a change to `.beads/issues.jsonl` on main
- [ ] Verify the Action runs and commits an updated PROGRESS.md
- [ ] Verify no commit is created when PROGRESS.md is already up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)