### PR TITLE
Expand API overview and fix protocol docs

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -4,7 +4,21 @@ The Ad Buyer Agent API is a FastAPI application running on port 8001 by default.
 
 Base URL: `http://localhost:8001`
 
-## Endpoint Summary
+## Why So Few Endpoints?
+
+The buyer agent exposes only 7 REST endpoints. This is intentional -- the buyer is primarily a **client** that consumes seller APIs, not a server with a large surface area of its own.
+
+A seller agent publishes inventory, manages accounts, processes orders, and handles creative assignments -- operations that demand dozens of endpoints. The buyer agent's job is different: it discovers sellers, browses their catalogs, negotiates pricing, and books deals. Most of that work happens through outbound calls to seller systems via [MCP](mcp-client.md), [A2A](a2a-client.md), or [REST/OpenDirect](../integration/opendirect.md).
+
+The buyer's own REST API exists for two purposes:
+
+1. **Workflow orchestration** -- the `/bookings` endpoints let operators (or upstream systems) submit a campaign brief and track the automated booking workflow.
+2. **Catalog proxy** -- the `/products/search` endpoint lets callers search seller inventory through the buyer without establishing a direct seller connection.
+
+!!! info "Where does the real work happen?"
+    The buyer's complexity lives in its **client libraries**, not its server endpoints. See [Protocol Overview](protocols.md) for how the buyer communicates with sellers, and the sections below for the specific seller endpoints consumed.
+
+## Buyer Endpoints
 
 | Method | Path | Tag | Summary |
 |--------|------|-----|---------|
@@ -16,11 +30,70 @@ Base URL: `http://localhost:8001`
 | `GET` | `/bookings` | Bookings | List all booking jobs |
 | `POST` | `/products/search` | Products | Search seller product catalog |
 
-## Tags
+### Tags
 
 - **Health** -- service health and readiness
 - **Bookings** -- campaign booking workflow lifecycle
 - **Products** -- seller inventory product search
