### PR TITLE
Align buyer docs with seller agent conventions

### DIFF
--- a/docs/api/a2a-client.md
+++ b/docs/api/a2a-client.md
@@ -8,7 +8,7 @@ The `A2AClient` connects to a seller's A2A endpoint and sends natural language m
 
 - **Endpoint**: `{base_url}/a2a/{agent_type}/jsonrpc`
 - **Agent card**: `{base_url}/a2a/{agent_type}/.well-known/agent-card.json`
-- **Agent types**: `"buyer"` or `"seller"` -- determines which agent persona handles the request
+- **Agent types**: `"buyer"` or `"seller"` --- determines which agent persona handles the request
 - **Protocol**: JSON-RPC 2.0 with `message/send` method
 - **Transport**: Standard HTTP POST with `Content-Type: application/json`
 
@@ -249,7 +249,7 @@ async with A2AClient(base_url="http://seller:8001") as client:
 | Automated booking workflows | -- | Preferred |
 | Deterministic, repeatable results | -- | Preferred |
 
-Use A2A when the request benefits from natural language interpretation -- for example, asking "What CTV inventory do you have under $25 with household targeting?" rather than constructing exact filter parameters.
+Use A2A when the request benefits from natural language interpretation --- for example, asking "What CTV inventory do you have under $25 with household targeting?" rather than constructing exact filter parameters.
 
 ## Error Handling
 
@@ -291,6 +291,6 @@ except httpx.HTTPStatusError as e:
 
 ## Related
 
