### PR TITLE
Expand auth docs and add change requests page

### DIFF
--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -1,13 +1,25 @@
 # Authentication
 
-The buyer agent uses API-key authentication via an HTTP middleware on all non-public endpoints.
+The buyer agent has two distinct authentication concerns:
 
-## X-API-Key Header
+1. **Inbound authentication** -- protecting the buyer's own API from unauthorized callers.
+2. **Outbound authentication** -- attaching the correct credentials when the buyer calls seller endpoints.
 
-Protected endpoints require the `X-API-Key` header:
+This page covers both, including the `ApiKeyStore` for managing per-seller credentials and the `AuthMiddleware` that injects keys into outgoing requests.
+
+!!! info "Seller-side reference"
+    For full details on how the seller validates keys, issues access tiers, and manages trust levels, see the [Seller Authentication docs](https://iabtechlab.github.io/seller-agent/api/authentication/).
+
+---
+
+## Inbound Authentication
+
+### X-Api-Key Header
+
+Protected endpoints on the buyer agent require the `X-Api-Key` header:
 
 ```bash
-curl -H "X-API-Key: your-secret-key" http://localhost:8001/bookings
+curl -H "X-Api-Key: your-secret-key" http://localhost:8001/bookings
 ```
 
 The middleware compares the provided key against the `api_key` setting. If the key is missing or does not match, the server returns `401`:
@@ -16,7 +28,7 @@ The middleware compares the provided key against the `api_key` setting. If the k
 {"detail": "Invalid or missing API key"}
 ```
 
-## Development Mode
+### Development Mode
 
 When `api_key` is empty (the default), authentication is **disabled entirely**. All requests are allowed without a key. This is the intended mode for local development.
 
@@ -26,7 +38,7 @@ To enable auth, set the `API_KEY` environment variable or add it to your `.env` 
 API_KEY=my-secret-buyer-key
 ```
 
-## Public Paths
+### Public Paths
 
 The following paths always skip authentication, even when an API key is configured:
 
@@ -37,7 +49,7 @@ The following paths always skip authentication, even when an API key is configur
 | `/openapi.json` | OpenAPI schema |
 | `/redoc` | ReDoc documentation |
 
-## Configuration
+### Configuration
 
 The API key is loaded through `pydantic-settings` in `ad_buyer.config.settings.Settings`:
 
@@ -49,3 +61,358 @@ class Settings(BaseSettings):
 ```
 
 Set it via any method that `pydantic-settings` supports: environment variable, `.env` file, or constructor argument.
+
+---
+
+## Outbound Authentication
+
+When the buyer calls seller endpoints (quotes, deals, media kits, etc.), it needs to present valid credentials. The seller uses these credentials to determine the buyer's [access tier](https://iabtechlab.github.io/seller-agent/api/authentication/) and unlock tiered pricing, negotiation capabilities, and richer data in responses.
+
+### How Sellers Authenticate Buyers
+
+Sellers accept credentials in two formats on every endpoint:
+
+```
+Authorization: Bearer <api_key>
+```
+
+```
+X-Api-Key: <api_key>
+```
+
+Unauthenticated requests receive `public`-tier access only -- price ranges instead of exact prices, no negotiation, and limited data.
+
+### Seller Access Tiers
+
+The tier the buyer receives depends on the identity fields associated with its API key:
+
+| Tier | Identity Required | Pricing Visibility | Negotiation |
+|------|-------------------|-------------------|-------------|
+| `public` | None (anonymous) | Price ranges only | No |
+| `seat` | DSP seat ID | Exact prices, no discounts | Limited |
+| `agency` | Agency ID | Tier discounts applied | Standard |
+| `advertiser` | Full advertiser identity | Full discounts + volume pricing | Premium |
+
+!!! tip "Maximize your access"
+    When creating an API key on the seller, include `seat_id`, `agency_id`, and `advertiser_id` to receive the highest tier. Keys with only a `seat_id` will be limited to seat-tier pricing.
+
+---
+
+## ApiKeyStore
+
+The `ApiKeyStore` provides file-backed credential storage for seller API keys. It stores one key per seller URL in a JSON file at `~/.ad_buyer/seller_keys.json`. Values are base64-encoded on disk to prevent accidental exposure in casual file reads.
+
+!!! warning "Not encryption"
+    Base64 encoding is an obfuscation layer, not encryption. For production deployments, back the store with a secrets manager or encrypted file system.
+
+### Initialization
+
+```python
+from ad_buyer.auth.key_store import ApiKeyStore
+
+# Default location: ~/.ad_buyer/seller_keys.json
+store = ApiKeyStore()
+
+# Custom location
+from pathlib import Path
+store = ApiKeyStore(store_path=Path("/etc/ad_buyer/keys.json"))
+```
+
+The store loads existing keys from disk on initialization. If the file does not exist, the store starts empty.
+
+### Store a Key
+
+Add or replace the API key for a seller URL:
+
+```python
+store.add_key("http://seller.example.com:8001", "sk-abc123secret")
+```
+
+The key is persisted to disk immediately. Trailing slashes on the URL are stripped for consistent lookup.
+
+```bash
+# Verify the key was stored (file contents are base64-encoded)
+cat ~/.ad_buyer/seller_keys.json
+```
+
+```json
+{
+  "http://seller.example.com:8001": "c2stYWJjMTIzc2VjcmV0"
+}
+```
+
+### Retrieve a Key
+
+```python
+key = store.get_key("http://seller.example.com:8001")
+if key:
+    print(f"Key: {key}")  # "sk-abc123secret"
+else:
+    print("No key stored for this seller")
+```
+
+Returns `None` if no key is stored for the given URL.
+
+### Remove a Key
+
+```python
+removed = store.remove_key("http://seller.example.com:8001")
+print(removed)  # True if the key existed, False otherwise
+```
+
+The file is updated on disk immediately after removal.
+
+### Rotate a Key
+
+Replace an existing key with a new one. This is functionally identical to `add_key` but communicates intent:
+
+```python
+store.rotate_key("http://seller.example.com:8001", "sk-new-key-456")
+```
+
+### List All Sellers
+
+Return all seller URLs that have a stored key:
+
+```python
+sellers = store.list_sellers()
+for url in sellers:
+    print(url)
+# http://seller-a.example.com:8001
+# http://seller-b.example.com:8001
+```
+
+### Full ApiKeyStore API
+
+| Method | Signature | Returns | Description |
+|--------|-----------|---------|-------------|
+| `add_key` | `(seller_url: str, api_key: str)` | `None` | Store or replace a key |
+| `get_key` | `(seller_url: str)` | `str \| None` | Retrieve a key |
+| `remove_key` | `(seller_url: str)` | `bool` | Remove a key; `True` if it existed |
+| `rotate_key` | `(seller_url: str, new_key: str)` | `None` | Replace with a new key |
+| `list_sellers` | `()` | `list[str]` | All seller URLs with stored keys |
+
+---
+
+## AuthMiddleware
+
+The `AuthMiddleware` sits between the buyer's HTTP clients and the network. It automatically attaches stored API keys to outgoing requests and inspects responses for `401` status codes that indicate expired or revoked credentials.
+
+### Initialization
+
+```python
+from ad_buyer.auth.key_store import ApiKeyStore
+from ad_buyer.auth.middleware import AuthMiddleware
+
+store = ApiKeyStore()
+store.add_key("http://seller.example.com:8001", "sk-abc123secret")
+
+# Send keys as X-Api-Key header (default)
+middleware = AuthMiddleware(key_store=store, header_type="api_key")
+
+# Or send keys as Bearer tokens
+middleware = AuthMiddleware(key_store=store, header_type="bearer")
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `key_store` | `ApiKeyStore` | *required* | The key store holding per-seller credentials |
+| `header_type` | `"api_key" \| "bearer"` | `"api_key"` | How to send the key in the HTTP header |
+
+### Adding Auth to Requests
+
+The `add_auth` method takes an `httpx.Request` and returns a new request with the appropriate auth header attached. If no key is stored for the request's seller URL, the request is returned unchanged.
+
+```python
+import httpx
+
+request = httpx.Request("GET", "http://seller.example.com:8001/api/v1/products")
+authenticated_request = middleware.add_auth(request)
+
+# The returned request now includes:
+#   X-Api-Key: sk-abc123secret       (if header_type="api_key")
+#   Authorization: Bearer sk-abc123   (if header_type="bearer")
+```
+
+The middleware extracts the base URL (`scheme://host:port`) from the request URL and looks up the key in the store. This means all paths on the same seller host share a single key.
+
+### Handling 401 Responses
+
+The `handle_response` method inspects HTTP responses and returns an `AuthResponse` indicating whether re-authentication is needed:
+
+```python
+from ad_buyer.auth.middleware import AuthResponse
+
+response = await http_client.send(authenticated_request)
+auth_result: AuthResponse = middleware.handle_response(response)
+
+if auth_result.needs_reauth:
+    print(f"Key expired for {auth_result.seller_url}")
+    # Acquire a new key from the seller and update the store
+    new_key = await acquire_new_key(auth_result.seller_url)
+    store.rotate_key(auth_result.seller_url, new_key)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `needs_reauth` | `bool` | `True` if the response was HTTP 401 |
+| `seller_url` | `str` | Base URL of the seller that returned the error |
+| `status_code` | `int` | HTTP status code from the response |
+
+!!! note "403 is not re-auth"
+    Only HTTP 401 (authentication failure) triggers `needs_reauth`. HTTP 403 (authorization / insufficient permissions) is intentionally excluded -- it means the key is valid but the buyer lacks access to the requested resource.
+
+---
+
+## Multi-Seller Credential Management
+
+The `ApiKeyStore` is designed for buyers that work with multiple sellers simultaneously. Each seller URL maps to its own API key, and the `AuthMiddleware` automatically selects the correct key based on the request URL.
+
+```python
+store = ApiKeyStore()
+
+# Register keys for multiple sellers
+store.add_key("http://seller-sports.example.com:8001", "sk-sports-key")
+store.add_key("http://seller-news.example.com:8001", "sk-news-key")
+store.add_key("http://seller-entertainment.example.com:8001", "sk-ent-key")
+
+middleware = AuthMiddleware(key_store=store)
+
+# Each request automatically gets the right key
+sports_req = httpx.Request("GET", "http://seller-sports.example.com:8001/api/v1/products")
+news_req = httpx.Request("GET", "http://seller-news.example.com:8001/api/v1/products")
+
+sports_auth = middleware.add_auth(sports_req)   # X-Api-Key: sk-sports-key
+news_auth = middleware.add_auth(news_req)       # X-Api-Key: sk-news-key
+```
+
+### URL Normalization
+
+The store strips trailing slashes to ensure consistent key lookup. These all resolve to the same key:
+
+```python
+store.add_key("http://seller.example.com:8001/", "sk-key")
+store.get_key("http://seller.example.com:8001")   # "sk-key"
+store.get_key("http://seller.example.com:8001/")  # "sk-key"
+```
+
+---
+
+## Key Acquisition Workflow
+
+Before the buyer can authenticate to a seller, it needs to obtain an API key. The seller's `/auth/api-keys` endpoint issues keys with identity fields that determine the buyer's access tier.
+
+```mermaid
+sequenceDiagram
+    participant Buyer as Buyer Agent
+    participant Store as ApiKeyStore
+    participant Seller as Seller Agent
+
+    Note over Buyer: Step 1: Create key on seller
+    Buyer->>Seller: POST /auth/api-keys (identity fields)
+    Seller-->>Buyer: { api_key: "sk-...", key_id: "..." }
+
+    Note over Buyer: Step 2: Store the key locally
+    Buyer->>Store: add_key(seller_url, api_key)
+    Store-->>Buyer: Persisted to ~/.ad_buyer/seller_keys.json
+
+    Note over Buyer: Step 3: Use key in subsequent requests
+    Buyer->>Seller: GET /api/v1/products (X-Api-Key: sk-...)
+    Seller-->>Buyer: Full product catalog (tier-appropriate data)
+```
+
+### Step 1: Request a Key from the Seller
+
+```bash
+curl -X POST http://seller.example.com:8001/auth/api-keys \
+  -H "Content-Type: application/json" \
+  -d '{
+    "seat_id": "seat-acme-001",
+    "seat_name": "Acme DSP",
+    "agency_id": "agency-mega",
+    "agency_name": "Mega Agency",
+    "advertiser_id": "adv-widget-co",
+    "advertiser_name": "Widget Co",
+    "label": "Widget Co production key",
+    "expires_in_days": 365
+  }'
+```
+
+!!! warning "Save the key immediately"
+    The seller returns the full API key **only once** in the creation response. It cannot be retrieved later. Store it immediately using `ApiKeyStore.add_key()`.
+
+### Step 2: Store the Key
+
+```python
+store = ApiKeyStore()
+store.add_key("http://seller.example.com:8001", "sk-returned-key-from-seller")
+```
+
+### Step 3: Verify Access
+
+```bash
+# Test that the key works and check your tier
+curl -H "X-Api-Key: sk-returned-key-from-seller" \
+  http://seller.example.com:8001/api/v1/products
+```
+
+A successful response with exact pricing (not just ranges) confirms the key is working and the buyer has been assigned an appropriate tier.
+
+### Key Rotation
+
+When a key expires or is compromised:
+
+1. Create a new key on the seller (`POST /auth/api-keys`)
+2. Rotate the local key: `store.rotate_key(seller_url, new_key)`
+3. Optionally revoke the old key on the seller (`DELETE /auth/api-keys/{key_id}`)
+
+```python
+# Rotate after receiving a 401
+auth_result = middleware.handle_response(response)
+if auth_result.needs_reauth:
+    # 1. Get a new key from the seller
+    new_key = await create_seller_api_key(auth_result.seller_url)
+
+    # 2. Update the local store
+    store.rotate_key(auth_result.seller_url, new_key)
+
+    # 3. Retry the failed request (middleware will use the new key)
+    retry_request = middleware.add_auth(original_request)
+    response = await client.send(retry_request)
+```
+
+---
+
+## DealsClient Authentication
+
+The `DealsClient` accepts credentials directly in its constructor and attaches them to every request. This is the simplest path for buyers that interact with a single seller per client instance.
+
+```python
+from ad_buyer.clients.deals_client import DealsClient
+
+# API key authentication (sent as X-Api-Key header)
+client = DealsClient(
+    seller_url="http://seller.example.com:8001",
+    api_key="sk-abc123secret",
+)
+
+# Bearer token authentication (sent as Authorization: Bearer header)
+client = DealsClient(
+    seller_url="http://seller.example.com:8001",
+    bearer_token="eyJhbGciOiJIUzI1NiIs...",
+)
+```
+
+!!! note "One auth method per client"
+    Provide either `api_key` **or** `bearer_token`, not both. If both are set, `api_key` takes precedence and is sent as the `X-Api-Key` header.
+
+For multi-seller scenarios, use `ApiKeyStore` + `AuthMiddleware` to manage credentials centrally, or create one `DealsClient` per seller with its own key.
+
+---
+
+## Related
+
+- [Seller Authentication](https://iabtechlab.github.io/seller-agent/api/authentication/) -- Seller-side key management, access tiers, and trust levels
+- [Deals API](deals.md) -- Deal client that uses these auth mechanisms
+- [Seller Discovery](seller-discovery.md) -- Discovering sellers to authenticate with
+- [Identity Strategy](../guides/identity.md) -- How buyer identity maps to seller tiers

--- a/docs/api/change-requests.md
+++ b/docs/api/change-requests.md
@@ -1,0 +1,415 @@
+# Change Requests
+
+Change requests allow the buyer to propose post-deal modifications to orders on the seller. Each request is validated against the current order state, assigned a severity level, and routed through the appropriate approval path on the seller side.
+
+!!! info "Planned client"
+    The buyer does not yet have a dedicated `ChangeRequestsClient`. The workflows below document the seller's REST API that the buyer calls directly. A typed client is planned for a future release.
+
+!!! tip "Seller-side reference"
+    For the full server-side behavior -- including severity auto-classification, validation rules, and the review/apply workflow -- see the [Seller Change Requests docs](https://iabtechlab.github.io/seller-agent/api/change-requests/).
+
+---
+
+## Overview
+
+```mermaid
+sequenceDiagram
+    participant Buyer as Buyer Agent
+    participant Seller as Seller Agent
+
+    Buyer->>Seller: POST /api/v1/change-requests
+    Note right of Seller: Validates order state,<br/>classifies severity
+
+    alt Minor change (auto-approved)
+        Seller-->>Buyer: CR created (status: approved)
+        Seller->>Seller: Auto-apply to order
+    else Material/Critical change
+        Seller-->>Buyer: CR created (status: pending_approval)
+        Note right of Seller: Awaits human review
+        Buyer->>Seller: GET /api/v1/change-requests/{cr_id}
+        Seller-->>Buyer: Current status
+    end
+```
+
+The buyer submits a change request and receives a change request ID. Minor changes (e.g., small flight date shifts, creative swaps) are auto-approved and applied immediately. Material and critical changes enter a review queue on the seller side.
+
+---
+
+## Severity Levels
+
+The seller automatically classifies each change request into one of three severity levels:
+
+| Severity | Approval Path | Description |
+|----------|--------------|-------------|
+| `minor` | Auto-approved | Low-impact changes: creative swaps, flight date shifts of 3 days or less |
+| `material` | Human review required | Significant changes: impression adjustments, targeting modifications |
+| `critical` | Senior review required | High-impact changes: pricing changes exceeding 20%, cancellations |
+
+### Severity by Change Type
+
+| Change Type | Default Severity | Notes |
+|------------|-----------------|-------|
+| `flight_dates` | `material` | Downgraded to `minor` if the shift is 3 days or less |
+| `impressions` | `material` | -- |
+| `pricing` | `critical` | Always `critical` when the price change exceeds 20% |
+| `creative` | `minor` | Auto-approved |
+| `targeting` | `material` | -- |
+| `cancellation` | `critical` | -- |
+| `other` | `material` | -- |
+
+!!! tip "Faster approvals"
+    Structure your changes to qualify as `minor` when possible. A 2-day flight shift is auto-approved; a 4-day shift requires human review.
+
+---
+
+## Submitting a Change Request
+
+**Endpoint:** `POST /api/v1/change-requests`
+
+### Request Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `order_id` | `str` | yes | The order to modify (seller-issued order/deal ID) |
+| `change_type` | `str` | yes | One of: `flight_dates`, `impressions`, `pricing`, `creative`, `targeting`, `cancellation`, `other` |
+| `diffs` | `list[object]` | no | Field-level changes with `field`, `old_value`, and `new_value` |
+| `proposed_values` | `object` | no | Key-value pairs of proposed new values |
+| `reason` | `str` | no | Explanation for the change |
+| `requested_by` | `str` | no | Identity of the requester (default: `system`) |
+
+### Diff Object
+
+Each entry in the `diffs` array describes one field-level change:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `field` | `str` | Name of the field being changed |
+| `old_value` | `any` | Current value |
+| `new_value` | `any` | Proposed new value |
+
+---
+
+### Example: Flight Date Shift (Auto-Approved)
+
+A 2-day shift falls within the 3-day threshold, so it receives `minor` classification and is auto-approved.
+
+```bash
+curl -X POST http://seller.example.com:8001/api/v1/change-requests \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: your-api-key" \
+  -d '{
+    "order_id": "ORD-A1B2C3D4E5F6",
+    "change_type": "flight_dates",
+    "diffs": [
+      {"field": "flight_start", "old_value": "2026-04-01", "new_value": "2026-04-03"},
+      {"field": "flight_end", "old_value": "2026-04-30", "new_value": "2026-05-02"}
+    ],
+    "reason": "Campaign launch delayed by 2 days",
+    "requested_by": "agent:buyer-001"
+  }'
+```
+
+**Expected response** (status `approved`, auto-applied):
+
+```json
+{
+  "change_request_id": "CR-X1Y2Z3",
+  "order_id": "ORD-A1B2C3D4E5F6",
+  "change_type": "flight_dates",
+  "severity": "minor",
+  "status": "approved",
+  "diffs": [
+    {"field": "flight_start", "old_value": "2026-04-01", "new_value": "2026-04-03"},
+    {"field": "flight_end", "old_value": "2026-04-30", "new_value": "2026-05-02"}
+  ],
+  "reason": "Campaign launch delayed by 2 days"
+}
+```
+
+### Example: Creative Swap (Auto-Approved)
+
+```bash
+curl -X POST http://seller.example.com:8001/api/v1/change-requests \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: your-api-key" \
+  -d '{
+    "order_id": "ORD-A1B2C3D4E5F6",
+    "change_type": "creative",
+    "diffs": [
+      {"field": "creative_id", "old_value": "cr-old-001", "new_value": "cr-new-002"}
+    ],
+    "reason": "Updated brand creative for Q3",
+    "requested_by": "agent:buyer-001"
+  }'
+```
+
+### Example: Impression Adjustment (Requires Review)
+
+```bash
+curl -X POST http://seller.example.com:8001/api/v1/change-requests \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: your-api-key" \
+  -d '{
+    "order_id": "ORD-A1B2C3D4E5F6",
+    "change_type": "impressions",
+    "diffs": [
+      {"field": "impressions", "old_value": 500000, "new_value": 750000}
+    ],
+    "proposed_values": {"impressions": 750000},
+    "reason": "Increasing budget for stronger Q3 performance",
+    "requested_by": "agent:buyer-001"
+  }'
+```
+
+**Expected response** (status `pending_approval`):
+
+```json
+{
+  "change_request_id": "CR-D4E5F6",
+  "order_id": "ORD-A1B2C3D4E5F6",
+  "change_type": "impressions",
+  "severity": "material",
+  "status": "pending_approval",
+  "diffs": [
+    {"field": "impressions", "old_value": 500000, "new_value": 750000}
+  ],
+  "reason": "Increasing budget for stronger Q3 performance"
+}
+```
+
+### Example: Pricing Change (Critical, Senior Review)
+
+```bash
+curl -X POST http://seller.example.com:8001/api/v1/change-requests \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: your-api-key" \
+  -d '{
+    "order_id": "ORD-A1B2C3D4E5F6",
+    "change_type": "pricing",
+    "diffs": [
+      {"field": "final_cpm", "old_value": 10.00, "new_value": 8.50}
+    ],
+    "proposed_values": {"final_cpm": 8.50},
+    "reason": "Requesting discount after volume commitment increase",
+    "requested_by": "agent:buyer-001"
+  }'
+```
+
+### Example: Order Cancellation (Critical)
+
+```bash
+curl -X POST http://seller.example.com:8001/api/v1/change-requests \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: your-api-key" \
+  -d '{
+    "order_id": "ORD-A1B2C3D4E5F6",
+    "change_type": "cancellation",
+    "reason": "Campaign cancelled by advertiser",
+    "requested_by": "agent:buyer-001"
+  }'
+```
+
+---
+
+## Checking Change Request Status
+
+After submitting a change request, poll its status to track progress through the approval pipeline.
+
+### Get a Specific Change Request
+
+**Endpoint:** `GET /api/v1/change-requests/{cr_id}`
+
+```bash
+curl -H "X-Api-Key: your-api-key" \
+  http://seller.example.com:8001/api/v1/change-requests/CR-X1Y2Z3
+```
+
+### List Change Requests for an Order
+
+**Endpoint:** `GET /api/v1/change-requests`
+
+```bash
+# All change requests for an order
+curl -H "X-Api-Key: your-api-key" \
+  "http://seller.example.com:8001/api/v1/change-requests?order_id=ORD-A1B2C3D4E5F6"
+
+# Filter by status
+curl -H "X-Api-Key: your-api-key" \
+  "http://seller.example.com:8001/api/v1/change-requests?order_id=ORD-A1B2C3D4E5F6&status=pending_approval"
+```
+
+| Query Parameter | Type | Description |
+|----------------|------|-------------|
+| `order_id` | `str` | Filter by order ID |
+| `status` | `str` | Filter by status (see lifecycle below) |
+
+---
+
+## Change Request Lifecycle
+
+Change requests move through a 7-state lifecycle on the seller:
+
+```
+pending --> validating --> pending_approval --> approved --> applied
+                 |                  |
+                 v                  v
+              failed           rejected
+```
+
+| Status | Description | Buyer Action |
+|--------|-------------|--------------|
+| `pending` | Created, awaiting validation | Wait |
+| `validating` | Being validated against order state | Wait |
+| `pending_approval` | Material/critical changes awaiting human review | Poll for updates |
+| `approved` | Approved (auto or manual), ready to apply | None required; seller applies |
+| `rejected` | Rejected by reviewer | Submit a revised request or accept rejection |
+| `applied` | Changes applied to the order | Verify updated order state |
+| `failed` | Validation failed (e.g., invalid order state) | Fix and resubmit |
+
+!!! note "Auto-approved changes skip the queue"
+    Minor changes (`creative`, small `flight_dates` shifts) go directly from `validating` to `approved` to `applied` without entering `pending_approval`.
+
+---
+
+## Validation Rules
+
+The seller enforces these constraints when processing change requests:
+
+| Rule | Detail | HTTP Response |
+|------|--------|---------------|
+| Order must be modifiable | Orders in `completed`, `cancelled`, or `failed` status cannot be changed | `422` with error details |
+| Cancellation requires active state | Cancellations only allowed from: `draft`, `submitted`, `pending_approval`, `approved`, `in_progress`, `booked` | `422` |
+| Impressions must be positive | Impression values must be positive integers | `422` |
+| Order must exist | The `order_id` must reference a valid order | `404` |
+
+### Error Response
+
+When validation fails, the seller returns HTTP `422` with the change request ID and error details:
+
+```json
+{
+  "change_request_id": "CR-X1Y2Z3",
+  "error": "validation_failed",
+  "detail": "Order ORD-A1B2C3D4E5F6 is in 'completed' status and cannot be modified"
+}
+```
+
+---
+
+## Buyer Workflow Patterns
+
+### Pattern 1: Simple Modification
+
+For changes that are likely auto-approved (creative swaps, small date shifts):
+
+```python
+import httpx
+
+async def submit_minor_change(seller_url: str, api_key: str, order_id: str):
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{seller_url}/api/v1/change-requests",
+            headers={"X-Api-Key": api_key, "Content-Type": "application/json"},
+            json={
+                "order_id": order_id,
+                "change_type": "creative",
+                "diffs": [
+                    {"field": "creative_id", "old_value": "cr-old", "new_value": "cr-new"}
+                ],
+                "reason": "Updated creative asset",
+                "requested_by": "agent:buyer-001",
+            },
+        )
+        cr = response.json()
+        print(f"CR {cr['change_request_id']}: {cr['status']}")
+        # Expected: status = "approved" (auto-approved)
+```
+
+### Pattern 2: Submit and Poll
+
+For material/critical changes that require seller review:
+
+```python
+import asyncio
+import httpx
+
+async def submit_and_poll(seller_url: str, api_key: str, order_id: str):
+    headers = {"X-Api-Key": api_key, "Content-Type": "application/json"}
+
+    async with httpx.AsyncClient() as client:
+        # Submit the change request
+        response = await client.post(
+            f"{seller_url}/api/v1/change-requests",
+            headers=headers,
+            json={
+                "order_id": order_id,
+                "change_type": "impressions",
+                "diffs": [
+                    {"field": "impressions", "old_value": 500000, "new_value": 750000}
+                ],
+                "proposed_values": {"impressions": 750000},
+                "reason": "Increasing volume for Q3",
+                "requested_by": "agent:buyer-001",
+            },
+        )
+        cr = response.json()
+        cr_id = cr["change_request_id"]
+        print(f"Submitted: {cr_id} (status: {cr['status']})")
+
+        # Poll until resolved
+        terminal_statuses = {"approved", "rejected", "applied", "failed"}
+        while cr["status"] not in terminal_statuses:
+            await asyncio.sleep(5)
+            response = await client.get(
+                f"{seller_url}/api/v1/change-requests/{cr_id}",
+                headers=headers,
+            )
+            cr = response.json()
+            print(f"  Status: {cr['status']}")
+
+        print(f"Final: {cr_id} -> {cr['status']}")
+```
+
+### Pattern 3: Batch Changes
+
+When multiple changes are needed on the same order, submit them individually. The seller processes each change request independently.
+
+```python
+changes = [
+    {
+        "change_type": "flight_dates",
+        "diffs": [
+            {"field": "flight_start", "old_value": "2026-04-01", "new_value": "2026-04-03"},
+            {"field": "flight_end", "old_value": "2026-04-30", "new_value": "2026-05-02"},
+        ],
+        "reason": "Shift flight by 2 days",
+    },
+    {
+        "change_type": "creative",
+        "diffs": [
+            {"field": "creative_id", "old_value": "cr-old", "new_value": "cr-new"},
+        ],
+        "reason": "Updated creative",
+    },
+]
+
+for change in changes:
+    change["order_id"] = order_id
+    change["requested_by"] = "agent:buyer-001"
+    response = await client.post(
+        f"{seller_url}/api/v1/change-requests",
+        headers=headers,
+        json=change,
+    )
+    cr = response.json()
+    print(f"  {cr['change_type']}: {cr['status']}")
+```
+
+---
+
+## Related
+
+- [Seller Change Requests](https://iabtechlab.github.io/seller-agent/api/change-requests/) -- Full server-side behavior, review/apply workflow
+- [Deals API](deals.md) -- Creating the deals that change requests modify
+- [Bookings API](bookings.md) -- Campaign booking workflow
+- [Authentication](authentication.md) -- API key setup for seller communication

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
       - MCP Client: api/mcp-client.md
       - A2A Client: api/a2a-client.md
       - Authentication: api/authentication.md
+      - Change Requests: api/change-requests.md
       - Media Kit: api/media-kit.md
       - Deals: api/deals.md
       - Bookings: api/bookings.md


### PR DESCRIPTION
## Summary
- **Authentication (buyer-2m7):** Expanded from a half-page inbound-only doc to full coverage of both inbound and outbound auth. Now documents `ApiKeyStore` (add/get/remove/rotate/list), `AuthMiddleware` (request decoration, 401 handling), multi-seller credential management, key acquisition workflow with sequence diagram, key rotation, and `DealsClient` auth patterns.
- **Change Requests (buyer-n4e):** New page documenting how the buyer submits post-deal modifications to seller orders. Covers severity levels (minor/material/critical), auto-classification rules, the 7-state lifecycle, validation constraints, and three buyer workflow patterns (simple, poll, batch). Notes that a typed client is planned but not yet implemented.
- Updated `mkdocs.yml` nav to include the new Change Requests page under API Reference.

## Test plan
- [ ] Run `mkdocs serve` locally and verify both pages render correctly
- [ ] Verify all internal links resolve (deals, bookings, authentication cross-refs)
- [ ] Verify external links to seller docs load correctly
- [ ] Confirm mermaid diagrams render in both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)