### PR TITLE
Add negotiation capability mentions to doc pages

### DIFF
--- a/docs/api/bookings.md
+++ b/docs/api/bookings.md
@@ -13,10 +13,13 @@ pending --> running --> awaiting_approval --> completed
 | Status | Meaning |
 |--------|---------|
 | `pending` | Job created, background flow starting |
-| `running` | Budget allocation and inventory research in progress |
+| `running` | Budget allocation, inventory research, and negotiation (if eligible) in progress |
 | `awaiting_approval` | Recommendations ready for human review |
 | `completed` | Deals booked (or no recommendations approved) |
 | `failed` | An error occurred during the flow |
+
+!!! info "Negotiation During the Running Phase"
+    During the `running` phase, the buyer agent may negotiate pricing with the seller for eligible buyer tiers (Agency and Advertiser). The `kpis.target_cpm` field in the campaign brief can drive negotiation behavior by setting the buyer's target price. See the [Negotiation Guide](../guides/negotiation.md) for details.
 
 ---
 

--- a/docs/api/products.md
+++ b/docs/api/products.md
@@ -77,3 +77,6 @@ The products endpoint returns structured error responses with an HTTP status cod
 
 !!! tip "Empty results are not errors"
     If no products match the search criteria, the endpoint returns `200` with an empty `results` array --- not a `404`.
+
+!!! tip "Negotiate Before Booking"
+    After finding products through search, eligible buyer tiers (Agency and Advertiser) can negotiate pricing with the seller before placing bookings. See the [Negotiation Guide](../guides/negotiation.md) for details.

--- a/docs/api/seller-discovery.md
+++ b/docs/api/seller-discovery.md
@@ -261,7 +261,8 @@ graph LR
     B --> C[Verify Trust]
     C --> D[Fetch Agent Cards]
     D --> E[Browse Media Kits]
-    E --> F[Compare & Book]
+    E --> F[Negotiate Pricing]
+    F --> G[Compare & Book]
 ```
 
 ### Portfolio Shopping Example

--- a/docs/architecture/agent-hierarchy.md
+++ b/docs/architecture/agent-hierarchy.md
@@ -358,6 +358,10 @@ sequenceDiagram
     CS->>RA: Research inventory
     RA-->>CS: Ranked product recommendations
     CS->>CS: Select best inventory
+    opt Negotiation (eligible tiers)
+        CS->>EA: Negotiate pricing
+        EA-->>CS: Negotiated terms
+    end
     CS->>EA: Book selected placements
     EA-->>CS: Booking confirmations
     CS-->>PM: Channel results

--- a/docs/architecture/booking-flow.md
+++ b/docs/architecture/booking-flow.md
@@ -50,6 +50,13 @@ sequenceDiagram
         Channels-->>Flow: Mobile recommendations
     end
 
+    opt Negotiation (eligible tiers)
+        Flow->>ODClient: NegotiationClient.start_negotiation()
+        ODClient->>Seller: POST /proposals/{id}/counter
+        Seller-->>ODClient: Counter-offer / accept
+        ODClient-->>Flow: Negotiated pricing
+    end
+
     Note over Flow: Step 4: Consolidate
     Flow->>Flow: consolidate_recommendations()
     Flow->>Flow: Set status: awaiting_approval
@@ -106,3 +113,6 @@ stateDiagram-v2
 ```
 
 These states are tracked in `BookingState.execution_status` using the `ExecutionStatus` enum.
+
+!!! note "Negotiation Between Research and Booking"
+    For Agency and Advertiser tier buyers, a negotiation phase can occur between the research and booking steps. The `NegotiationClient` handles multi-turn price negotiation with the seller agent before orders are placed. See the [Negotiation Guide](../guides/negotiation.md) for details on configuring negotiation strategies.

--- a/docs/architecture/models.md
+++ b/docs/architecture/models.md
@@ -196,6 +196,12 @@ Performance metrics for a line item. Fields: `line_id`, `impressions_delivered`,
 | `OrderStatus` | `PENDING`, `APPROVED`, `REJECTED` |
 | `LineBookingStatus` | `Draft`, `PendingReservation`, `Reserved`, `PendingBooking`, `Booked`, `InFlight`, `Finished`, `Stopped`, `Cancelled`, `Expired` |
 
+## Negotiation Models
+
+The negotiation module defines its own set of models for managing multi-turn price negotiations with seller agents. These include negotiation state, offer history, and strategy configuration. See the [Negotiation Guide](../guides/negotiation.md) for the full model reference and usage examples.
+
+---
+
 ## Model Relationships
 
 ```mermaid

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -76,6 +76,7 @@ graph TB
 | **IABMCPClient** | MCP SDK client with Streamable HTTP transport | `clients/mcp_client.py` |
 | **A2AClient** | JSON-RPC 2.0 client for conversational agent-to-agent requests | `clients/a2a_client.py` |
 | **OpenDirectClient** | Async HTTP client for IAB OpenDirect 2.1 seller APIs | `clients/opendirect_client.py` |
+| **NegotiationClient** | Multi-turn price negotiation with seller agents via A2A/proposals | `clients/negotiation_client.py` |
 | **BookingState** | Pydantic state model tracking the full flow lifecycle | `models/flow_state.py` |
 | **Settings** | Environment-based configuration via pydantic-settings | `config/settings.py` |
 
@@ -115,7 +116,7 @@ graph LR
     Buyer -->|"status + booked lines"| CM
 ```
 