-- [MCP Client](mcp-client.md) -- structured tool execution protocol
-- [Protocol Overview](protocols.md) -- comparison of all three protocols
+- [MCP Client](mcp-client.md) --- structured tool execution protocol
+- [Protocol Overview](protocols.md) --- comparison of all three protocols
 - [Seller A2A Documentation](https://iabtechlab.github.io/seller-agent/api/a2a/)

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -2,8 +2,8 @@
 
 The buyer agent has two distinct authentication concerns:
 
-1. **Inbound authentication** -- protecting the buyer's own API from unauthorized callers.
-2. **Outbound authentication** -- attaching the correct credentials when the buyer calls seller endpoints.
+1. **Inbound authentication** --- protecting the buyer's own API from unauthorized callers.
+2. **Outbound authentication** --- attaching the correct credentials when the buyer calls seller endpoints.
 
 This page covers both, including the `ApiKeyStore` for managing per-seller credentials and the `AuthMiddleware` that injects keys into outgoing requests.
 
@@ -80,7 +80,7 @@ Authorization: Bearer <api_key>
 X-Api-Key: <api_key>
 ```
 
-Unauthenticated requests receive `public`-tier access only -- price ranges instead of exact prices, no negotiation, and limited data.
+Unauthenticated requests receive `public`-tier access only --- price ranges instead of exact prices, no negotiation, and limited data.
 
 ### Seller Access Tiers
 
@@ -260,7 +260,7 @@ if auth_result.needs_reauth:
 | `status_code` | `int` | HTTP status code from the response |
 
 !!! note "403 is not re-auth"
-    Only HTTP 401 (authentication failure) triggers `needs_reauth`. HTTP 403 (authorization / insufficient permissions) is intentionally excluded -- it means the key is valid but the buyer lacks access to the requested resource.
+    Only HTTP 401 (authentication failure) triggers `needs_reauth`. HTTP 403 (authorization / insufficient permissions) is intentionally excluded --- it means the key is valid but the buyer lacks access to the requested resource.
 
 ---
 
@@ -412,7 +412,7 @@ For multi-seller scenarios, use `ApiKeyStore` + `AuthMiddleware` to manage crede
 
 ## Related
 
-- [Seller Authentication](https://iabtechlab.github.io/seller-agent/api/authentication/) -- Seller-side key management, access tiers, and trust levels
-- [Deals API](deals.md) -- Deal client that uses these auth mechanisms
-- [Seller Discovery](seller-discovery.md) -- Discovering sellers to authenticate with
-- [Identity Strategy](../guides/identity.md) -- How buyer identity maps to seller tiers
+- [Seller Authentication](https://iabtechlab.github.io/seller-agent/api/authentication/) --- Seller-side key management, access tiers, and trust levels
+- [Deals API](deals.md) --- Deal client that uses these auth mechanisms
+- [Seller Discovery](seller-discovery.md) --- Discovering sellers to authenticate with
+- [Identity Strategy](../guides/identity.md) --- How buyer identity maps to seller tiers

--- a/docs/api/bookings.md
+++ b/docs/api/bookings.md
@@ -1,6 +1,6 @@
 # Bookings API
 
-The bookings endpoints manage the full campaign booking lifecycle -- from brief submission through approval to deal execution.
+The bookings endpoints manage the full campaign booking lifecycle --- from brief submission through approval to deal execution.
 
 ## Status Lifecycle
 
@@ -24,7 +24,7 @@ pending --> running --> awaiting_approval --> completed
 
 Start a new booking workflow. The flow runs in the background; poll `GET /bookings/{job_id}` for progress.
 
-### Request Body -- `BookingRequest`
+### Request Body --- `BookingRequest`
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -44,7 +44,7 @@ Start a new booking workflow. The flow runs in the background; poll `GET /bookin
 | `kpis` | `object` | no | Key performance indicators |
 | `channels` | `list[string]` | no | Preferred channels (e.g. `branding`, `ctv`, `mobile_app`, `performance`) |
 
-### Response -- `BookingResponse`
+### Response --- `BookingResponse`
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -80,7 +80,7 @@ curl -X POST http://localhost:8001/bookings \
 
 Retrieve the current status of a booking workflow.
 
-### Response -- `BookingStatus`
+### Response --- `BookingStatus`
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -106,7 +106,7 @@ curl http://localhost:8001/bookings/a1b2c3d4-5678-90ab-cdef-1234567890ab
 
 Approve specific product recommendations for booking. Only valid when the job status is `awaiting_approval`.
 
-### Request Body -- `ApprovalRequest`
+### Request Body --- `ApprovalRequest`
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|

--- a/docs/api/change-requests.md
+++ b/docs/api/change-requests.md
@@ -6,7 +6,7 @@ Change requests allow the buyer to propose post-deal modifications to orders on 
     The buyer does not yet have a dedicated `ChangeRequestsClient`. The workflows below document the seller's REST API that the buyer calls directly. A typed client is planned for a future release.
 
 !!! tip "Seller-side reference"
-    For the full server-side behavior -- including severity auto-classification, validation rules, and the review/apply workflow -- see the [Seller Change Requests docs](https://iabtechlab.github.io/seller-agent/api/change-requests/).
+    For the full server-side behavior --- including severity auto-classification, validation rules, and the review/apply workflow --- see the [Seller Change Requests docs](https://iabtechlab.github.io/seller-agent/api/change-requests/).
 
 ---
 
@@ -409,7 +409,7 @@ for change in changes:
 
 ## Related
 
-- [Seller Change Requests](https://iabtechlab.github.io/seller-agent/api/change-requests/) -- Full server-side behavior, review/apply workflow
-- [Deals API](deals.md) -- Creating the deals that change requests modify
-- [Bookings API](bookings.md) -- Campaign booking workflow
-- [Authentication](authentication.md) -- API key setup for seller communication
+- [Seller Change Requests](https://iabtechlab.github.io/seller-agent/api/change-requests/) --- Full server-side behavior, review/apply workflow
+- [Deals API](deals.md) --- Creating the deals that change requests modify
+- [Bookings API](bookings.md) --- Campaign booking workflow
+- [Authentication](authentication.md) --- API key setup for seller communication

--- a/docs/api/deals.md
+++ b/docs/api/deals.md
@@ -1,6 +1,6 @@
 # Deals API Client
 
-The `DealsClient` is the buyer's interface to the seller's **quote-then-book** deal endpoints. Instead of fabricating deal IDs client-side, the buyer requests a non-binding price quote from the seller, optionally negotiates, and then books a deal -- receiving a seller-issued Deal ID with OpenRTB activation parameters.
+The `DealsClient` is the buyer's interface to the seller's **quote-then-book** deal endpoints. Instead of fabricating deal IDs client-side, the buyer requests a non-binding price quote from the seller, optionally negotiates, and then books a deal --- receiving a seller-issued Deal ID with OpenRTB activation parameters.
 
 ## Overview
 
@@ -499,7 +499,7 @@ except DealsClientError as e:
 | Product not found | `404` | `not_found` | Raised immediately |
 
 !!! warning "Retry behavior"
-    Only 502, 503, and 504 status codes trigger automatic retries. Client errors (4xx) are never retried -- they indicate a problem with the request itself.
+    Only 502, 503, and 504 status codes trigger automatic retries. Client errors (4xx) are never retried --- they indicate a problem with the request itself.
 
 ### Seller Error Response
 
@@ -575,9 +575,9 @@ store.disconnect()
 
 ## Related
 
-- [Seller Quotes API](https://iabtechlab.github.io/seller-agent/api/quotes/) -- Seller-side quote endpoints
-- [Seller Orders API](https://iabtechlab.github.io/seller-agent/api/orders/) -- Seller-side deal/order endpoints
-- [Negotiation Guide](../guides/negotiation.md) -- How to negotiate pricing with sellers
-- [Media Kit Discovery](media-kit.md) -- Browse seller inventory before requesting quotes
-- [Bookings API](bookings.md) -- Campaign booking workflow (brief-based)
-- [Authentication](authentication.md) -- API key and token setup
+- [Seller Quotes API](https://iabtechlab.github.io/seller-agent/api/quotes/) --- Seller-side quote endpoints
+- [Seller Orders API](https://iabtechlab.github.io/seller-agent/api/orders/) --- Seller-side deal/order endpoints
+- [Negotiation Guide](../guides/negotiation.md) --- How to negotiate pricing with sellers
+- [Media Kit Discovery](media-kit.md) --- Browse seller inventory before requesting quotes
+- [Bookings API](bookings.md) --- Campaign booking workflow (brief-based)
+- [Authentication](authentication.md) --- API key and token setup

--- a/docs/api/mcp-client.md
+++ b/docs/api/mcp-client.md
@@ -1,6 +1,6 @@
 # MCP Client (Seller Communication)
 
-The buyer agent uses the **Model Context Protocol (MCP)** as its primary protocol for calling seller agent tools. MCP provides deterministic, structured tool execution over HTTP -- ideal for automated workflows where the buyer knows exactly which operation to perform.
+The buyer agent uses the **Model Context Protocol (MCP)** as its primary protocol for calling seller agent tools. MCP provides deterministic, structured tool execution over HTTP --- ideal for automated workflows where the buyer knows exactly which operation to perform.
 
 ## Client Implementations
 
@@ -26,8 +26,8 @@ Connection flow:
 
 A lightweight HTTP fallback that does not require the MCP SDK. It calls simple REST endpoints exposed by the seller.
 
-- **Tool listing**: `GET /mcp/tools` -- returns available tool definitions
-- **Tool execution**: `POST /mcp/call` -- sends `{"name": ..., "arguments": {...}}`
+- **Tool listing**: `GET /mcp/tools` --- returns available tool definitions
+- **Tool execution**: `POST /mcp/call` --- sends `{"name": ..., "arguments": {...}}`
 - **Fallback chain**: Tries `/mcp/tools`, then `call_tool("list_tools")`, then assumes standard OpenDirect tools
 - **No session**: Each request is independent (no SSE connection)
 
@@ -175,21 +175,21 @@ Neither MCP client implementation retries failed requests automatically. For pro
 
 - **Connection errors**: Safe to retry immediately (seller may be restarting)
 - **Timeouts**: Safe to retry with backoff
-- **Tool errors** (`isError=True`): Do not retry -- the error is deterministic
-- **Auth failures** (401/403): Do not retry -- fix credentials first
+- **Tool errors** (`isError=True`): Do not retry --- the error is deterministic
+- **Auth failures** (401/403): Do not retry --- fix credentials first
 
 ### Fallback Chain
 
 The `SimpleMCPClient` implements a tool discovery fallback chain:
 
-1. Try `GET /mcp/tools` -- standard tool listing endpoint
-2. Try `call_tool("list_tools")` -- some sellers expose listing as a tool
+1. Try `GET /mcp/tools` --- standard tool listing endpoint
+2. Try `call_tool("list_tools")` --- some sellers expose listing as a tool
 3. Fall back to a default set of standard OpenDirect tools
 
 If all three fail, the client assumes the standard tool set and tool calls may fail at execution time.
 
 ## Related
 
-- [A2A Client](a2a-client.md) -- conversational protocol for discovery and negotiation
-- [Protocol Overview](protocols.md) -- comparison of all three protocols
+- [A2A Client](a2a-client.md) --- conversational protocol for discovery and negotiation
+- [Protocol Overview](protocols.md) --- comparison of all three protocols
 - [Seller MCP Documentation](https://iabtechlab.github.io/seller-agent/api/mcp/)

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -6,14 +6,14 @@ Base URL: `http://localhost:8001`
 
 ## Why So Few Endpoints?
 
-The buyer agent exposes only 7 REST endpoints. This is intentional -- the buyer is primarily a **client** that consumes seller APIs, not a server with a large surface area of its own.
+The buyer agent exposes only 7 REST endpoints. This is intentional --- the buyer is primarily a **client** that consumes seller APIs, not a server with a large surface area of its own.
 
-A seller agent publishes inventory, manages accounts, processes orders, and handles creative assignments -- operations that demand dozens of endpoints. The buyer agent's job is different: it discovers sellers, browses their catalogs, negotiates pricing, and books deals. Most of that work happens through outbound calls to seller systems via [MCP](mcp-client.md), [A2A](a2a-client.md), or [REST/OpenDirect](../integration/opendirect.md).
+A seller agent publishes inventory, manages accounts, processes orders, and handles creative assignments --- operations that demand dozens of endpoints. The buyer agent's job is different: it discovers sellers, browses their catalogs, negotiates pricing, and books deals. Most of that work happens through outbound calls to seller systems via [MCP](mcp-client.md), [A2A](a2a-client.md), or [REST/OpenDirect](../integration/opendirect.md).
 
 The buyer's own REST API exists for two purposes:
 
-1. **Workflow orchestration** -- the `/bookings` endpoints let operators (or upstream systems) submit a campaign brief and track the automated booking workflow.
-2. **Catalog proxy** -- the `/products/search` endpoint lets callers search seller inventory through the buyer without establishing a direct seller connection.
+1. **Workflow orchestration** --- the `/bookings` endpoints let operators (or upstream systems) submit a campaign brief and track the automated booking workflow.
+2. **Catalog proxy** --- the `/products/search` endpoint lets callers search seller inventory through the buyer without establishing a direct seller connection.
 
 !!! info "Where does the real work happen?"
     The buyer's complexity lives in its **client libraries**, not its server endpoints. See [Protocol Overview](protocols.md) for how the buyer communicates with sellers, and the sections below for the specific seller endpoints consumed.
@@ -32,9 +32,9 @@ The buyer's own REST API exists for two purposes:
 
 ### Tags
 
-- **Health** -- service health and readiness
-- **Bookings** -- campaign booking workflow lifecycle
-- **Products** -- seller inventory product search
+- **Health** --- service health and readiness
+- **Bookings** --- campaign booking workflow lifecycle
+- **Products** --- seller inventory product search
 
 ---
 
@@ -99,7 +99,7 @@ Via [A2A](a2a-client.md), the buyer sends natural language requests to the selle
 
 When the server is running, Swagger UI is available at `/docs` and ReDoc at `/redoc`. The raw OpenAPI schema is at `/openapi.json`.
 
-## Related Pages
+## Related
 
 - [Authentication](authentication.md)
 - [Protocol Overview](protocols.md)

--- a/docs/api/products.md
+++ b/docs/api/products.md
@@ -6,7 +6,7 @@ The products endpoint lets you search the seller agent's product catalog directl
 
 Search available advertising products from connected seller agents.
 
-### Request Body -- `ProductSearchRequest`
+### Request Body --- `ProductSearchRequest`
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
@@ -76,4 +76,4 @@ The products endpoint returns structured error responses with an HTTP status cod
 | `500` | `internal_error` | Unexpected error during product search execution |
 
 !!! tip "Empty results are not errors"
-    If no products match the search criteria, the endpoint returns `200` with an empty `results` array -- not a `404`.
+    If no products match the search criteria, the endpoint returns `200` with an empty `results` array --- not a `404`.

--- a/docs/api/protocols.md
+++ b/docs/api/protocols.md
@@ -18,13 +18,13 @@ The buyer agent supports **three protocols** for communicating with seller agent
 ## When to Use Which
 
 !!! tip "Decision guide"
-    **Use MCP** when you know exactly which operation to perform and want fast, predictable results. This covers the vast majority of automated workflows -- listing products, creating orders, booking line items.
+    **Use MCP** when you know exactly which operation to perform and want fast, predictable results. This covers the vast majority of automated workflows --- listing products, creating orders, booking line items.
 
     **Use A2A** when the request is ambiguous or benefits from interpretation. Examples: multi-criteria inventory searches expressed in natural language, complex negotiation exchanges where the seller's AI can reason about pricing, or exploratory discovery where you do not know the exact tool to call.
 
-    **Use REST (OpenDirect)** when integrating with systems that do not support MCP or A2A -- for example, existing dashboards, third-party DSP platforms, or legacy ad servers. The buyer's own REST API also uses this path internally to proxy requests from human operators.
+    **Use REST (OpenDirect)** when integrating with systems that do not support MCP or A2A --- for example, existing dashboards, third-party DSP platforms, or legacy ad servers. The buyer's own REST API also uses this path internally to proxy requests from human operators.
 
-Most buyers will use MCP exclusively and only reach for A2A in discovery or negotiation scenarios. The `UnifiedClient` makes switching trivial -- change a single `protocol` parameter.
+Most buyers will use MCP exclusively and only reach for A2A in discovery or negotiation scenarios. The `UnifiedClient` makes switching trivial --- change a single `protocol` parameter.
 
 ## UnifiedClient
 
@@ -46,8 +46,8 @@ await client.connect()
 result = await client.list_products()  # sends "List all available advertising products"
 ```
 
-- `Protocol.MCP` (default) -- executes tools directly via the MCP session. Fast and deterministic.
-- `Protocol.A2A` -- converts tool calls to natural language, sends them to the seller's AI agent. Slower but handles ambiguity.
+- `Protocol.MCP` (default) --- executes tools directly via the MCP session. Fast and deterministic.
+- `Protocol.A2A` --- converts tool calls to natural language, sends them to the seller's AI agent. Slower but handles ambiguity.
 
 ### Dual-Protocol Operation
 
@@ -136,8 +136,8 @@ Set via environment variables or `config/settings.py`.
 
 ## Related
 
-- [MCP Client](mcp-client.md) -- detailed MCP client usage
-- [A2A Client](a2a-client.md) -- detailed A2A client usage
-- [API Overview](overview.md) -- buyer REST API reference
+- [MCP Client](mcp-client.md) --- detailed MCP client usage
+- [A2A Client](a2a-client.md) --- detailed A2A client usage
+- [API Overview](overview.md) --- buyer REST API reference
 - [Seller MCP Documentation](https://iabtechlab.github.io/seller-agent/api/mcp/)
 - [Seller A2A Documentation](https://iabtechlab.github.io/seller-agent/api/a2a/)

--- a/docs/api/sessions.md
+++ b/docs/api/sessions.md
@@ -1,6 +1,6 @@
 # Sessions & Persistence
 
-Sessions enable **multi-turn conversations** between the buyer agent and seller agents. Rather than treating each API call as an isolated request, sessions maintain context across a sequence of messages -- allowing the buyer to browse inventory, negotiate pricing, and close deals within a single conversational thread.
+Sessions enable **multi-turn conversations** between the buyer agent and seller agents. Rather than treating each API call as an isolated request, sessions maintain context across a sequence of messages --- allowing the buyer to browse inventory, negotiate pricing, and close deals within a single conversational thread.
 
 ## Overview
 
@@ -33,7 +33,7 @@ The buyer agent uses two components for session management:
 
 | Component | Role |
 |-----------|------|
-| **SessionManager** | Orchestrates the session lifecycle -- creation, reuse, messaging, and closure |
+| **SessionManager** | Orchestrates the session lifecycle --- creation, reuse, messaging, and closure |
 | **SessionStore** | File-backed persistence layer that stores active sessions as JSON |
 
 ---
@@ -108,7 +108,7 @@ curl -X POST http://seller.example.com:8001/sessions \
 }
 ```
 
-The `SessionManager` automatically persists the returned session record to the `SessionStore`. Sessions follow a **7-day TTL** by default -- if the seller does not specify an `expires_at`, the manager uses its own 7-day fallback.
+The `SessionManager` automatically persists the returned session record to the `SessionStore`. Sessions follow a **7-day TTL** by default --- if the seller does not specify an `expires_at`, the manager uses its own 7-day fallback.
 
 ### Get or Create (Recommended)
 
@@ -163,7 +163,7 @@ If the seller returns a **404** (session not found or expired on the seller side
 2. Creates a new session with the seller
 3. Retries the message on the new session
 
-This means callers do not need to handle session expiry manually -- the manager recovers automatically.
+This means callers do not need to handle session expiry manually --- the manager recovers automatically.
 
 ```mermaid
 sequenceDiagram
@@ -198,7 +198,7 @@ await manager.close_session(
 
 **Seller endpoint:** `POST /sessions/{session_id}/close`
 
-This sends a close request to the seller and removes the session from the local store. If the close request fails (e.g., the session already expired on the seller side), the error is logged but not raised -- the local cleanup still occurs.
+This sends a close request to the seller and removes the session from the local store. If the close request fails (e.g., the session already expired on the seller side), the error is logged but not raised --- the local cleanup still occurs.
 
 ---
 
@@ -222,7 +222,7 @@ The `SessionStore` is the persistence backend, storing session records as a JSON
 
 ### How It Works
 
-- Sessions are keyed by **seller URL** -- one active session per seller
+- Sessions are keyed by **seller URL** --- one active session per seller
 - The store file is created automatically if it does not exist
 - Reads happen on initialization; writes happen on every save/remove
 - Expired sessions are retained in the file but filtered out by `get()`
@@ -310,9 +310,9 @@ stateDiagram-v2
 
 ### Typical Flow
 
-1. **Create** -- Call `get_or_create_session()` to establish a session with a seller
-2. **Converse** -- Send messages via `send_message()` for browsing, negotiation, or deal-making
-3. **Close** -- Call `close_session()` when the conversation is complete
+1. **Create** --- Call `get_or_create_session()` to establish a session with a seller
+2. **Converse** --- Send messages via `send_message()` for browsing, negotiation, or deal-making
+3. **Close** --- Call `close_session()` when the conversation is complete
 
 ### Expiry Handling
 
@@ -361,7 +361,7 @@ sequenceDiagram
     Buyer->>SM: close_session()
 ```
 
-The session provides **context continuity** -- the seller knows the full conversation history and can reference previous offers, counter-offers, and agreements without the buyer needing to resend them.
+The session provides **context continuity** --- the seller knows the full conversation history and can reference previous offers, counter-offers, and agreements without the buyer needing to resend them.
 
 ### How Sessions Relate to Other APIs
 
@@ -497,14 +497,14 @@ except RuntimeError as e:
 ```
 
 !!! note "Close is fire-and-forget"
-    `close_session()` never raises -- it logs a warning if the remote close fails and always cleans up the local store. This prevents cleanup errors from disrupting the caller's flow.
+    `close_session()` never raises --- it logs a warning if the remote close fails and always cleans up the local store. This prevents cleanup errors from disrupting the caller's flow.
 
 ---
 
 ## Related
 
-- [Seller Sessions API](https://iabtechlab.github.io/seller-agent/) -- Seller-side session endpoints (POST /sessions, GET /sessions, etc.)
-- [Authentication](authentication.md) -- Buyer identity setup for session creation
-- [Media Kit Discovery](media-kit.md) -- Browse seller inventory before starting a session
-- [Bookings](bookings.md) -- Campaign booking workflow
-- [Seller Agent Integration](../integration/seller-agent.md) -- Full integration guide
+- [Seller Sessions API](https://iabtechlab.github.io/seller-agent/) --- Seller-side session endpoints (POST /sessions, GET /sessions, etc.)
+- [Authentication](authentication.md) --- Buyer identity setup for session creation
+- [Media Kit Discovery](media-kit.md) --- Browse seller inventory before starting a session
+- [Bookings](bookings.md) --- Campaign booking workflow
+- [Seller Agent Integration](../integration/seller-agent.md) --- Full integration guide

--- a/docs/architecture/agent-hierarchy.md
+++ b/docs/architecture/agent-hierarchy.md
@@ -48,7 +48,7 @@ graph TB
 
 ---
 
-## Level 1 -- Portfolio Manager
+## Level 1 --- Portfolio Manager
 
 The Portfolio Manager is the top-level orchestrator. It receives a campaign brief and determines how to allocate budget across channels.
 
@@ -59,7 +59,7 @@ The Portfolio Manager is the top-level orchestrator. It receives a campaign brie
 | Role | Portfolio Manager |
 | LLM | `anthropic/claude-opus-4-20250514` (configurable via `MANAGER_LLM_MODEL`) |
 | Temperature | 0.3 |
-| Delegation | Enabled -- delegates to Level 2 agents |
+| Delegation | Enabled --- delegates to Level 2 agents |
 | Memory | Enabled |
 
 **Responsibilities:**
@@ -83,7 +83,7 @@ manager = create_portfolio_manager(
 
 ---
 
-## Level 2 -- Channel Specialists
+## Level 2 --- Channel Specialists
 
 Each Level 2 agent owns a specific advertising channel. They receive budget allocations from the Portfolio Manager and coordinate Level 3 agents to research inventory and execute bookings.
 
@@ -95,7 +95,7 @@ All channel specialists share these defaults:
 |-----------|-------|
 | LLM | `anthropic/claude-sonnet-4-5-20250929` (configurable via `DEFAULT_LLM_MODEL`) |
 | Temperature | 0.5 |
-| Delegation | Enabled -- delegates to Level 3 agents |
+| Delegation | Enabled --- delegates to Level 3 agents |
 | Memory | Enabled |
 
 ### Branding Specialist
@@ -174,9 +174,9 @@ Discovers inventory and obtains Deal IDs for activation in traditional DSP platf
 
 ---
 
-## Level 3 -- Functional Agents
+## Level 3 --- Functional Agents
 
-Level 3 agents are shared across channels. They do not make strategic decisions -- they execute specific functions on behalf of the Level 2 specialists.
+Level 3 agents are shared across channels. They do not make strategic decisions --- they execute specific functions on behalf of the Level 2 specialists.
 
 **Key directory:** `src/ad_buyer/agents/level3/`
 
@@ -185,7 +185,7 @@ All functional agents share these defaults:
 | Attribute | Value |
 |-----------|-------|
 | LLM | `anthropic/claude-sonnet-4-5-20250929` |
-| Delegation | Disabled -- they are leaf-level executors |
+| Delegation | Disabled --- they are leaf-level executors |
 | Memory | Enabled |
 
 ### Audience Planner (UCP)
@@ -254,7 +254,7 @@ Retrieves and analyzes campaign performance data.
 
 ## Crew Coordination
 
-Agents are organized into **crews** -- CrewAI constructs that define which agents work together, what tasks they perform, and how authority flows.
+Agents are organized into **crews** --- CrewAI constructs that define which agents work together, what tasks they perform, and how authority flows.
 
 ### Portfolio Crew
 
@@ -285,13 +285,13 @@ result = crew.kickoff()
 
 | Role | Agent | Process |
 |------|-------|---------|
-| Manager | Portfolio Manager (L1) | Hierarchical -- assigns tasks and reviews output |
+| Manager | Portfolio Manager (L1) | Hierarchical --- assigns tasks and reviews output |
 | Workers | Branding, CTV, Mobile, Performance (L2) | Receive budget allocation and channel guidance |
 
 **Tasks:**
 
-1. **Budget Allocation** -- Analyze the brief, determine optimal channel split
-2. **Channel Coordination** -- Provide targeting and quality guidance per channel
+1. **Budget Allocation** --- Analyze the brief, determine optimal channel split
+2. **Channel Coordination** --- Provide targeting and quality guidance per channel
 
 ### Channel Crews
 
@@ -331,8 +331,8 @@ Four channel crew factory functions are available:
 
 All channel crews follow the same two-task pattern:
 
-1. **Research Task** -- The Research Agent searches inventory matching the channel brief and audience plan, using both research and audience tools
-2. **Recommendation Task** -- The channel specialist reviews findings and selects the best inventory
+1. **Research Task** --- The Research Agent searches inventory matching the channel brief and audience plan, using both research and audience tools
+2. **Recommendation Task** --- The channel specialist reviews findings and selects the best inventory
 
 !!! info "Audience context"
     Channel crews accept an optional `audience_plan` parameter. When provided, the Research Agent incorporates UCP-compatible audience targeting into its inventory search. This plan typically comes from the Audience Planner agent.
@@ -368,8 +368,8 @@ sequenceDiagram
 
 ## Related
 
-- [Architecture Overview](overview.md) -- Full system architecture
-- [Tools Reference](tools.md) -- All CrewAI tools available to agents
-- [DSP Deal Flow](dsp-deal-flow.md) -- DSP-specific deal discovery workflow
-- [Booking Flow](booking-flow.md) -- Detailed booking sequence
-- [Configuration](../guides/configuration.md) -- LLM and agent settings
+- [Architecture Overview](overview.md) --- Full system architecture
+- [Tools Reference](tools.md) --- All CrewAI tools available to agents
+- [DSP Deal Flow](dsp-deal-flow.md) --- DSP-specific deal discovery workflow
+- [Booking Flow](booking-flow.md) --- Detailed booking sequence
+- [Configuration](../guides/configuration.md) --- LLM and agent settings

--- a/docs/architecture/deal-store.md
+++ b/docs/architecture/deal-store.md
@@ -6,9 +6,9 @@ The `DealStore` is the buyer agent's SQLite-backed persistence layer for deal li
 
 Without persistent storage, all deal state lives in memory and is lost on process restart. The DealStore solves three problems:
 
-- **Crash resilience** -- A server restart mid-negotiation no longer means lost deals. The buyer can resume from the last known state.
-- **Audit trail** -- Every status change and negotiation round is recorded in append-only tables. This supports post-campaign analysis and dispute resolution.
-- **Portfolio tracking** -- The buyer can query all active deals across sellers, filter by status, and calculate aggregate spend -- enabling informed budget allocation decisions.
+- **Crash resilience** --- A server restart mid-negotiation no longer means lost deals. The buyer can resume from the last known state.
+- **Audit trail** --- Every status change and negotiation round is recorded in append-only tables. This supports post-campaign analysis and dispute resolution.
+- **Portfolio tracking** --- The buyer can query all active deals across sellers, filter by status, and calculate aggregate spend --- enabling informed budget allocation decisions.
 
 !!! info "Synchronous by design"
     The DealStore uses synchronous `sqlite3` (not `aiosqlite`) because CrewAI runs flows in worker threads that may not have an asyncio event loop. Thread safety is provided by `check_same_thread=False` and a `threading.Lock()`.
@@ -523,11 +523,11 @@ store.connect()
 
 ---
 
-## Related Pages
+## Related
 
-- [Deals API Client](../api/deals.md) -- `DealsClient` methods, request/response models, and error handling
-- [Booking Flow](booking-flow.md) -- End-to-end sequence diagram for the `DealBookingFlow`
-- [Negotiation Guide](../guides/negotiation.md) -- How to negotiate pricing with sellers
-- [Models](models.md) -- Pydantic data model reference
-- [Seller Quotes API](https://iabtechlab.github.io/seller-agent/api/quotes/) -- Seller-side quote endpoints
-- [Seller Orders API](https://iabtechlab.github.io/seller-agent/api/orders/) -- Seller-side deal/order endpoints
+- [Deals API Client](../api/deals.md) --- `DealsClient` methods, request/response models, and error handling
+- [Booking Flow](booking-flow.md) --- End-to-end sequence diagram for the `DealBookingFlow`
+- [Negotiation Guide](../guides/negotiation.md) --- How to negotiate pricing with sellers
+- [Models](models.md) --- Pydantic data model reference
+- [Seller Quotes API](https://iabtechlab.github.io/seller-agent/api/quotes/) --- Seller-side quote endpoints
+- [Seller Orders API](https://iabtechlab.github.io/seller-agent/api/orders/) --- Seller-side deal/order endpoints

--- a/docs/architecture/dsp-deal-flow.md
+++ b/docs/architecture/dsp-deal-flow.md
@@ -254,7 +254,7 @@ When a `DealStore` is provided, the flow persists deal state at three points:
 | `evaluate_and_select` | Updates status after product selection | `evaluating_pricing` |
 | `request_deal_id` | Updates with final status | `deal_created` or `failed` |
 
-Persistence is best-effort -- failures are logged but never raise exceptions, so the flow continues even if the store is unavailable.
+Persistence is best-effort --- failures are logged but never raise exceptions, so the flow continues even if the store is unavailable.
 
 ---
 
@@ -279,8 +279,8 @@ if status["status"] == "failed":
 
 ## Related
 
-- [Agent Hierarchy](agent-hierarchy.md) -- DSP Specialist role in the hierarchy
-- [Tools Reference](tools.md) -- DSP tools used by this flow
-- [Deals API](../api/deals.md) -- REST API for quote-then-book deals
-- [Booking Flow](booking-flow.md) -- Alternative flow for full campaign booking
-- [Identity Strategy](../guides/identity.md) -- How buyer identity affects pricing tiers
+- [Agent Hierarchy](agent-hierarchy.md) --- DSP Specialist role in the hierarchy
+- [Tools Reference](tools.md) --- DSP tools used by this flow
+- [Deals API](../api/deals.md) --- REST API for quote-then-book deals
+- [Booking Flow](booking-flow.md) --- Alternative flow for full campaign booking
+- [Identity Strategy](../guides/identity.md) --- How buyer identity affects pricing tiers

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -91,8 +91,8 @@ Human        --> REST API      --> Buyer Agent  --> (MCP or A2A) --> Seller Agen
 
 | Protocol | Transport | Use Case |
 |----------|-----------|----------|
-| **MCP** | Streamable HTTP (SSE) | Automated workflows -- structured tool calls, deterministic |
-| **A2A** | JSON-RPC 2.0 | Discovery and negotiation -- natural language, multi-turn |
+| **MCP** | Streamable HTTP (SSE) | Automated workflows --- structured tool calls, deterministic |
+| **A2A** | JSON-RPC 2.0 | Discovery and negotiation --- natural language, multi-turn |
 | **REST** | Standard HTTP | Operator dashboards and legacy integration |
 
 MCP is the default. The `UnifiedClient` can switch protocols per-request or operate in dual-protocol mode via `connect_both()`.
@@ -119,8 +119,8 @@ The buyer agent acts as an automated media buyer. It receives campaign requireme
 
 See also: [Seller Agent Architecture](https://iabtechlab.github.io/seller-agent/architecture/overview/)
 
-## Related Pages
+## Related
 
-- [Booking Flow](booking-flow.md) -- detailed sequence diagram
-- [Models](models.md) -- data model reference
+- [Booking Flow](booking-flow.md) --- detailed sequence diagram
+- [Models](models.md) --- data model reference
 - [Seller Agent Integration](../integration/seller-agent.md)

--- a/docs/architecture/tools.md
+++ b/docs/architecture/tools.md
@@ -113,9 +113,9 @@ result = tool._run(
 ```
 
 !!! tip "Score thresholds"
-    - **>= 0.7**: Strong match -- proceed with targeting
-    - **0.5 -- 0.7**: Moderate -- proceed with caution, may limit reach
-    - **< 0.5**: Weak -- consider broadening targeting or reviewing alternatives
+    - **>= 0.7**: Strong match --- proceed with targeting
+    - **0.5 --- 0.7**: Moderate --- proceed with caution, may limit reach
+    - **< 0.5**: Weak --- consider broadening targeting or reviewing alternatives
 
 ---
 
@@ -507,7 +507,7 @@ dsp_tools = [
 
 ## Related
 
-- [Agent Hierarchy](agent-hierarchy.md) -- Which agents use which tools
-- [DSP Deal Flow](dsp-deal-flow.md) -- How DSP tools work together in a flow
-- [Booking Flow](booking-flow.md) -- How execution tools drive the booking lifecycle
-- [Configuration](../guides/configuration.md) -- Tool-related settings
+- [Agent Hierarchy](agent-hierarchy.md) --- Which agents use which tools
+- [DSP Deal Flow](dsp-deal-flow.md) --- How DSP tools work together in a flow
+- [Booking Flow](booking-flow.md) --- How execution tools drive the booking lifecycle
+- [Configuration](../guides/configuration.md) --- Tool-related settings

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -270,6 +270,6 @@ CREW_MAX_ITERATIONS=5
 
 ## Related
 
-- [Agent Hierarchy](../architecture/agent-hierarchy.md) -- How LLM settings map to agent levels
-- [Architecture Overview](../architecture/overview.md) -- System component overview
-- [Authentication](../api/authentication.md) -- API key setup for inbound requests
+- [Agent Hierarchy](../architecture/agent-hierarchy.md) --- How LLM settings map to agent levels
+- [Architecture Overview](../architecture/overview.md) --- System component overview
+- [Authentication](../api/authentication.md) --- API key setup for inbound requests

--- a/docs/guides/deal-booking.md
+++ b/docs/guides/deal-booking.md
@@ -1,13 +1,13 @@
 # Deal Booking
 
-This guide walks you through the complete deal booking process -- from browsing a seller's inventory to getting a confirmed Deal ID you can activate in your DSP.
+This guide walks you through the complete deal booking process --- from browsing a seller's inventory to getting a confirmed Deal ID you can activate in your DSP.
 
 ## Prerequisites
 
 Before you start, you need:
 
-- **A running seller agent** -- The seller's API must be reachable (e.g. `http://seller.example.com:8001`). See [Seller Agent Integration](../integration/seller-agent.md) for connection details.
-- **An API key** -- Get one from the seller for authenticated access. Public browsing works without a key, but you need one to see exact pricing and book deals.
+- **A running seller agent** --- The seller's API must be reachable (e.g. `http://seller.example.com:8001`). See [Seller Agent Integration](../integration/seller-agent.md) for connection details.
+- **An API key** --- Get one from the seller for authenticated access. Public browsing works without a key, but you need one to see exact pricing and book deals.
 - **Python 3.11+** with the `ad_buyer` package installed.
 
 !!! tip "Check your access tier"
@@ -106,8 +106,8 @@ async with MediaKitClient(api_key="your-api-key") as mk:
 
 Look for two things on each package:
 
-- **`negotiation_enabled`** -- If `True`, you can negotiate the price down (Step 4).
-- **`product_id`** on the placements -- You'll need this to request a quote.
+- **`negotiation_enabled`** --- If `True`, you can negotiate the price down (Step 4).
+- **`product_id`** on the placements --- You'll need this to request a quote.
 
 See [Media Kit](../api/media-kit.md) for the full API.
 
@@ -211,9 +211,9 @@ if deal.openrtb_params:
 
 The seller returns a `DealResponse` with:
 
-- **`deal_id`** -- The seller's unique deal identifier.
-- **`openrtb_params`** -- Plug these into your DSP's deal targeting. The `id` field is what goes into OpenRTB bid requests.
-- **`activation_instructions`** -- Any seller-specific setup steps (e.g., creative specs, trafficking notes).
+- **`deal_id`** --- The seller's unique deal identifier.
+- **`openrtb_params`** --- Plug these into your DSP's deal targeting. The `id` field is what goes into OpenRTB bid requests.
+- **`activation_instructions`** --- Any seller-specific setup steps (e.g., creative specs, trafficking notes).
 
 ### Step 6: Track Your Deal
 
@@ -301,13 +301,13 @@ result = flow.kickoff()
 
 **What happens inside:**
 
-1. **Brief validation** -- Checks required fields (objectives, budget, dates, audience).
-2. **Audience planning** -- Analyzes targeting requirements, estimates coverage per channel.
-3. **Budget allocation** -- Portfolio manager splits budget across channels (branding, CTV, mobile, performance).
-4. **Parallel research** -- Channel specialists research inventory simultaneously.
-5. **Consolidation** -- All recommendations are gathered for review.
-6. **Approval checkpoint** -- Waits for human approval (or auto-approves).
-7. **Booking execution** -- Books approved recommendations.
+1. **Brief validation** --- Checks required fields (objectives, budget, dates, audience).
+2. **Audience planning** --- Analyzes targeting requirements, estimates coverage per channel.
+3. **Budget allocation** --- Portfolio manager splits budget across channels (branding, CTV, mobile, performance).
+4. **Parallel research** --- Channel specialists research inventory simultaneously.
+5. **Consolidation** --- All recommendations are gathered for review.
+6. **Approval checkpoint** --- Waits for human approval (or auto-approves).
+7. **Booking execution** --- Books approved recommendations.
 
 **Approving recommendations:**
 
@@ -355,7 +355,7 @@ curl -X POST http://localhost:8001/bookings/{job_id}/approve-all
 
 ## Using DSPDealFlow (Single-Deal, Direct Mode)
 
-`DSPDealFlow` is for when you know roughly what you want and just need a Deal ID. It discovers inventory, picks the best match, and requests a deal -- all in one shot.
+`DSPDealFlow` is for when you know roughly what you want and just need a Deal ID. It discovers inventory, picks the best match, and requests a deal --- all in one shot.
 
 Use this for **single-deal, targeted acquisition** rather than full-campaign planning.
 
@@ -387,10 +387,10 @@ print(f"Deal: {result['status']['deal_response']}")
 
 **Flow steps:**
 
-1. **Receive request** -- Validates the natural-language request and buyer context.
-2. **Discover inventory** -- Searches the seller's catalog for matches.
-3. **Evaluate and select** -- Uses a DSP agent (CrewAI) to pick the best product.
-4. **Request Deal ID** -- Calls the seller's deal endpoint for the selected product.
+1. **Receive request** --- Validates the natural-language request and buyer context.
+2. **Discover inventory** --- Searches the seller's catalog for matches.
+3. **Evaluate and select** --- Uses a DSP agent (CrewAI) to pick the best product.
+4. **Request Deal ID** --- Calls the seller's deal endpoint for the selected product.
 
 **Key difference from DealBookingFlow:**
 
@@ -452,7 +452,7 @@ client = DealsClient(
 
 ### Expired Quotes
 
-Quotes have a limited lifetime. If you try to book an expired quote, you'll get a 409 or 400 error. The fix is simple -- request a new quote:
+Quotes have a limited lifetime. If you try to book an expired quote, you'll get a 409 or 400 error. The fix is simple --- request a new quote:
 
 ```python
 try:
@@ -466,7 +466,7 @@ except DealsClientError as e:
 
 ### DealStore Persistence Errors
 
-The `DealsClient` and flow classes treat persistence as **best-effort**. If the `DealStore` fails (disk full, locked, etc.), the API call still succeeds -- you just lose the local record. Errors are logged but never re-raised.
+The `DealsClient` and flow classes treat persistence as **best-effort**. If the `DealStore` fails (disk full, locked, etc.), the API call still succeeds --- you just lose the local record. Errors are logged but never re-raised.
 
 ---
 
@@ -496,8 +496,8 @@ async with DealsClient(seller_url=url, api_key=key) as client:
 
 ## Related
 
-- [Negotiation](negotiation.md) -- Multi-turn price negotiation strategies
-- [Media Kit](../api/media-kit.md) -- Browsing seller inventory
-- [Bookings API](../api/bookings.md) -- REST API for the booking workflow
-- [Authentication](../api/authentication.md) -- API key setup and access tiers
-- [Seller Agent Integration](../integration/seller-agent.md) -- Connecting to a seller
+- [Negotiation](negotiation.md) --- Multi-turn price negotiation strategies
+- [Media Kit](../api/media-kit.md) --- Browsing seller inventory
+- [Bookings API](../api/bookings.md) --- REST API for the booking workflow
+- [Authentication](../api/authentication.md) --- API key setup and access tiers
+- [Seller Agent Integration](../integration/seller-agent.md) --- Connecting to a seller

--- a/docs/guides/identity.md
+++ b/docs/guides/identity.md
@@ -6,7 +6,7 @@ Identity is the buyer's most valuable negotiating asset. Every interaction with 
 
 Seller pricing is not one-size-fits-all. Sellers apply tiered discounts based on how much they know about the buyer:
 
-- **Anonymous buyers** see price ranges only -- no exact pricing, no negotiation.
+- **Anonymous buyers** see price ranges only --- no exact pricing, no negotiation.
 - **Known DSP seats** get fixed pricing with a modest discount.
 - **Agencies** unlock negotiation and deeper discounts.
 - **Advertisers** get the best rates, volume discounts, and full inventory access.
@@ -30,7 +30,7 @@ The buyer is anonymous. The seller returns price ranges (e.g., "$28--$42 CPM") b
 
 ### SEAT
 
-The buyer reveals its DSP seat identifier (e.g., `ttd-seat-123`). The seller returns exact pricing with a 5% discount. Negotiation is not available -- the buyer accepts posted prices. This is the minimum tier for transacting.
+The buyer reveals its DSP seat identifier (e.g., `ttd-seat-123`). The seller returns exact pricing with a 5% discount. Negotiation is not available --- the buyer accepts posted prices. This is the minimum tier for transacting.
 
 ### AGENCY
 
@@ -45,7 +45,7 @@ The buyer reveals full identity including the advertiser (name, ID, industry ver
 
 ## BuyerIdentityStrategy
 
-The `IdentityStrategy` class recommends which tier to present based on the deal context. It does not modify the buyer's stored identity -- instead, it creates masked copies that expose only the fields appropriate for the recommended tier.
+The `IdentityStrategy` class recommends which tier to present based on the deal context. It does not modify the buyer's stored identity --- instead, it creates masked copies that expose only the fields appropriate for the recommended tier.
 
 ### Decision Logic
 
@@ -72,10 +72,10 @@ flowchart TD
     M --> N
 ```
 
-1. **Deal type** -- Programmatic Guaranteed always requires ADVERTISER tier (guaranteed inventory needs full identity).
-2. **Deal value** -- Higher-value deals justify revealing more identity for larger absolute savings.
-3. **Seller relationship** -- Trusted or established sellers earn a one-tier upgrade (the buyer is comfortable sharing more).
-4. **Campaign goal** -- Performance campaigns benefit from higher tiers because sellers can apply better targeting with more buyer information.
+1. **Deal type** --- Programmatic Guaranteed always requires ADVERTISER tier (guaranteed inventory needs full identity).
+2. **Deal value** --- Higher-value deals justify revealing more identity for larger absolute savings.
+3. **Seller relationship** --- Trusted or established sellers earn a one-tier upgrade (the buyer is comfortable sharing more).
+4. **Campaign goal** --- Performance campaigns benefit from higher tiers because sellers can apply better targeting with more buyer information.
 
 ### Thresholds
 
@@ -353,7 +353,7 @@ sellers = store.list_sellers()
 
 ## Related
 
-- [Authentication](../api/authentication.md) -- API key setup for authenticating requests
-- [Media Kit Discovery](../api/media-kit.md) -- how tiers affect inventory access and pricing
-- [Negotiation Guide](negotiation.md) -- negotiation workflows and tier requirements
-- [Seller Pricing Rules](https://iabtechlab.github.io/seller-agent/guides/pricing-rules/) -- how sellers configure tier-based discounts
+- [Authentication](../api/authentication.md) --- API key setup for authenticating requests
+- [Media Kit Discovery](../api/media-kit.md) --- how tiers affect inventory access and pricing
+- [Negotiation Guide](negotiation.md) --- negotiation workflows and tier requirements
+- [Seller Pricing Rules](https://iabtechlab.github.io/seller-agent/guides/pricing-rules/) --- how sellers configure tier-based discounts

--- a/docs/guides/media-kit.md
+++ b/docs/guides/media-kit.md
@@ -1,6 +1,6 @@
 # Media Kit Browsing
 
-A seller's **media kit** is its inventory catalog -- a curated collection of ad packages that describe what the seller has to offer, how it is priced, and who it reaches. Before you can book a deal, you need to browse what is available. The `MediaKitClient` is the buyer agent's tool for doing that.
+A seller's **media kit** is its inventory catalog --- a curated collection of ad packages that describe what the seller has to offer, how it is priced, and who it reaches. Before you can book a deal, you need to browse what is available. The `MediaKitClient` is the buyer agent's tool for doing that.
 
 This guide walks through practical patterns for browsing inventory, interpreting what you see, and connecting discovery to the rest of the buying workflow.
 
@@ -11,7 +11,7 @@ This guide walks through practical patterns for browsing inventory, interpreting
 
 ### Public Browsing (No Authentication)
 
-The fastest way to evaluate a seller's inventory is to browse without authentication. You see package names, descriptions, ad formats, content categories, and price ranges -- enough to decide whether it is worth authenticating for exact pricing.
+The fastest way to evaluate a seller's inventory is to browse without authentication. You see package names, descriptions, ad formats, content categories, and price ranges --- enough to decide whether it is worth authenticating for exact pricing.
 
 ```python
 from ad_buyer.media_kit import MediaKitClient
@@ -195,7 +195,7 @@ async with MediaKitClient(api_key="your-key") as client:
 
 Key details about aggregation:
 
-- Sellers are queried concurrently -- a slow or unreachable seller does not block the others.
+- Sellers are queried concurrently --- a slow or unreachable seller does not block the others.
 - Failed sellers are silently skipped (warnings are logged).
 - Every returned `PackageSummary` has its `seller_url` set, so you can trace each package back to its source.
 
@@ -277,7 +277,7 @@ sequenceDiagram
     Seller-->>Client: Best pricing, negotiation enabled
 ```
 
-This approach minimizes identity exposure -- you only reveal who you are when you are ready to transact.
+This approach minimizes identity exposure --- you only reveal who you are when you are ready to transact.
 
 !!! info "Identity Strategy Automation"
     The `IdentityStrategy` class can automate tier selection based on deal value, seller trust, and campaign goals. See the [Identity Strategy Guide](identity.md) for details.
@@ -299,17 +299,17 @@ graph LR
 
 ### Step-by-Step
 
-1. **Browse** -- Use `get_media_kit()` or `list_packages()` to survey what is available. Start public to minimize information exposure.
+1. **Browse** --- Use `get_media_kit()` or `list_packages()` to survey what is available. Start public to minimize information exposure.
 
-2. **Select** -- Identify packages that match your campaign requirements (ad format, content category, geo, device targeting).
+2. **Select** --- Identify packages that match your campaign requirements (ad format, content category, geo, device targeting).
 
-3. **Get exact pricing** -- Authenticate with your API key and call `get_package()` on your shortlisted packages. Compare `exact_price` and `floor_price`.
+3. **Get exact pricing** --- Authenticate with your API key and call `get_package()` on your shortlisted packages. Compare `exact_price` and `floor_price`.
 
-4. **Check negotiation eligibility** -- Look at the `negotiation_enabled` flag on `PackageDetail`. This is `True` only for Agency and Advertiser tier buyers.
+4. **Check negotiation eligibility** --- Look at the `negotiation_enabled` flag on `PackageDetail`. This is `True` only for Agency and Advertiser tier buyers.
 
-5. **Negotiate or accept** -- If negotiation is enabled and the price is above your target, use the [Negotiation module](negotiation.md) to drive counter-offers. If not, accept the posted price.
+5. **Negotiate or accept** --- If negotiation is enabled and the price is above your target, use the [Negotiation module](negotiation.md) to drive counter-offers. If not, accept the posted price.
 
-6. **Book the deal** -- Use the [Booking flow](../api/bookings.md) to finalize the transaction via the OpenDirect API.
+6. **Book the deal** --- Use the [Booking flow](../api/bookings.md) to finalize the transaction via the OpenDirect API.
 
 ### Connecting to Negotiation
 
@@ -339,7 +339,7 @@ if isinstance(pkg, PackageDetail) and pkg.negotiation_enabled:
 
 **Use aggregation for market research.** The `aggregate_across_sellers` method is useful for comparing inventory and pricing across the market before committing to a specific seller.
 
-**Filter by layer to match your needs.** Curated packages are premium bundles the publisher has assembled -- they tend to perform better but cost more. Synced packages come directly from the ad server and offer broader reach at lower prices.
+**Filter by layer to match your needs.** Curated packages are premium bundles the publisher has assembled --- they tend to perform better but cost more. Synced packages come directly from the ad server and offer broader reach at lower prices.
 
 **Watch for `negotiation_enabled`.** Not all packages support negotiation. Check this flag before investing time in a negotiation strategy. If it is `False`, you must accept the posted price or look elsewhere.
 
@@ -347,9 +347,9 @@ if isinstance(pkg, PackageDetail) and pkg.negotiation_enabled:
 
 ## Related
 
-- [Media Kit API Reference](../api/media-kit.md) -- Endpoint details, data models, error handling
-- [Identity Strategy Guide](identity.md) -- How identity tier affects pricing and access
-- [Negotiation Guide](negotiation.md) -- Multi-turn price negotiation after discovery
-- [Bookings API](../api/bookings.md) -- Booking deals after negotiation
-- [Authentication](../api/authentication.md) -- API key setup for authenticated access
-- [Seller Media Kit Setup](https://iabtechlab.github.io/seller-agent/guides/media-kit/) -- How publishers configure their media kit
+- [Media Kit API Reference](../api/media-kit.md) --- Endpoint details, data models, error handling
+- [Identity Strategy Guide](identity.md) --- How identity tier affects pricing and access
+- [Negotiation Guide](negotiation.md) --- Multi-turn price negotiation after discovery
+- [Bookings API](../api/bookings.md) --- Booking deals after negotiation
+- [Authentication](../api/authentication.md) --- API key setup for authenticated access
+- [Seller Media Kit Setup](https://iabtechlab.github.io/seller-agent/guides/media-kit/) --- How publishers configure their media kit

--- a/docs/guides/multi-seller.md
+++ b/docs/guides/multi-seller.md
@@ -7,13 +7,13 @@ This guide walks through the process of discovering multiple sellers, comparing 
 
 ## Why Multi-Seller?
 
-**Competitive pricing** -- Comparing packages across sellers ensures you are not overpaying. Sellers price differently based on their inventory mix, audience composition, and demand.
+**Competitive pricing** --- Comparing packages across sellers ensures you are not overpaying. Sellers price differently based on their inventory mix, audience composition, and demand.
 
-**Portfolio optimization** -- A CTV-focused seller may have premium living-room inventory but limited mobile reach. Combining packages from specialized sellers lets you build a balanced media plan.
+**Portfolio optimization** --- A CTV-focused seller may have premium living-room inventory but limited mobile reach. Combining packages from specialized sellers lets you build a balanced media plan.
 
-**Risk diversification** -- Spreading spend across sellers protects against delivery shortfalls. If one seller under-delivers, the others can absorb the gap.
+**Risk diversification** --- Spreading spend across sellers protects against delivery shortfalls. If one seller under-delivers, the others can absorb the gap.
 
-**Negotiation leverage** -- When sellers know you are shopping competitively, they are more likely to offer favorable terms. The buyer agent's identity strategy lets you control exactly how much you reveal to each seller.
+**Negotiation leverage** --- When sellers know you are shopping competitively, they are more likely to offer favorable terms. The buyer agent's identity strategy lets you control exactly how much you reveal to each seller.
 
 ## Step-by-Step Workflow
 
@@ -276,7 +276,7 @@ print(f"Selected {len(selected)} packages, budget remaining: ${remaining}")
 
 ### Step 7: Book Deals with Selected Sellers
 
-Submit booking requests for your selected packages. The bookings API runs the workflow in the background -- submit the brief and then poll for status.
+Submit booking requests for your selected packages. The bookings API runs the workflow in the background --- submit the brief and then poll for status.
 
 ```python
 import httpx
@@ -692,8 +692,8 @@ asyncio.run(multi_seller_workflow())
 
 ## Related
 
-- [Negotiation](negotiation.md) -- Detailed guide on negotiation strategies and manual step-by-step control
-- [Media Kit API](../api/media-kit.md) -- Full API reference for browsing seller inventory
-- [Bookings API](../api/bookings.md) -- Booking lifecycle and approval endpoints
-- [Authentication](../api/authentication.md) -- API key setup for authenticated access
-- [Seller Agent Guide](../integration/seller-agent.md) -- How to integrate with seller agents
+- [Negotiation](negotiation.md) --- Detailed guide on negotiation strategies and manual step-by-step control
+- [Media Kit API](../api/media-kit.md) --- Full API reference for browsing seller inventory
+- [Bookings API](../api/bookings.md) --- Booking lifecycle and approval endpoints
+- [Authentication](../api/authentication.md) --- API key setup for authenticated access
+- [Seller Agent Guide](../integration/seller-agent.md) --- How to integrate with seller agents

--- a/docs/guides/sessions.md
+++ b/docs/guides/sessions.md
@@ -1,6 +1,6 @@
 # Session Management
 
-Sessions enable multi-turn conversations with seller agents. Instead of treating each API call as a one-off request, a session maintains context across a sequence of messages -- the seller remembers what you've asked, what you've negotiated, and where you left off. This is essential for any workflow that spans more than a single request: browsing inventory, negotiating prices, and booking deals all benefit from conversational continuity.
+Sessions enable multi-turn conversations with seller agents. Instead of treating each API call as a one-off request, a session maintains context across a sequence of messages --- the seller remembers what you've asked, what you've negotiated, and where you left off. This is essential for any workflow that spans more than a single request: browsing inventory, negotiating prices, and booking deals all benefit from conversational continuity.
 
 ## Why Sessions Matter
 
@@ -8,9 +8,9 @@ Without sessions, every message to a seller starts from scratch. The seller has 
 
 Sessions solve three problems:
 
-1. **Context continuity** -- The seller tracks the full conversation history. When you counter-offer in round three of a negotiation, the seller knows what happened in rounds one and two.
-2. **Negotiation state** -- Price discussions, counter-offers, and concessions are tied to the session. Walking away and coming back later picks up where you left off (within the 7-day TTL).
-3. **Conversation history** -- Inquiries, quotes, and agreements are all linked. The seller can reference a quote it gave earlier in the session when confirming a deal.
+1. **Context continuity** --- The seller tracks the full conversation history. When you counter-offer in round three of a negotiation, the seller knows what happened in rounds one and two.
+2. **Negotiation state** --- Price discussions, counter-offers, and concessions are tied to the session. Walking away and coming back later picks up where you left off (within the 7-day TTL).
+3. **Conversation history** --- Inquiries, quotes, and agreements are all linked. The seller can reference a quote it gave earlier in the session when confirming a deal.
 
 ## Starting a Session with a Seller
 
@@ -142,7 +142,7 @@ counter = await manager.send_message(
 
 ## Resuming Expired Sessions
 
-Sessions have a 7-day TTL. When a session expires, the buyer agent handles recovery automatically -- you do not need to detect or manage expiry yourself.
+Sessions have a 7-day TTL. When a session expires, the buyer agent handles recovery automatically --- you do not need to detect or manage expiry yourself.
 
 ### Automatic Recovery
 
@@ -287,7 +287,7 @@ Sessions are persisted to a JSON file on disk so they survive process restarts. 
 
 ### How It Works
 
-- Sessions are keyed by **seller URL** -- one active session per seller at a time
+- Sessions are keyed by **seller URL** --- one active session per seller at a time
 - The store file is created automatically if it does not exist
 - Data is loaded from disk on `SessionStore` initialization
 - Every `save()` or `remove()` call writes immediately to disk
@@ -368,7 +368,7 @@ print(f"Removed {removed} expired sessions")
 
 ## Managing Multiple Seller Sessions
 
-The buyer agent often works with multiple sellers simultaneously -- comparing inventory, running parallel negotiations, or maintaining ongoing relationships. The session system supports this natively because sessions are keyed by seller URL.
+The buyer agent often works with multiple sellers simultaneously --- comparing inventory, running parallel negotiations, or maintaining ongoing relationships. The session system supports this natively because sessions are keyed by seller URL.
 
 ### One Session Per Seller
 
@@ -437,7 +437,7 @@ This returns only non-expired sessions. Expired sessions are filtered out automa
 
 ## Closing Sessions and Cleanup
 
-When a conversation is complete, close the session explicitly. This is good practice but not strictly required -- sessions expire automatically after 7 days.
+When a conversation is complete, close the session explicitly. This is good practice but not strictly required --- sessions expire automatically after 7 days.
 
 ### Closing a Single Session
 
@@ -448,7 +448,7 @@ await manager.close_session(
 )
 ```
 
-This sends `POST /sessions/{session_id}/close` to the seller and removes the session from the local store. If the remote close fails (e.g., the session already expired on the seller side), the error is logged but not raised -- local cleanup always happens.
+This sends `POST /sessions/{session_id}/close` to the seller and removes the session from the local store. If the remote close fails (e.g., the session already expired on the seller side), the error is logged but not raised --- local cleanup always happens.
 
 ### Closing All Sessions
 
@@ -506,8 +506,8 @@ except RuntimeError as e:
 
 ## Related
 
-- [Sessions API Reference](../api/sessions.md) -- Full API documentation for SessionManager and SessionStore
-- [Negotiation Guide](negotiation.md) -- Multi-turn price negotiation with strategies
-- [Identity Strategy](identity.md) -- How identity tiers affect session behavior and pricing
-- [Authentication](../api/authentication.md) -- API key setup for authenticated sessions
-- [Seller Agent Integration](../integration/seller-agent.md) -- End-to-end integration with seller agents
+- [Sessions API Reference](../api/sessions.md) --- Full API documentation for SessionManager and SessionStore
+- [Negotiation Guide](negotiation.md) --- Multi-turn price negotiation with strategies
+- [Identity Strategy](identity.md) --- How identity tiers affect session behavior and pricing
+- [Authentication](../api/authentication.md) --- API key setup for authenticated sessions
+- [Seller Agent Integration](../integration/seller-agent.md) --- End-to-end integration with seller agents

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,31 +1,31 @@
 # Ad Buyer Agent
 
-The Ad Buyer Agent is an automated advertising buying system built on [CrewAI](https://crewai.com/) and the [IAB OpenDirect 2.1](https://iabtechlab.com/standards/opendirect/) protocol. It receives a campaign brief, allocates budget across channels, researches seller inventory, builds recommendations, and books deals -- all through a single API.
+The Ad Buyer Agent is an automated advertising buying system built on [CrewAI](https://crewai.com/) and the [IAB OpenDirect 2.1](https://iabtechlab.com/standards/opendirect/) protocol. It receives a campaign brief, allocates budget across channels, researches seller inventory, builds recommendations, and books deals --- all through a single API.
 
-Part of the IAB Tech Lab Agent Ecosystem -- see also the [Seller Agent](https://iabtechlab.github.io/seller-agent/).
+Part of the IAB Tech Lab Agent Ecosystem --- see also the [Seller Agent](https://iabtechlab.github.io/seller-agent/).
 
 ## Key Capabilities
 
-- **Campaign briefing** -- accept structured campaign briefs with objectives, budget, dates, audience, and KPIs.
-- **Budget allocation** -- a portfolio-manager agent splits budget across channels (branding, CTV, mobile, performance).
-- **Inventory research** -- channel-specialist agents query seller product catalogs via MCP and A2A protocols.
-- **Recommendation consolidation** -- recommendations from all channels are ranked and presented for review.
-- **Human approval** -- optional approval checkpoint before committing spend.
-- **Deal booking** -- approved recommendations are booked via the quote-then-book deal flow (IAB Deals API v1.0).
-- **Multi-turn negotiation** -- pluggable negotiation strategies (anchor, split-the-difference, walk-away) over A2A conversations.
-- **Multi-seller discovery** -- discover and compare sellers via AAMP registry with trust verification and capability filtering.
-- **Tiered identity strategy** -- four pricing tiers (seat, agency, advertiser, anonymous) determine rate cards and discounts.
-- **Persistent session management** -- sessions track conversation state, negotiation history, and deal context across interactions.
-- **Linear TV buying** -- scatter and upfront buying with DMA-level targeting, CPP/CPM pricing, and daypart selection.
-- **Media kit browsing** -- progressive disclosure of seller inventory from summary through full product details and pricing.
+- **Campaign briefing** --- accept structured campaign briefs with objectives, budget, dates, audience, and KPIs.
+- **Budget allocation** --- a portfolio-manager agent splits budget across channels (branding, CTV, mobile, performance).
+- **Inventory research** --- channel-specialist agents query seller product catalogs via MCP and A2A protocols.
+- **Recommendation consolidation** --- recommendations from all channels are ranked and presented for review.
+- **Human approval** --- optional approval checkpoint before committing spend.
+- **Deal booking** --- approved recommendations are booked via the quote-then-book deal flow (IAB Deals API v1.0).
+- **Multi-turn negotiation** --- pluggable negotiation strategies (anchor, split-the-difference, walk-away) over A2A conversations.
+- **Multi-seller discovery** --- discover and compare sellers via AAMP registry with trust verification and capability filtering.
+- **Tiered identity strategy** --- four pricing tiers (seat, agency, advertiser, anonymous) determine rate cards and discounts.
+- **Persistent session management** --- sessions track conversation state, negotiation history, and deal context across interactions.
+- **Linear TV buying** --- scatter and upfront buying with DMA-level targeting, CPP/CPM pricing, and daypart selection.
+- **Media kit browsing** --- progressive disclosure of seller inventory from summary through full product details and pricing.
 
-## Communication Protocols
+## Access Methods
 
 The buyer agent communicates with seller agents using three protocols:
 
 | Protocol | Use Case | Speed |
 |----------|----------|-------|
-| **[MCP](api/mcp-client.md)** | Automated tool calls -- structured, deterministic | Fast |
+| **[MCP](api/mcp-client.md)** | Automated tool calls --- structured, deterministic | Fast |
 | **[A2A](api/a2a-client.md)** | Conversational discovery & negotiation | Moderate |
 | **[REST](api/overview.md)** | Operator dashboards, legacy integration | Fast |
 
@@ -48,43 +48,38 @@ See the [API Overview](api/overview.md) for full details.
 
 ### Getting Started
 
-- [Quickstart](getting-started/quickstart.md) -- install, configure, and run your first booking
+- [Quickstart](getting-started/quickstart.md) --- install, configure, and run your first booking
 
 ### Architecture & Reference
 
-- [Agent Hierarchy](architecture/agent-hierarchy.md) -- portfolio manager, channel specialists, and tool agents
-- [Tools Reference](architecture/tools.md) -- all CrewAI tools available to agents
-- [Configuration](guides/configuration.md) -- environment variables, seller connections, and feature flags
-- [API Reference](api/overview.md) -- all endpoints, models, and curl examples
-- [Protocol Overview](api/protocols.md) -- comparison of MCP, A2A, and REST
+- [Agent Hierarchy](architecture/agent-hierarchy.md) --- portfolio manager, channel specialists, and tool agents
+- [Tools Reference](architecture/tools.md) --- all CrewAI tools available to agents
+- [Configuration](guides/configuration.md) --- environment variables, seller connections, and feature flags
+- [API Reference](api/overview.md) --- all endpoints, models, and curl examples
+- [Protocol Overview](api/protocols.md) --- comparison of MCP, A2A, and REST
 
 ### Guides
 
-- [Negotiation](guides/negotiation.md) -- multi-turn negotiation strategies and deal flow
-- [Identity Strategy](guides/identity.md) -- tiered pricing and buyer identity resolution
-- [Sessions](guides/sessions.md) -- persistent session management across interactions
-- [Multi-Seller Discovery](guides/multi-seller.md) -- AAMP registry and trust verification
-- [Linear TV Buying](guides/linear-tv.md) -- scatter, upfront, DMA targeting, and CPP/CPM pricing
-- [Media Kit Browsing](guides/media-kit.md) -- progressive disclosure of seller inventory
-- [Deal Booking](guides/deal-booking.md) -- end-to-end quote-then-book workflow
+- [Negotiation](guides/negotiation.md) --- multi-turn negotiation strategies and deal flow
+- [Identity Strategy](guides/identity.md) --- tiered pricing and buyer identity resolution
+- [Sessions](guides/sessions.md) --- persistent session management across interactions
+- [Multi-Seller Discovery](guides/multi-seller.md) --- AAMP registry and trust verification
+- [Linear TV Buying](guides/linear-tv.md) --- scatter, upfront, DMA targeting, and CPP/CPM pricing
+- [Media Kit Browsing](guides/media-kit.md) --- progressive disclosure of seller inventory
+- [Deal Booking](guides/deal-booking.md) --- end-to-end quote-then-book workflow
 
 ### Integration
 
-- [MCP Client](api/mcp-client.md) -- structured tool calls to seller agents
-- [A2A Client](api/a2a-client.md) -- conversational discovery and negotiation
-- [Seller Agent Integration](integration/seller-agent.md) -- connecting to seller agents and the OpenDirect protocol
+- [MCP Client](api/mcp-client.md) --- structured tool calls to seller agents
+- [A2A Client](api/a2a-client.md) --- conversational discovery and negotiation
+- [Seller Agent Integration](integration/seller-agent.md) --- connecting to seller agents and the OpenDirect protocol
 
 ### Planned Features
 
-- [Multi-Seller Orchestration](guides/multi-seller-orchestration.md) -- cross-seller campaign optimization
-- [Campaign Pipeline](guides/campaign-pipeline.md) -- end-to-end campaign lifecycle
-- [Budget Pacing](guides/budget-pacing.md) -- real-time spend management
-- [Creative Management](guides/creative-management.md) -- asset upload and assignment
-- [Order State Machine](architecture/state-machine.md) -- formal order status transitions
-- [Event Bus](architecture/event-bus.md) -- inter-agent event routing
+- [Multi-Seller Orchestration](guides/multi-seller-orchestration.md) --- cross-seller campaign optimization
+- [Campaign Pipeline](guides/campaign-pipeline.md) --- end-to-end campaign lifecycle
+- [Budget Pacing](guides/budget-pacing.md) --- real-time spend management
+- [Creative Management](guides/creative-management.md) --- asset upload and assignment
+- [Order State Machine](architecture/state-machine.md) --- formal order status transitions
+- [Event Bus](architecture/event-bus.md) --- inter-agent event routing
 
-## Links
-
-- [Seller Agent Documentation](https://iabtechlab.github.io/seller-agent/)
-- [IAB OpenDirect 2.1 Specification](https://iabtechlab.com/standards/opendirect/)
-- [IAB Tech Lab](https://iabtechlab.com/)

--- a/docs/integration/seller-agent.md
+++ b/docs/integration/seller-agent.md
@@ -56,30 +56,30 @@ This returns the seller's capabilities, supported OpenDirect version, and availa
 
 The buyer queries the seller's product catalog during the research phase:
 
-- **List products**: `GET /products?$skip=0&$top=50` -- paginated product listing
-- **Search products**: `POST /products/search` -- filtered search with channel, format, pricing criteria
-- **Get product**: `GET /products/{id}` -- single product details
+- **List products**: `GET /products?$skip=0&$top=50` --- paginated product listing
+- **Search products**: `POST /products/search` --- filtered search with channel, format, pricing criteria
+- **Get product**: `GET /products/{id}` --- single product details
 
 ### Availability and Pricing
 
 Before recommending products, channel specialists check availability:
 
-- **Check avails**: `POST /products/avails` -- returns available impressions, estimated CPM, total cost, and delivery confidence
+- **Check avails**: `POST /products/avails` --- returns available impressions, estimated CPM, total cost, and delivery confidence
 
 ### Order and Line Management
 
 After approval, the buyer creates orders and books line items:
 
-- **Create order**: `POST /accounts/{id}/orders` -- creates an insertion order
-- **Create line**: `POST /accounts/{id}/orders/{id}/lines` -- creates a line item for a product
-- **Reserve line**: `PATCH /accounts/{id}/orders/{id}/lines/{id}?action=reserve` -- reserves inventory
-- **Book line**: `PATCH /accounts/{id}/orders/{id}/lines/{id}?action=book` -- confirms the booking
+- **Create order**: `POST /accounts/{id}/orders` --- creates an insertion order
+- **Create line**: `POST /accounts/{id}/orders/{id}/lines` --- creates a line item for a product
+- **Reserve line**: `PATCH /accounts/{id}/orders/{id}/lines/{id}?action=reserve` --- reserves inventory
+- **Book line**: `PATCH /accounts/{id}/orders/{id}/lines/{id}?action=book` --- confirms the booking
 
 ### Performance Monitoring
 
 For in-flight campaigns:
 
-- **Line stats**: `GET /accounts/{id}/orders/{id}/lines/{id}/stats` -- delivery metrics, pacing, spend
+- **Line stats**: `GET /accounts/{id}/orders/{id}/lines/{id}/stats` --- delivery metrics, pacing, spend
 
 ## Request Flow
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,13 +8,13 @@ theme:
   name: material
   palette:
     - scheme: default
-      primary: teal
+      primary: indigo
       accent: amber
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - scheme: slate
-      primary: teal
+      primary: indigo
       accent: amber
       toggle:
         icon: material/brightness-4
@@ -77,8 +77,8 @@ nav:
       - Deal Store: architecture/deal-store.md
       - Models: architecture/models.md
       - Tools Reference: architecture/tools.md
-      - Order State Machine (Planned): architecture/state-machine.md
-      - Event Bus (Planned): architecture/event-bus.md
+      - Order State Machine: architecture/state-machine.md
+      - Event Bus: architecture/event-bus.md
   - Guides:
       - Configuration: guides/configuration.md
       - Deal Booking: guides/deal-booking.md
@@ -88,10 +88,10 @@ nav:
       - Identity Strategy: guides/identity.md
       - Sessions: guides/sessions.md
       - Multi-Seller Discovery: guides/multi-seller.md
-      - Multi-Seller Orchestration (Planned): guides/multi-seller-orchestration.md
-      - Campaign Pipeline (Planned): guides/campaign-pipeline.md
-      - Budget Pacing (Planned): guides/budget-pacing.md
-      - Creative Management (Planned): guides/creative-management.md
+      - Multi-Seller Orchestration: guides/multi-seller-orchestration.md
+      - Campaign Pipeline: guides/campaign-pipeline.md
+      - Budget Pacing: guides/budget-pacing.md
+      - Creative Management: guides/creative-management.md
   - Integration:
       - Seller Agent Guide: integration/seller-agent.md
       - OpenDirect Protocol: integration/opendirect.md


### PR DESCRIPTION
## Summary
- Changed theme primary color from `teal` to `indigo` in both light and dark palette schemes
- Replaced prose em-dashes (`--`) with (`---`) across all 24 docs files, preserving `--` in code blocks, inline code, table placeholders, and CLI flags
- Removed `(Planned)` suffix from 6 nav entries in mkdocs.yml (pages retain their "Coming Soon" admonitions)
- Standardized `## Related Pages` headers to `## Related` (3 files)
- Removed `## Links` section from home page (docs/index.md)
- Renamed `## Communication Protocols` to `## Access Methods` on home page to match seller terminology

## Test plan
- [ ] Verify `mkdocs serve` renders correctly with indigo theme
- [ ] Spot-check em-dash rendering in prose vs code blocks
- [ ] Confirm nav entries display without (Planned) suffix
- [ ] Verify no broken links from removed Links section

🤖 Generated with [Claude Code](https://claude.com/claude-code)