### PR TITLE
Docs: update home page, expand A2A schemas, add error sections

### DIFF
--- a/docs/api/a2a-client.md
+++ b/docs/api/a2a-client.md
@@ -14,6 +14,144 @@ The `A2AClient` connects to a seller's A2A endpoint and sends natural language m
 
 No explicit connect step is needed. The client sends requests immediately.
 
+## JSON-RPC Request Structure
+
+Every A2A request is a JSON-RPC 2.0 envelope containing a natural language message. The buyer constructs this envelope automatically; understanding the wire format is useful for debugging and integration testing.
+
+### Envelope Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `jsonrpc` | `str` | Always `"2.0"` |
+| `method` | `str` | Always `"message/send"` |
+| `params` | `object` | Contains `message` and optional `contextId` |
+| `id` | `str` | Client-generated UUID for request correlation |
+
+### `params.message` Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `messageId` | `str` | yes | Client-generated UUID identifying this message |
+| `role` | `str` | yes | Always `"user"` for buyer-initiated messages |
+| `parts` | `list[object]` | yes | Message content parts (see below) |
+
+### Message Parts
+
+Each entry in the `parts` array has a `kind` field that determines its structure:
+
+| Kind | Fields | Description |
+|------|--------|-------------|
+| `text` | `kind`, `text` | Natural language text content |
+| `data` | `kind`, `data` | Structured data (JSON object) |
+
+The buyer currently sends only `text` parts. The seller may return both `text` and `data` parts in its response.
+
+### Wire Format Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "message/send",
+  "params": {
+    "message": {
+      "messageId": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+      "role": "user",
+      "parts": [
+        {"kind": "text", "text": "List all available advertising products"}
+      ]
+    },
+    "contextId": "ctx-previous-response-id"
+  },
+  "id": "f9e8d7c6-5432-10ab-cdef-fedcba987654"
+}
+```
+
+The `contextId` field is omitted on the first message in a conversation and included on subsequent messages to continue the same context.
+
+## Request Formats for Key Operations
+
+Each convenience method generates a specific natural language prompt. Here is the request format for each operation:
+
+### `send_message(message, context_id)`
+
+Sends an arbitrary natural language message. This is the base method all other convenience methods call.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `message` | `str` | yes | Natural language request text |
+| `context_id` | `str` | no | Context ID from a previous response for multi-turn |
+
+### `get_agent_card()`
+
+Fetches the seller's agent card via `GET` (not JSON-RPC). No parameters.
+
+**Endpoint:** `GET {base_url}/a2a/{agent_type}/.well-known/agent-card.json`
+
+### `list_products()`
+
+No parameters. Sends: `"List all available advertising products"`
+
+### `search_products(criteria)`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `criteria` | `str` | yes | Natural language search criteria |
+
+Sends: `"Search for advertising products: {criteria}"`
+
+### `create_account(name, advertiser_id)`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `str` | yes | Account name |
+| `advertiser_id` | `str` | yes | Advertiser organization ID |
+
+Sends: `"Create an account named '{name}' for advertiser {advertiser_id}"`
+
+### `create_order(account_id, name, budget, start_date, end_date)`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `account_id` | `str` | yes | Account ID |
+| `name` | `str` | yes | Order name |
+| `budget` | `float` | yes | Budget in USD |
+| `start_date` | `str` | yes | Start date (YYYY-MM-DD) |
+| `end_date` | `str` | yes | End date (YYYY-MM-DD) |
+
+Sends: `"Create an order named '{name}' for account {account_id} with budget ${budget:,.2f} from {start_date} to {end_date}"`
+
+### `create_line(order_id, product_id, name, quantity, start_date, end_date)`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `order_id` | `str` | yes | Order ID |
+| `product_id` | `str` | yes | Product ID |
+| `name` | `str` | yes | Line item name |
+| `quantity` | `int` | yes | Impressions to book |
+| `start_date` | `str` | yes | Start date (YYYY-MM-DD) |
+| `end_date` | `str` | yes | End date (YYYY-MM-DD) |
+
+Sends: `"Create a line item named '{name}' for order {order_id} using product {product_id} with {quantity:,} impressions from {start_date} to {end_date}"`
+
+### `book_line(line_id)`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `line_id` | `str` | yes | Line item ID to book |
+
+Sends: `"Book line item {line_id}"`
+
+### `check_availability(product_id, quantity, start_date, end_date)`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `product_id` | `str` | yes | Product ID |
+| `quantity` | `int` | yes | Requested impressions |
+| `start_date` | `str` | no | Start date (YYYY-MM-DD) |
+| `end_date` | `str` | no | End date (YYYY-MM-DD) |
+
+Sends: `"Check availability for product {product_id} with {quantity:,} impressions"` (appends date range if both dates provided)
+
 ## Convenience Methods
 
 The `A2AClient` provides typed convenience methods that translate structured calls into natural language messages:
@@ -112,6 +250,44 @@ async with A2AClient(base_url="http://seller:8001") as client:
 | Deterministic, repeatable results | -- | Preferred |
 
 Use A2A when the request benefits from natural language interpretation -- for example, asking "What CTV inventory do you have under $25 with household targeting?" rather than constructing exact filter parameters.
+
+## Error Handling
+
+The client raises `A2AError` when the seller returns a JSON-RPC error response. HTTP-level errors (connection refused, timeouts) raise standard `httpx` exceptions.
+
+```python
+from ad_buyer.clients.a2a_client import A2AClient, A2AError
+import httpx
+
+try:
+    response = await client.send_message("List products")
+except A2AError as e:
+    # Seller returned a JSON-RPC error
+    print(f"A2A error: {e}")
+except httpx.ConnectError:
+    # Seller agent is unreachable
+    print("Cannot connect to seller")
+except httpx.TimeoutException:
+    # Request timed out (default: 60s)
+    print("Request timed out")
+except httpx.HTTPStatusError as e:
+    # Seller returned non-2xx HTTP status
+    print(f"HTTP {e.response.status_code}")
+```
+
+### Error Scenarios
+
+| Scenario | Exception | Description |
+|----------|-----------|-------------|
+| JSON-RPC error in response | `A2AError` | Seller processed the request but returned an error (e.g., invalid tool, internal failure) |
+| Seller unreachable | `httpx.ConnectError` | Cannot establish TCP connection to the seller endpoint |
+| Request timeout | `httpx.TimeoutException` | No response within the configured timeout (default: 60s) |
+| HTTP 4xx/5xx | `httpx.HTTPStatusError` | Seller returned an HTTP error before JSON-RPC processing |
+| Invalid agent card | `httpx.HTTPStatusError` | Agent card endpoint returned non-2xx status |
+| Malformed response | `KeyError` / `TypeError` | Seller returned JSON that does not match expected A2A structure |
+
+!!! note "No automatic retries"
+    Unlike the `DealsClient`, the A2A client does not retry failed requests automatically. Callers should implement their own retry logic for transient failures (connection errors, timeouts).
 
 ## Related
 

--- a/docs/api/bookings.md
+++ b/docs/api/bookings.md
@@ -175,3 +175,46 @@ List all booking jobs, optionally filtered by status.
 ```bash
 curl "http://localhost:8001/bookings?status=awaiting_approval&limit=5"
 ```
+
+---
+
+## Error Handling
+
+All booking endpoints return structured error responses with an HTTP status code and a JSON body containing `error` and `detail` fields.
+
+```json
+{
+  "error": "not_found",
+  "detail": "Booking job a1b2c3d4-... not found"
+}
+```
+
+### Error Codes
+
+| Endpoint | HTTP Status | `error` | When |
+|----------|------------|---------|------|
+| `POST /bookings` | `400` | `invalid_brief` | Required brief fields missing or invalid (e.g., budget <= 0, empty objectives, end_date before start_date) |
+| `POST /bookings` | `422` | `validation_error` | Brief payload fails Pydantic schema validation |
+| `GET /bookings/{job_id}` | `404` | `not_found` | No booking job exists with the given ID |
+| `POST /bookings/{job_id}/approve` | `404` | `not_found` | No booking job exists with the given ID |
+| `POST /bookings/{job_id}/approve` | `409` | `invalid_status` | Job is not in `awaiting_approval` status |
+| `POST /bookings/{job_id}/approve` | `400` | `invalid_products` | None of the submitted product IDs match pending recommendations |
+| `POST /bookings/{job_id}/approve-all` | `404` | `not_found` | No booking job exists with the given ID |
+| `POST /bookings/{job_id}/approve-all` | `409` | `invalid_status` | Job is not in `awaiting_approval` status |
+| `GET /bookings` | `422` | `validation_error` | Invalid query parameter value (e.g., non-integer `limit`) |
+| *any* | `500` | `internal_error` | Unexpected server error during booking flow execution |
+
+### Booking Flow Failures
+
+When the background booking flow fails (seller unreachable, budget allocation error, etc.), the job transitions to `failed` status rather than returning an HTTP error. Poll `GET /bookings/{job_id}` and check the `errors` array:
+
+```json
+{
+  "job_id": "a1b2c3d4-...",
+  "status": "failed",
+  "errors": [
+    "Seller agent unreachable at http://seller:8001",
+    "Budget allocation failed: no valid channel splits found"
+  ]
+}
+```

--- a/docs/api/mcp-client.md
+++ b/docs/api/mcp-client.md
@@ -109,6 +109,85 @@ async with IABMCPClient(base_url="http://seller:8001") as client:
 
 Use MCP when you know the exact tool and arguments. The buyer's CrewAI tools default to MCP for all standard operations.
 
+## Error Handling
+
+MCP client errors fall into two categories: connection-level failures (cannot reach the seller) and tool-level failures (the tool call itself failed).
+
+### IABMCPClient Errors
+
+```python
+from ad_buyer.clients.mcp_client import IABMCPClient
+
+try:
+    async with IABMCPClient(base_url="http://seller:8001") as client:
+        result = await client.list_products()
+except ConnectionError:
+    # Seller agent is not running or SSE endpoint is unavailable
+    print("Cannot connect to seller MCP endpoint")
+except TimeoutError:
+    # SSE connection or tool call timed out
+    print("MCP request timed out")
+```
+
+### SimpleMCPClient Errors
+
+The `SimpleMCPClient` uses standard HTTP and raises `httpx` exceptions:
+
+```python
+import httpx
+
+try:
+    result = await client.call_tool("list_products", {})
+except httpx.ConnectError:
+    print("Seller unreachable")
+except httpx.TimeoutException:
+    print("Request timed out")
+except httpx.HTTPStatusError as e:
+    print(f"HTTP {e.response.status_code}")
+```
+
+### Error Scenarios
+
+| Scenario | Client | Exception | Description |
+|----------|--------|-----------|-------------|
+| Seller unreachable | Both | `ConnectionError` / `httpx.ConnectError` | Cannot establish connection to the seller's MCP endpoint |
+| SSE stream failure | `IABMCPClient` | `ConnectionError` | Streamable HTTP connection dropped or failed to initialize |
+| Tool not found | Both | Tool result with `isError=True` | Requested tool name does not exist in the seller's tool registry |
+| Tool execution error | Both | Tool result with `isError=True` | Seller tool raised an error during execution |
+| Authentication failure | Both | `httpx.HTTPStatusError` (401/403) | API key or token is invalid or missing |
+| Request timeout | Both | `TimeoutError` / `httpx.TimeoutException` | No response within the configured timeout |
+| Invalid arguments | Both | Tool result with `isError=True` | Tool arguments do not match the expected schema |
+| Session expired | `IABMCPClient` | `ConnectionError` | MCP session was invalidated; reconnect required |
+
+### Tool-Level Errors
+
+When a tool call reaches the seller but fails during execution, the response `MCPToolResult` has `isError=True` rather than raising an exception:
+
+```python
+result = await client.call_tool("get_product", {"id": "nonexistent"})
+if result.isError:
+    print(f"Tool error: {result.content}")
+```
+
+### Retry Behavior
+
+Neither MCP client implementation retries failed requests automatically. For production use, wrap calls in retry logic for transient failures:
+
+- **Connection errors**: Safe to retry immediately (seller may be restarting)
+- **Timeouts**: Safe to retry with backoff
+- **Tool errors** (`isError=True`): Do not retry -- the error is deterministic
+- **Auth failures** (401/403): Do not retry -- fix credentials first
+
+### Fallback Chain
+
+The `SimpleMCPClient` implements a tool discovery fallback chain:
+
+1. Try `GET /mcp/tools` -- standard tool listing endpoint
+2. Try `call_tool("list_tools")` -- some sellers expose listing as a tool
+3. Fall back to a default set of standard OpenDirect tools
+
+If all three fail, the client assumes the standard tool set and tool calls may fail at execution time.
+
 ## Related
 
 - [A2A Client](a2a-client.md) -- conversational protocol for discovery and negotiation

--- a/docs/api/products.md
+++ b/docs/api/products.md
@@ -50,3 +50,30 @@ The product search connects to the seller agent's OpenDirect API. Make sure:
 2. Authentication credentials (`OPENDIRECT_TOKEN` or `OPENDIRECT_API_KEY`) are set if the seller requires them.
 
 See [Seller Agent Integration](../integration/seller-agent.md) for details.
+
+---
+
+## Error Handling
+
+The products endpoint returns structured error responses with an HTTP status code and a JSON body.
+
+```json
+{
+  "error": "seller_unreachable",
+  "detail": "Cannot connect to seller agent at http://seller:8001"
+}
+```
+
+### Error Codes
+
+| HTTP Status | `error` | When |
+|------------|---------|------|
+| `422` | `validation_error` | Invalid search parameters (e.g., `min_price` > `max_price`, `limit` out of 1-50 range) |
+| `502` | `seller_unreachable` | Seller agent is not running or not accessible at the configured `OPENDIRECT_BASE_URL` |
+| `502` | `seller_error` | Seller agent returned a non-2xx response to the product search request |
+| `401` | `auth_error` | Seller rejected the configured `OPENDIRECT_TOKEN` or `OPENDIRECT_API_KEY` |
+| `504` | `seller_timeout` | Seller agent did not respond within the request timeout |
+| `500` | `internal_error` | Unexpected error during product search execution |
+
+!!! tip "Empty results are not errors"
+    If no products match the search criteria, the endpoint returns `200` with an empty `results` array -- not a `404`.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Get the buyer agent running locally and execute your first booking workflow.
+Get the buyer agent running locally and verify it works.
 
 ## Prerequisites
 
@@ -65,7 +65,7 @@ All settings are loaded from environment variables or the `.env` file via `pydan
 uvicorn ad_buyer.interfaces.api.main:app --reload --port 8001
 ```
 
-The API will be available at `http://localhost:8001`. Interactive docs are served at `/docs` (Swagger) and `/redoc`.
+The API will be available at `http://localhost:8001`.
 
 ## Verify It Works
 