-The buyer agent acts as an automated media buyer. It receives campaign requirements from a user or campaign manager, uses AI agents to plan and research, and executes deals against one or more seller agents using MCP (primary), A2A (conversational), or OpenDirect 2.1 REST (legacy).
+The buyer agent acts as an automated media buyer. It receives campaign requirements from a user or campaign manager, uses AI agents to plan and research, negotiates pricing for eligible buyer tiers, and executes deals against one or more seller agents using MCP (primary), A2A (conversational), or OpenDirect 2.1 REST (legacy).
 
 See also: [Seller Agent Architecture](https://iabtechlab.github.io/seller-agent/architecture/overview/)
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -107,4 +107,5 @@ On a fresh server, this returns an empty list:
 - [**Running with Seller**](running-with-seller.md) — Connect to the seller agent and execute a full booking workflow end-to-end.
 - [**Configuration**](../guides/configuration.md) — Deep dive into all configuration options.
 - [**Deal Booking Guide**](../guides/deal-booking.md) — Understand the full booking lifecycle.
+- [**Negotiation Guide**](../guides/negotiation.md) — Configure automated price negotiation with seller agents.
 - [**API Reference**](../api/overview.md) — Explore every endpoint in detail.

--- a/docs/integration/opendirect.md
+++ b/docs/integration/opendirect.md
@@ -175,8 +175,12 @@ The `OpenDirectClient` (`clients/opendirect_client.py`) provides typed async met
 
 All methods return typed Pydantic models from `models/opendirect.py`.
 
+!!! note "Negotiation Is Not Part of OpenDirect"
+    Price negotiation happens via the A2A protocol and the `NegotiationClient`, not through OpenDirect endpoints. OpenDirect handles the booking lifecycle (orders, lines, reservation, confirmation) after pricing has been agreed upon. See the [Negotiation Guide](../guides/negotiation.md) for how negotiation integrates with the booking flow.
+
 ## References
 
 - [IAB OpenDirect 2.1 Specification](https://iabtechlab.com/standards/opendirect/)
 - [IAB Tech Lab](https://iabtechlab.com/)
 - [Seller Agent Documentation](https://iabtechlab.github.io/seller-agent/)
+- [Negotiation Guide](../guides/negotiation.md)

--- a/docs/integration/seller-agent.md
+++ b/docs/integration/seller-agent.md
@@ -1,6 +1,6 @@
 # Seller Agent Integration
 
-The buyer agent connects to one or more seller agents to search inventory, check availability, and book deals using the IAB OpenDirect 2.1 protocol.
+The buyer agent connects to one or more seller agents to search inventory, check availability, negotiate pricing, and book deals using the IAB OpenDirect 2.1 protocol.
 
 ## Connection Configuration
 
@@ -66,6 +66,16 @@ Before recommending products, channel specialists check availability:
 
 - **Check avails**: `POST /products/avails` --- returns available impressions, estimated CPM, total cost, and delivery confidence
 
+### Negotiation
+
+For eligible buyer tiers (Agency and Advertiser), the buyer can negotiate pricing with the seller before booking:
+
+- **Start negotiation**: Via `NegotiationClient`, the buyer submits a counter-offer on a seller's proposal
+- **Multi-turn**: The buyer and seller exchange offers until agreement or walk-away
+- **Auto or manual**: Negotiations can run fully automatically using a pluggable `NegotiationStrategy`, or step-by-step
+
+See the [Negotiation Guide](../guides/negotiation.md) for configuration and strategy details.
+
 ### Order and Line Management
 
 After approval, the buyer creates orders and books line items:
@@ -97,6 +107,11 @@ sequenceDiagram
     Buyer->>Seller: POST /products/avails
     Seller-->>Buyer: Availability + pricing
 
+    opt Negotiation (Agency/Advertiser tiers)
+        Buyer->>Seller: POST /proposals/{id}/counter
+        Seller-->>Buyer: Counter-offer or accept
+    end
+
     Buyer->>Seller: POST /accounts/{id}/orders
     Seller-->>Buyer: Order created
 
@@ -115,3 +130,4 @@ sequenceDiagram
 - [Seller Agent Documentation](https://iabtechlab.github.io/seller-agent/)
 - [Seller Agent Buyer Integration Guide](https://iabtechlab.github.io/seller-agent/integration/buyer-agent/)
 - [OpenDirect Protocol](opendirect.md)
+- [Negotiation Guide](../guides/negotiation.md)


### PR DESCRIPTION
## Summary
- Adds negotiation capability cross-references to 10 documentation pages where it was missing
- Each page gets brief, contextual mentions (a sentence, table row, admonition, or small subsection) linking to the existing Negotiation Guide
- No page rewrites; additions only

## Pages Updated (priority order)
1. **Seller Agent Integration** — updated opening sentence, added Negotiation subsection, added negotiation step to sequence diagram, added Related link
2. **Booking Flow** — added negotiation step to sequence diagram, added note admonition about negotiation between research and booking
3. **Bookings API** — added info admonition about negotiation during `running` phase and `kpis.target_cpm` driving negotiation
4. **Quickstart** — added Negotiation Guide link to Next Steps
5. **Architecture Overview** — added NegotiationClient to Component Summary table, added "negotiates pricing" to closing description
6. **OpenDirect Integration** — added note that negotiation happens via A2A/NegotiationClient not OpenDirect, added Reference link
7. **Agent Hierarchy** — added negotiation step to execution flow sequence diagram
8. **Products API** — added tip admonition about negotiating before booking after product search
9. **Data Models** — added Negotiation Models section with cross-reference to negotiation guide
10. **Seller Discovery** — added "Negotiate" step to discovery workflow diagram

## Test plan
- [x] `mkdocs build --strict` passes with zero warnings/errors
- [x] All relative links point to existing `../guides/negotiation.md`
- [x] No changes to "Coming Soon" stub pages (state-machine.md, event-bus.md)

bead: buyer-eeq

🤖 Generated with [Claude Code](https://claude.com/claude-code)