### PR TITLE
Restructure quickstart: standalone setup + seller workflow

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Get the buyer agent running locally and execute your first booking workflow.
+Get the buyer agent running locally and verify it works.
 
 ## Prerequisites
 
@@ -65,7 +65,7 @@ All settings are loaded from environment variables or the `.env` file via `pydan
 uvicorn ad_buyer.interfaces.api.main:app --reload --port 8001
 ```
 
-The API will be available at `http://localhost:8001`. Interactive docs are served at `/docs` (Swagger) and `/redoc`.
+The API will be available at `http://localhost:8001`.
 
 ## Verify It Works
 
@@ -79,67 +79,32 @@ Expected response:
 {"status": "healthy", "version": "1.0.0"}
 ```
 
-## Example Workflow
+## Browse the API Docs
 
-### 1. Create a booking
+The buyer agent serves interactive API documentation:
+
+- **Swagger UI**: [http://localhost:8001/docs](http://localhost:8001/docs)
+- **ReDoc**: [http://localhost:8001/redoc](http://localhost:8001/redoc)
+
+## First API Calls
+
+These calls work without a seller agent running.
+
+### List Bookings
 
 ```bash
-curl -X POST http://localhost:8001/bookings \
-  -H "Content-Type: application/json" \
-  -d '{
-    "brief": {
-      "name": "Summer Campaign 2026",
-      "objectives": ["brand_awareness", "reach"],
-      "budget": 50000,
-      "start_date": "2026-07-01",
-      "end_date": "2026-08-31",
-      "target_audience": {
-        "demographics": {"age": "25-54"},
-        "interests": ["travel", "outdoor"]
-      },
-      "kpis": {"target_cpm": 12, "viewability": 70},
-      "channels": ["branding", "ctv"]
-    },
-    "auto_approve": false
-  }'
+curl http://localhost:8001/bookings
 ```
 
-Response:
+On a fresh server, this returns an empty list:
 
 ```json