@@ -79,67 +79,32 @@ Expected response:
 {"status": "healthy", "version": "1.0.0"}
 ```
 
-## Example Workflow
+## Browse the API Docs
 
-### 1. Create a booking
+The buyer agent serves interactive API documentation:
+
+- **Swagger UI**: [http://localhost:8001/docs](http://localhost:8001/docs)
+- **ReDoc**: [http://localhost:8001/redoc](http://localhost:8001/redoc)
+
+## First API Calls
+
+These calls work without a seller agent running.
+
+### List Bookings
 
 ```bash
-curl -X POST http://localhost:8001/bookings \
-  -H "Content-Type: application/json" \
-  -d '{
-    "brief": {
-      "name": "Summer Campaign 2026",
-      "objectives": ["brand_awareness", "reach"],
-      "budget": 50000,
-      "start_date": "2026-07-01",
-      "end_date": "2026-08-31",
-      "target_audience": {
-        "demographics": {"age": "25-54"},
-        "interests": ["travel", "outdoor"]
-      },
-      "kpis": {"target_cpm": 12, "viewability": 70},
-      "channels": ["branding", "ctv"]
-    },
-    "auto_approve": false
-  }'
+curl http://localhost:8001/bookings
 ```
 
-Response:
+On a fresh server, this returns an empty list:
 
 ```json
