### PR TITLE
Fix stale PROGRESS.md: use beads-sync JSONL in GitHub Action

### DIFF
--- a/.github/workflows/update-progress.yml
+++ b/.github/workflows/update-progress.yml
@@ -12,6 +12,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use beads-sync JSONL if available
+        run: |
+          # The beads-sync branch may have fresher issues.jsonl than main.
+          # bd sync exports to beads-sync but assume-unchanged can prevent
+          # those changes from reaching main via normal commits.
+          # Fetch and overlay the beads-sync copy as a safety net.
+          if git rev-parse --verify origin/beads-sync >/dev/null 2>&1; then
+            echo "Found beads-sync branch, checking for fresher JSONL..."
+            sync_jsonl=$(git show origin/beads-sync:.beads/issues.jsonl 2>/dev/null || true)
+            if [ -n "$sync_jsonl" ]; then
+              echo "$sync_jsonl" > .beads/issues.jsonl
+              echo "Using issues.jsonl from beads-sync branch"
+            else
+              echo "No issues.jsonl on beads-sync, using main copy"
+            fi
+          else
+            echo "No beads-sync branch on remote, using main copy"
+          fi
 
       - uses: actions/setup-python@v5
         with:
@@ -24,7 +45,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .beads/PROGRESS.md
+          git add .beads/PROGRESS.md .beads/issues.jsonl
           if ! git diff --cached --quiet; then
             git commit -m "Auto-update PROGRESS.md"
             git push


### PR DESCRIPTION
## Summary

- Fixes stale `PROGRESS.md` caused by `bd` setting `assume-unchanged` on `.beads/issues.jsonl`, which prevents JSONL changes from reaching main via normal commits
- The GitHub Action now fetches `issues.jsonl` from the `beads-sync` branch (if available) before generating `PROGRESS.md`, ensuring it always uses the freshest data
- Also stages `issues.jsonl` in the commit step so main's copy stays synchronized

## Root Cause

`bd` (the beads issue tracker) sets `git update-index --assume-unchanged` on `.beads/issues.jsonl` to suppress noise in `git status` from daemon auto-flush writes. This causes git to silently ignore all modifications to the file, so when PRs merge to main, the JSONL stays stale. The GitHub Action then generates `PROGRESS.md` from stale data.

## How It Works

1. `bd sync` exports fresh data to the `beads-sync` branch worktree
2. The GitHub Action now checks for a `beads-sync` branch on the remote
3. If found, it overlays the fresher `issues.jsonl` before running `generate_progress.py`
4. Both `PROGRESS.md` and `issues.jsonl` are committed back to main

**Note:** A complementary fix to the shared pre-commit hook (`agent_range/hooks/pre-commit`) clears the `assume-unchanged` flag before `bd hook pre-commit` runs, ensuring JSONL changes are included in feature branch commits going forward.

## Test plan
- [ ] Verify the Action handles missing `beads-sync` branch gracefully (logs "No beads-sync branch" and uses main copy)
- [ ] Verify the Action fetches fresher JSONL from `beads-sync` when available
- [ ] Verify `PROGRESS.md` reflects current bead statuses after merge

bead: ar-bkd

🤖 Generated with [Claude Code](https://claude.com/claude-code)