+
+---
+
+## Seller Endpoints Consumed
+
+The buyer agent acts as a client to seller systems. The table below lists the seller-side endpoints the buyer calls, grouped by domain.
+
+### Quotes & Deals (REST)
+
+The [`DealsClient`](deals.md) communicates with the seller's quote-then-book REST API:
+
+| Method | Seller Endpoint | Purpose | Buyer Client Method |
+|--------|----------------|---------|---------------------|
+| `POST` | `/api/v1/quotes` | Request non-binding price quote | `DealsClient.request_quote()` |
+| `GET` | `/api/v1/quotes/{id}` | Retrieve a quote | `DealsClient.get_quote()` |
+| `POST` | `/api/v1/deals` | Book a deal from a quote | `DealsClient.book_deal()` |
+| `GET` | `/api/v1/deals/{id}` | Retrieve deal status | `DealsClient.get_deal()` |
+| `POST` | `/api/v1/deals/{id}/makegoods` | Request makegood (linear TV) | `DealsClient.request_makegood()` |
+| `POST` | `/api/v1/deals/{id}/cancel` | Request cancellation (linear TV) | `DealsClient.request_cancellation()` |
+
+### OpenDirect (REST)
+
+The [`OpenDirectClient`](../integration/opendirect.md) implements the IAB OpenDirect 2.1 resource model:
+
+| Method | Seller Endpoint | Purpose |
+|--------|----------------|---------|
+| `GET` | `/products` | List products |
+| `GET` | `/products/{id}` | Get product detail |
+| `POST` | `/products/search` | Search products with filters |
+| `POST` | `/products/avails` | Check inventory availability |
+| `POST/GET` | `/accounts` | Create / list accounts |
+| `GET` | `/accounts/{id}` | Get account detail |
+| `POST/GET` | `/accounts/{id}/orders` | Create / list orders |
+| `GET` | `/accounts/{id}/orders/{id}` | Get order detail |
+| `POST/GET` | `/accounts/{id}/orders/{id}/lines` | Create / list line items |
+| `PUT/PATCH` | `/accounts/{id}/orders/{id}/lines/{id}` | Update / book line items |
+| `GET` | `/accounts/{id}/orders/{id}/lines/{id}/stats` | Line item delivery stats |
+| `POST/GET` | `/accounts/{id}/creatives` | Create / list creatives |
+
+### MCP Tools (Seller)
+
+Via [MCP](mcp-client.md), the buyer calls seller-side tools directly. These map to the same underlying operations as the OpenDirect endpoints:
+
+| Tool | Purpose |
+|------|---------|
+| `list_products` / `get_product` / `search_products` | Product catalog |
+| `list_accounts` / `create_account` / `get_account` | Account management |
+| `list_orders` / `create_order` / `get_order` | Order management |
+| `list_lines` / `create_line` / `get_line` / `update_line` | Line item management |
+| `list_creatives` / `create_creative` / `create_assignment` | Creative management |
+
+### A2A (Conversational)
+
+Via [A2A](a2a-client.md), the buyer sends natural language requests to the seller's AI agent. The same operations are available but expressed conversationally (e.g., *"Find me CTV inventory with household targeting under $30 CPM"*).
+
+!!! tip "Seller documentation"
+    For full details on the seller-side endpoints and tools listed above, see the [Seller Agent API Reference](https://iabtechlab.github.io/seller-agent/api/overview/).
+
+---
 
 ## Interactive Documentation
 
@@ -29,5 +102,10 @@ When the server is running, Swagger UI is available at `/docs` and ReDoc at `/re
 ## Related Pages
 
 - [Authentication](authentication.md)
+- [Protocol Overview](protocols.md)
 - [Bookings API](bookings.md)
 - [Products API](products.md)
+- [Deals API Client](deals.md)
+- [MCP Client](mcp-client.md)
+- [A2A Client](a2a-client.md)
+- [Seller Agent Docs](https://iabtechlab.github.io/seller-agent/)

--- a/docs/api/protocols.md
+++ b/docs/api/protocols.md
@@ -15,6 +15,17 @@ The buyer agent supports **three protocols** for communicating with seller agent
 
 **MCP** is the default for all CrewAI tool operations. **A2A** is used for exploratory discovery and complex negotiations where natural language interpretation adds value. **REST** (OpenDirect 2.1) supports operator dashboards and legacy integrations.
 
+## When to Use Which
+
+!!! tip "Decision guide"
+    **Use MCP** when you know exactly which operation to perform and want fast, predictable results. This covers the vast majority of automated workflows -- listing products, creating orders, booking line items.
+
+    **Use A2A** when the request is ambiguous or benefits from interpretation. Examples: multi-criteria inventory searches expressed in natural language, complex negotiation exchanges where the seller's AI can reason about pricing, or exploratory discovery where you do not know the exact tool to call.
+
+    **Use REST (OpenDirect)** when integrating with systems that do not support MCP or A2A -- for example, existing dashboards, third-party DSP platforms, or legacy ad servers. The buyer's own REST API also uses this path internally to proxy requests from human operators.
+
+Most buyers will use MCP exclusively and only reach for A2A in discovery or negotiation scenarios. The `UnifiedClient` makes switching trivial -- change a single `protocol` parameter.
+
 ## UnifiedClient
 
 The `UnifiedClient` wraps both MCP and A2A behind a single interface. CrewAI tools use it internally so they can switch protocols without changing their logic.


### PR DESCRIPTION
## Summary
- **API Overview** (`docs/api/overview.md`): Added "Why So Few Endpoints?" section explaining the buyer is primarily a client, not a server. Added comprehensive "Seller Endpoints Consumed" section documenting every seller endpoint the buyer calls across REST (quotes/deals), OpenDirect, MCP tools, and A2A.
- **Protocol Overview** (`docs/api/protocols.md`): Added "When to Use Which" decision guide with admonition block explaining when to choose MCP vs A2A vs REST/OpenDirect.
- Confirmed `protocols.md` exists on disk and is correctly referenced in `mkdocs.yml` -- the reported 404 was likely a deployment timing issue.

## Test plan
- [ ] Run `mkdocs serve` locally and verify both pages render without errors
- [ ] Confirm the Protocol Overview page loads (no 404)
- [ ] Verify all internal cross-references resolve (links to deals.md, mcp-client.md, a2a-client.md, etc.)
- [ ] Verify external link to seller docs is correct

bead: buyer-724

🤖 Generated with [Claude Code](https://claude.com/claude-code)