-{
-  "job_id": "a1b2c3d4-...",
-  "status": "pending",
-  "message": "Booking workflow started. Use GET /bookings/{job_id} to check status."
-}
+{"jobs": [], "total": 0}
 ```
 
-### 2. Check status
+## Next Steps
 
-```bash
-curl http://localhost:8001/bookings/a1b2c3d4-...
-```
-
-Poll until `status` reaches `awaiting_approval` (or `completed` if `auto_approve` was true).
-
-### 3. Approve recommendations
-
-```bash
-curl -X POST http://localhost:8001/bookings/a1b2c3d4-.../approve-all
-```
-
-Or approve specific products:
-
-```bash
-curl -X POST http://localhost:8001/bookings/a1b2c3d4-.../approve \
-  -H "Content-Type: application/json" \
-  -d '{"approved_product_ids": ["prod_001", "prod_003"]}'
-```
-
-### 4. View results
-
-```bash
-curl http://localhost:8001/bookings/a1b2c3d4-...
-```
-
-The response now includes `booked_lines` with confirmed deal details.
+- [**Running with Seller**](running-with-seller.md) — Connect to the seller agent and execute a full booking workflow end-to-end.
+- [**Configuration**](../guides/configuration.md) — Deep dive into all configuration options.
+- [**Deal Booking Guide**](../guides/deal-booking.md) — Understand the full booking lifecycle.
+- [**API Reference**](../api/overview.md) — Explore every endpoint in detail.

--- a/docs/getting-started/running-with-seller.md
+++ b/docs/getting-started/running-with-seller.md
@@ -1,0 +1,122 @@
+# Running with Seller
+
+Walk through a full booking workflow with the buyer and seller agents running together.
+
+## Prerequisites
+
+- Buyer agent installed and running (see [Quickstart](quickstart.md))
+- Seller agent installed and running — follow the [Seller Agent Quickstart](https://iabtechlab.github.io/seller-agent/getting-started/quickstart/)
+
+!!! tip "Default Ports"
+    The seller agent runs on port **3000** by default, the buyer agent on port **8001**. The buyer's `OPENDIRECT_BASE_URL` should point to the seller's API (e.g. `http://localhost:3000/api/v2.1`).
+
+## Start Both Agents
+
+### 1. Start the seller agent
+
+In a separate terminal:
+
+```bash
+cd seller_agent
+uvicorn seller_agent.api.main:app --reload --port 3000
+```
+
+Verify the seller is running:
+
+```bash
+curl http://localhost:3000/health
+```
+
+### 2. Start the buyer agent
+
+In another terminal:
+
+```bash
+cd ad_buyer_system
+uvicorn ad_buyer.interfaces.api.main:app --reload --port 8001
+```
+
+Verify the buyer is running:
+
+```bash
+curl http://localhost:8001/health
+```
+
+## Booking Workflow
+
+### 1. Create a booking
+
+Submit a campaign brief to the buyer agent. It will contact the seller agent in the background to find matching inventory, allocate budget, and build recommendations.
+
+```bash
+curl -X POST http://localhost:8001/bookings \
+  -H "Content-Type: application/json" \
+  -d '{
+    "brief": {
+      "name": "Summer Campaign 2026",
+      "objectives": ["brand_awareness", "reach"],
+      "budget": 50000,
+      "start_date": "2026-07-01",
+      "end_date": "2026-08-31",
+      "target_audience": {
+        "demographics": {"age": "25-54"},
+        "interests": ["travel", "outdoor"]
+      },
+      "kpis": {"target_cpm": 12, "viewability": 70},
+      "channels": ["branding", "ctv"]
+    },
+    "auto_approve": false
+  }'
+```
+
+Response:
+
+```json
+{
+  "job_id": "a1b2c3d4-...",
+  "status": "pending",
+  "message": "Booking workflow started. Use GET /bookings/{job_id} to check status."
+}
+```
+
+### 2. Check status
+
+Poll the booking endpoint until the status reaches `awaiting_approval` (or `completed` if `auto_approve` was true):
+
+```bash
+curl http://localhost:8001/bookings/a1b2c3d4-...
+```
+
+### 3. Approve recommendations
+
+Once the booking reaches `awaiting_approval`, review the recommendations and approve them.
+
+Approve all recommendations:
+
+```bash
+curl -X POST http://localhost:8001/bookings/a1b2c3d4-.../approve-all
+```
+
+Or approve specific products:
+
+```bash
+curl -X POST http://localhost:8001/bookings/a1b2c3d4-.../approve \
+  -H "Content-Type: application/json" \
+  -d '{"approved_product_ids": ["prod_001", "prod_003"]}'
+```
+
+### 4. View results
+
+```bash
+curl http://localhost:8001/bookings/a1b2c3d4-...
+```
+
+The response now includes `booked_lines` with confirmed deal details from the seller.
+
+## Next Steps
+
+- [**Deal Booking Guide**](../guides/deal-booking.md) — Detailed explanation of the booking lifecycle and deal states.
+- [**Negotiation**](../guides/negotiation.md) — How the buyer agent negotiates pricing and terms.
+- [**Media Kit Browsing**](../guides/media-kit.md) — Explore seller inventory before booking.
+- [**Multi-Seller Discovery**](../guides/multi-seller.md) — Connect to multiple sellers simultaneously.
+- [**Seller Agent Integration**](../integration/seller-agent.md) — Technical details on the buyer-seller protocol.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,16 @@ Part of the IAB Tech Lab Agent Ecosystem -- see also the [Seller Agent](https://
 
 - **Campaign briefing** -- accept structured campaign briefs with objectives, budget, dates, audience, and KPIs.
 - **Budget allocation** -- a portfolio-manager agent splits budget across channels (branding, CTV, mobile, performance).
-- **Inventory research** -- channel-specialist agents query seller product catalogs via OpenDirect.
+- **Inventory research** -- channel-specialist agents query seller product catalogs via MCP and A2A protocols.
 - **Recommendation consolidation** -- recommendations from all channels are ranked and presented for review.
 - **Human approval** -- optional approval checkpoint before committing spend.
-- **Deal booking** -- approved recommendations are booked as line items against seller APIs.
+- **Deal booking** -- approved recommendations are booked via the quote-then-book deal flow (IAB Deals API v1.0).
+- **Multi-turn negotiation** -- pluggable negotiation strategies (anchor, split-the-difference, walk-away) over A2A conversations.
+- **Multi-seller discovery** -- discover and compare sellers via AAMP registry with trust verification and capability filtering.
+- **Tiered identity strategy** -- four pricing tiers (seat, agency, advertiser, anonymous) determine rate cards and discounts.
+- **Persistent session management** -- sessions track conversation state, negotiation history, and deal context across interactions.
+- **Linear TV buying** -- scatter and upfront buying with DMA-level targeting, CPP/CPM pricing, and daypart selection.
+- **Media kit browsing** -- progressive disclosure of seller inventory from summary through full product details and pricing.
 
 ## Communication Protocols
 
@@ -40,13 +46,42 @@ See the [API Overview](api/overview.md) for full details.
 
 ## Documentation
 
+### Getting Started
+
 - [Quickstart](getting-started/quickstart.md) -- install, configure, and run your first booking
+
+### Architecture & Reference
+
+- [Agent Hierarchy](architecture/agent-hierarchy.md) -- portfolio manager, channel specialists, and tool agents
+- [Tools Reference](architecture/tools.md) -- all CrewAI tools available to agents
+- [Configuration](guides/configuration.md) -- environment variables, seller connections, and feature flags
 - [API Reference](api/overview.md) -- all endpoints, models, and curl examples
-- [Architecture](architecture/overview.md) -- system design, agent hierarchy, and flow diagrams
+- [Protocol Overview](api/protocols.md) -- comparison of MCP, A2A, and REST
+
+### Guides
+
+- [Negotiation](guides/negotiation.md) -- multi-turn negotiation strategies and deal flow
+- [Identity Strategy](guides/identity.md) -- tiered pricing and buyer identity resolution
+- [Sessions](guides/sessions.md) -- persistent session management across interactions
+- [Multi-Seller Discovery](guides/multi-seller.md) -- AAMP registry and trust verification
+- [Linear TV Buying](guides/linear-tv.md) -- scatter, upfront, DMA targeting, and CPP/CPM pricing
+- [Media Kit Browsing](guides/media-kit.md) -- progressive disclosure of seller inventory
+- [Deal Booking](guides/deal-booking.md) -- end-to-end quote-then-book workflow
+
+### Integration
+
 - [MCP Client](api/mcp-client.md) -- structured tool calls to seller agents
 - [A2A Client](api/a2a-client.md) -- conversational discovery and negotiation
-- [Protocol Overview](api/protocols.md) -- comparison of MCP, A2A, and REST
-- [Integration](integration/seller-agent.md) -- connecting to seller agents and the OpenDirect protocol
+- [Seller Agent Integration](integration/seller-agent.md) -- connecting to seller agents and the OpenDirect protocol
+
+### Planned Features
+
+- [Multi-Seller Orchestration](guides/multi-seller-orchestration.md) -- cross-seller campaign optimization
+- [Campaign Pipeline](guides/campaign-pipeline.md) -- end-to-end campaign lifecycle
+- [Budget Pacing](guides/budget-pacing.md) -- real-time spend management
+- [Creative Management](guides/creative-management.md) -- asset upload and assignment
+- [Order State Machine](architecture/state-machine.md) -- formal order status transitions
+- [Event Bus](architecture/event-bus.md) -- inter-agent event routing
 
 ## Links
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
   - Home: index.md
   - Getting Started:
       - Quickstart: getting-started/quickstart.md
+      - Running with Seller: getting-started/running-with-seller.md
   - API Reference:
       - Overview: api/overview.md
       - Protocol Overview: api/protocols.md


### PR DESCRIPTION
## Summary

- **Home page (ar-0hk):** Updated Key Capabilities to include all Phase 1 features (multi-turn negotiation, multi-seller discovery, tiered identity, persistent sessions, quote-then-book deals, linear TV buying, media kit browsing). Reorganized Documentation links into logical sections (Getting Started, Architecture & Reference, Guides, Integration, Planned Features).
- **A2A Client (buyer-5sk):** Added JSON-RPC request schema with envelope/field tables, wire format example, and per-method request parameter tables for all convenience methods. Added error handling section with exception table.
- **Error docs (buyer-i7a):** Added error handling sections with HTTP status/error code tables to bookings, products, and MCP client pages -- modeled after the deals.md error table style.

## Test plan
- [ ] Run `mkdocs serve` and verify all five changed pages render correctly
- [ ] Confirm new internal links in index.md resolve to existing pages
- [ ] Verify error tables in bookings, products, and MCP client match deals.md formatting


🤖 Generated with [Claude Code](https://claude.com/claude-code)