-{
-  "job_id": "a1b2c3d4-...",
-  "status": "pending",
-  "message": "Booking workflow started. Use GET /bookings/{job_id} to check status."
-}
+{"jobs": [], "total": 0}
 ```
 
-### 2. Check status
+## Next Steps
 
-```bash
-curl http://localhost:8001/bookings/a1b2c3d4-...
-```
-
-Poll until `status` reaches `awaiting_approval` (or `completed` if `auto_approve` was true).
-
-### 3. Approve recommendations
-
-```bash
-curl -X POST http://localhost:8001/bookings/a1b2c3d4-.../approve-all
-```
-
-Or approve specific products:
-
-```bash
-curl -X POST http://localhost:8001/bookings/a1b2c3d4-.../approve \
-  -H "Content-Type: application/json" \
-  -d '{"approved_product_ids": ["prod_001", "prod_003"]}'
-```
-
-### 4. View results
-
-```bash
-curl http://localhost:8001/bookings/a1b2c3d4-...
-```
-
-The response now includes `booked_lines` with confirmed deal details.
+- [**Running with Seller**](running-with-seller.md) — Connect to the seller agent and execute a full booking workflow end-to-end.
+- [**Configuration**](../guides/configuration.md) — Deep dive into all configuration options.
+- [**Deal Booking Guide**](../guides/deal-booking.md) — Understand the full booking lifecycle.
+- [**API Reference**](../api/overview.md) — Explore every endpoint in detail.

--- a/docs/getting-started/running-with-seller.md
+++ b/docs/getting-started/running-with-seller.md
@@ -1,0 +1,122 @@
+# Running with Seller
+
+Walk through a full booking workflow with the buyer and seller agents running together.
+
+## Prerequisites
+
+- Buyer agent installed and running (see [Quickstart](quickstart.md))
+- Seller agent installed and running — follow the [Seller Agent Quickstart](https://iabtechlab.github.io/seller-agent/getting-started/quickstart/)
+
+!!! tip "Default Ports"
+    The seller agent runs on port **3000** by default, the buyer agent on port **8001**. The buyer's `OPENDIRECT_BASE_URL` should point to the seller's API (e.g. `http://localhost:3000/api/v2.1`).
+
+## Start Both Agents
+
+### 1. Start the seller agent
+
+In a separate terminal:
+
+```bash
+cd seller_agent
+uvicorn seller_agent.api.main:app --reload --port 3000
+```
+
+Verify the seller is running:
+
+```bash
+curl http://localhost:3000/health
+```
+
+### 2. Start the buyer agent
+
+In another terminal:
+
+```bash
+cd ad_buyer_system
+uvicorn ad_buyer.interfaces.api.main:app --reload --port 8001
+```
+
+Verify the buyer is running:
+
+```bash
+curl http://localhost:8001/health
+```
+
+## Booking Workflow
+
+### 1. Create a booking
+
+Submit a campaign brief to the buyer agent. It will contact the seller agent in the background to find matching inventory, allocate budget, and build recommendations.
+
+```bash
+curl -X POST http://localhost:8001/bookings \
+  -H "Content-Type: application/json" \
+  -d '{
+    "brief": {
+      "name": "Summer Campaign 2026",
+      "objectives": ["brand_awareness", "reach"],
+      "budget": 50000,
+      "start_date": "2026-07-01",
+      "end_date": "2026-08-31",
+      "target_audience": {
+        "demographics": {"age": "25-54"},
+        "interests": ["travel", "outdoor"]
+      },
+      "kpis": {"target_cpm": 12, "viewability": 70},
+      "channels": ["branding", "ctv"]
+    },
+    "auto_approve": false
+  }'
+```
+
+Response:
+
+```json
+{
+  "job_id": "a1b2c3d4-...",
+  "status": "pending",
+  "message": "Booking workflow started. Use GET /bookings/{job_id} to check status."
+}
+```
+
+### 2. Check status
+
+Poll the booking endpoint until the status reaches `awaiting_approval` (or `completed` if `auto_approve` was true):
+
+```bash
+curl http://localhost:8001/bookings/a1b2c3d4-...
+```
+
+### 3. Approve recommendations
+
+Once the booking reaches `awaiting_approval`, review the recommendations and approve them.
+
+Approve all recommendations:
+
+```bash
+curl -X POST http://localhost:8001/bookings/a1b2c3d4-.../approve-all
+```
+
+Or approve specific products:
+
+```bash
+curl -X POST http://localhost:8001/bookings/a1b2c3d4-.../approve \
+  -H "Content-Type: application/json" \
+  -d '{"approved_product_ids": ["prod_001", "prod_003"]}'
+```
+
+### 4. View results
+
+```bash
+curl http://localhost:8001/bookings/a1b2c3d4-...
+```
+
+The response now includes `booked_lines` with confirmed deal details from the seller.
+
+## Next Steps
+
+- [**Deal Booking Guide**](../guides/deal-booking.md) — Detailed explanation of the booking lifecycle and deal states.
+- [**Negotiation**](../guides/negotiation.md) — How the buyer agent negotiates pricing and terms.
+- [**Media Kit Browsing**](../guides/media-kit.md) — Explore seller inventory before booking.
+- [**Multi-Seller Discovery**](../guides/multi-seller.md) — Connect to multiple sellers simultaneously.
+- [**Seller Agent Integration**](../integration/seller-agent.md) — Technical details on the buyer-seller protocol.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
   - Home: index.md
   - Getting Started:
       - Quickstart: getting-started/quickstart.md
+      - Running with Seller: getting-started/running-with-seller.md
   - API Reference:
       - Overview: api/overview.md
       - Protocol Overview: api/protocols.md


### PR DESCRIPTION
## Summary
- **Rewrote `docs/getting-started/quickstart.md`** to be a standalone setup guide (matching the [seller agent's quickstart pattern](https://iabtechlab.github.io/seller-agent/getting-started/quickstart/)): prerequisites, install, configure, start server, health check, browse API docs, list bookings (empty), next steps.
- **Created `docs/getting-started/running-with-seller.md`** with the full end-to-end booking walkthrough that requires the seller agent running (create booking, poll status, approve, view results).
- **Updated `mkdocs.yml`** nav to include the new "Running with Seller" page under Getting Started.

## Motivation
The previous quickstart combined installation with a full booking flow that required the seller agent. New users couldn't verify their setup was working without first setting up a separate system. Now the quickstart is self-contained -- get running and confirm it works in under 5 minutes.

## Test plan
- [ ] `mkdocs serve` renders both pages correctly
- [ ] All internal links resolve (next steps, cross-page references)
- [ ] Health check and list-bookings examples work against a running server

bead: buyer-6sb

Generated with [Claude Code](https://claude.com/claude-code)