### PR TITLE
Implement buyer order state machine

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,46 +1,41 @@
 # API Overview
 
-The Ad Buyer Agent API is a FastAPI application running on port 8001 by default. All endpoints return JSON.
+The Ad Buyer Agent API exposes **7 endpoints** across **3 tags**. All endpoints are served from a single FastAPI application.
 
-Base URL: `http://localhost:8001`
+**Base URL:** `http://localhost:8001`
+**OpenAPI docs:** `http://localhost:8001/docs`
 
-## Why So Few Endpoints?
+The buyer agent is primarily a **client** that consumes seller APIs, not a server with a large surface area of its own. Most of its work happens through outbound calls to seller systems via [MCP](mcp-client.md), [A2A](a2a-client.md), or [REST/OpenDirect](../integration/opendirect.md). The buyer's own REST API handles workflow orchestration and catalog proxying.
 
-The buyer agent exposes only 7 REST endpoints. This is intentional --- the buyer is primarily a **client** that consumes seller APIs, not a server with a large surface area of its own.
+---
 
-A seller agent publishes inventory, manages accounts, processes orders, and handles creative assignments --- operations that demand dozens of endpoints. The buyer agent's job is different: it discovers sellers, browses their catalogs, negotiates pricing, and books deals. Most of that work happens through outbound calls to seller systems via [MCP](mcp-client.md), [A2A](a2a-client.md), or [REST/OpenDirect](../integration/opendirect.md).
+## Health
 
-The buyer's own REST API exists for two purposes:
+| Method | Path | Summary |
+|--------|------|---------|
+| `GET` | `/health` | Service health check |
 
-1. **Workflow orchestration** --- the `/bookings` endpoints let operators (or upstream systems) submit a campaign brief and track the automated booking workflow.
-2. **Catalog proxy** --- the `/products/search` endpoint lets callers search seller inventory through the buyer without establishing a direct seller connection.
+## Bookings
 
-!!! info "Where does the real work happen?"
-    The buyer's complexity lives in its **client libraries**, not its server endpoints. See [Protocol Overview](protocols.md) for how the buyer communicates with sellers, and the sections below for the specific seller endpoints consumed.
+| Method | Path | Summary |
+|--------|------|---------|
+| `POST` | `/bookings` | Start a new booking workflow |
+| `GET` | `/bookings` | List all booking jobs |
+| `GET` | `/bookings/{job_id}` | Get booking workflow status |
+| `POST` | `/bookings/{job_id}/approve` | Approve specific recommendations |
+| `POST` | `/bookings/{job_id}/approve-all` | Approve all recommendations |
 
-## Buyer Endpoints
+## Products
 
-| Method | Path | Tag | Summary |
-|--------|------|-----|---------|
-| `GET` | `/health` | Health | Service health check |
-| `POST` | `/bookings` | Bookings | Start a new booking workflow |
-| `GET` | `/bookings/{job_id}` | Bookings | Get booking workflow status |
-| `POST` | `/bookings/{job_id}/approve` | Bookings | Approve specific recommendations |
-| `POST` | `/bookings/{job_id}/approve-all` | Bookings | Approve all recommendations |
-| `GET` | `/bookings` | Bookings | List all booking jobs |
-| `POST` | `/products/search` | Products | Search seller product catalog |
-
-### Tags
-
-- **Health** --- service health and readiness
-- **Bookings** --- campaign booking workflow lifecycle
-- **Products** --- seller inventory product search
+| Method | Path | Summary |
+|--------|------|---------|
+| `POST` | `/products/search` | Search seller product catalog |
 
 ---
 
 ## Seller Endpoints Consumed
 
-The buyer agent acts as a client to seller systems. The table below lists the seller-side endpoints the buyer calls, grouped by domain.
+The buyer agent acts as a client to seller systems. The tables below list the seller-side endpoints the buyer calls, grouped by domain.
 
 ### Quotes & Deals (REST)
 
@@ -94,10 +89,6 @@ Via [A2A](a2a-client.md), the buyer sends natural language requests to the selle
     For full details on the seller-side endpoints and tools listed above, see the [Seller Agent API Reference](https://iabtechlab.github.io/seller-agent/api/overview/).
 
 ---
-
-## Interactive Documentation
-
-When the server is running, Swagger UI is available at `/docs` and ReDoc at `/redoc`. The raw OpenAPI schema is at `/openapi.json`.
 
 ## Related
 

--- a/src/ad_buyer/flows/deal_booking_flow.py
+++ b/src/ad_buyer/flows/deal_booking_flow.py
@@ -27,6 +27,7 @@ from ..models.flow_state import (
     ExecutionStatus,
     ProductRecommendation,
 )
+from ..models.state_machine import BuyerDealStatus, DealStateMachine, InvalidTransitionError
 from ..models.ucp import AudiencePlan, SignalType, UCPConsent
 from ..storage.deal_store import DealStore
 
@@ -94,6 +95,9 @@ class DealBookingFlow(Flow[BookingState]):
     def _persist_deal_status(self, deal_id: str, new_status: str) -> None:
         """Best-effort update deal status in the store.
 
+        Uses DealStore.update_deal_status() which enforces state machine
+        transitions when both statuses are valid BuyerDealStatus values.
+
         Args:
             deal_id: The deal to update.
             new_status: New status value.
@@ -101,7 +105,13 @@ class DealBookingFlow(Flow[BookingState]):
         if self._store is None:
             return
         try:
-            self._store.update_deal_status(deal_id, new_status, triggered_by="system")
+            ok = self._store.update_deal_status(deal_id, new_status, triggered_by="system")
+            if not ok:
+                logger.warning(
+                    "State machine rejected transition to %s for deal %s",
+                    new_status,
+                    deal_id,
+                )
         except Exception:
             logger.exception(
                 "Failed to persist status change to %s for deal %s",

--- a/src/ad_buyer/flows/dsp_deal_flow.py
+++ b/src/ad_buyer/flows/dsp_deal_flow.py
@@ -22,6 +22,7 @@ from ..models.buyer_identity import (
     DealResponse,
     DealType,
 )
+from ..models.state_machine import BuyerDealStatus, DealStateMachine, InvalidTransitionError
 from ..storage.deal_store import DealStore
 from ..tools.dsp import DiscoverInventoryTool, GetPricingTool, RequestDealTool
 
@@ -192,15 +193,24 @@ class DSPDealFlow(Flow[DSPFlowState]):
     def _persist_deal_status(self, new_status: str) -> None:
         """Best-effort update deal status in the store.
 
+        Uses DealStore.update_deal_status() which enforces state machine
+        transitions when both statuses are valid BuyerDealStatus values.
+
         Args:
             new_status: New status value.
         """
         if self._store is None or self._store_deal_id is None:
             return
         try:
-            self._store.update_deal_status(
+            ok = self._store.update_deal_status(
                 self._store_deal_id, new_status, triggered_by="system"
             )
+            if not ok:
+                logger.warning(
+                    "State machine rejected transition to %s for deal %s",
+                    new_status,
+                    self._store_deal_id,
+                )
         except Exception:
             logger.exception(
                 "Failed to persist status %s for deal %s",

--- a/src/ad_buyer/models/state_machine.py
+++ b/src/ad_buyer/models/state_machine.py
@@ -1,0 +1,498 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Buyer Order State Machine (buyer-5er).
+
+Formal state machine for buyer deal and campaign lifecycles, adapted from
+the seller's OrderStateMachine framework.  Provides:
+
+- BuyerDealStatus: deal lifecycle (quoted -> negotiating -> ... -> completed)
+- BuyerCampaignStatus: campaign/booking lifecycle (maps to ExecutionStatus)
+- DealStateMachine / CampaignStateMachine: configurable transitions, guard
+  conditions, and a full audit log of every state change
+- Linear TV extensions: makegood_pending, partially_canceled
+
+Existing code continues to work: ExecutionStatus and DSPFlowStatus are
+preserved and mapped into the new enums where flows need the machine.
+
+Pure Pydantic + stdlib -- no external dependencies.
+"""
+
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import Any, Callable, Optional
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Buyer Deal Status
+# ---------------------------------------------------------------------------
+
+
+class BuyerDealStatus(str, Enum):
+    """Status for buyer deal lifecycle.
+
+    Happy path:
+        quoted -> negotiating -> accepted -> booking -> booked ->
+        delivering -> completed
+
+    Linear TV extensions:
+        delivering -> makegood_pending -> delivering
+        booked -> partially_canceled -> delivering
+
+    Terminal states: completed, failed, cancelled, expired
+    """
+
+    # Entry
+    QUOTED = "quoted"
+
+    # Negotiation
+    NEGOTIATING = "negotiating"
+
+    # Acceptance
+    ACCEPTED = "accepted"
+
+    # Booking
+    BOOKING = "booking"
+    BOOKED = "booked"
+
+    # Delivery
+    DELIVERING = "delivering"
+
+    # Terminal
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    EXPIRED = "expired"
+
+    # Linear TV extensions
+    MAKEGOOD_PENDING = "makegood_pending"
+    PARTIALLY_CANCELED = "partially_canceled"
+
+
+# ---------------------------------------------------------------------------
+# Buyer Campaign Status
+# ---------------------------------------------------------------------------
+
+
+class BuyerCampaignStatus(str, Enum):
+    """Status for buyer campaign/booking lifecycle.
+
+    Maps to the existing ExecutionStatus enum used by BookingState.
+    """
+
+    INITIALIZED = "initialized"
+    BRIEF_RECEIVED = "brief_received"
+    VALIDATION_FAILED = "validation_failed"
+    BUDGET_ALLOCATED = "budget_allocated"
+    RESEARCHING = "researching"
+    AWAITING_APPROVAL = "awaiting_approval"
+    EXECUTING_BOOKINGS = "executing_bookings"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+# ---------------------------------------------------------------------------
+# Audit models
+# ---------------------------------------------------------------------------
+
+
+class StateTransition(BaseModel):
+    """Immutable record of a single state change."""
+
+    transition_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    from_status: str
+    to_status: str
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    actor: str = "system"  # "system", "human:<user_id>", "agent:<agent_id>"
+    reason: str = ""
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class OrderAuditLog(BaseModel):
+    """Append-only audit trail for an entity's lifecycle."""
+
+    order_id: str
+    transitions: list[StateTransition] = Field(default_factory=list)
+
+    @property
+    def current_status(self) -> Optional[str]:
+        if self.transitions:
+            return self.transitions[-1].to_status
+        return None
+
+    def append(self, transition: StateTransition) -> None:
+        self.transitions.append(transition)
+
+
+# ---------------------------------------------------------------------------
+# Transition rules
+# ---------------------------------------------------------------------------
+
+# Type alias for guard functions: (order_id, from_status, to_status, context) -> bool
+GuardFn = Callable[[str, Any, Any, dict[str, Any]], bool]
+
+
+class TransitionRule(BaseModel):
+    """Defines a permitted state transition with optional guard condition."""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    from_status: Any  # enum member
+    to_status: Any  # enum member
+    guard: Optional[GuardFn] = Field(default=None, exclude=True)
+    description: str = ""
+
+
+# ---------------------------------------------------------------------------
+# InvalidTransitionError
+# ---------------------------------------------------------------------------
+
+
+class InvalidTransitionError(Exception):
+    """Raised when a state transition is not allowed."""
+
+    def __init__(
+        self, order_id: str, from_status: Any, to_status: Any, reason: str = ""
+    ):
+        self.order_id = order_id
+        self.from_status = from_status
+        self.to_status = to_status
+        from_val = from_status.value if hasattr(from_status, "value") else str(from_status)
+        to_val = to_status.value if hasattr(to_status, "value") else str(to_status)
+        msg = f"Cannot transition order {order_id} from {from_val} to {to_val}"
+        if reason:
+            msg += f": {reason}"
+        super().__init__(msg)
+
+
+# ---------------------------------------------------------------------------
+# Generic State Machine base
+# ---------------------------------------------------------------------------
+
+
+class _BaseStateMachine:
+    """Generic state machine with configurable transitions and audit trail.
+
+    Subclasses set the status enum type; this base provides the machinery.
+    """
+
+    def __init__(
+        self,
+        order_id: str,
+        initial_status: Any,
+        rules: Optional[list[TransitionRule]] = None,
+    ):
+        self.order_id = order_id
+        self._status = initial_status
+        self._rules = list(rules) if rules else []
+        self._audit = OrderAuditLog(order_id=order_id)
+
+        # Index rules for fast lookup: (from, to) -> rule
+        self._rule_index: dict[tuple[Any, Any], TransitionRule] = {
+            (r.from_status, r.to_status): r for r in self._rules
+        }
+
+    @property
+    def status(self) -> Any:
+        return self._status
+
+    @property
+    def audit_log(self) -> OrderAuditLog:
+        return self._audit
+
+    @property
+    def history(self) -> list[StateTransition]:
+        return self._audit.transitions
+
+    def allowed_transitions(self) -> list[Any]:
+        """Return the list of states reachable from the current state."""
+        return [
+            to for (frm, to), _ in self._rule_index.items()
+            if frm == self._status
+        ]
+
+    def can_transition(
+        self, to_status: Any, context: Optional[dict[str, Any]] = None
+    ) -> bool:
+        """Check whether a transition is permitted (including guard)."""
+        rule = self._rule_index.get((self._status, to_status))
+        if rule is None:
+            return False
+        if rule.guard is not None:
+            return rule.guard(self.order_id, self._status, to_status, context or {})
+        return True
+
+    def transition(
+        self,
+        to_status: Any,
+        *,
+        actor: str = "system",
+        reason: str = "",
+        context: Optional[dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> StateTransition:
+        """Execute a state transition.
+
+        Raises InvalidTransitionError if not allowed.
+        Returns the StateTransition audit record.
+        """
+        rule = self._rule_index.get((self._status, to_status))
+        if rule is None:
+            raise InvalidTransitionError(
+                self.order_id, self._status, to_status, "no matching transition rule"
+            )
+
+        if rule.guard is not None:
+            ctx = context or {}
+            if not rule.guard(self.order_id, self._status, to_status, ctx):
+                raise InvalidTransitionError(
+                    self.order_id, self._status, to_status, "guard condition failed"
+                )
+
+        from_status = self._status
+        self._status = to_status
+
+        record = StateTransition(
+            from_status=from_status.value if hasattr(from_status, "value") else str(from_status),
+            to_status=to_status.value if hasattr(to_status, "value") else str(to_status),
+            actor=actor,
+            reason=reason or rule.description,
+            metadata=metadata or {},
+        )
+        self._audit.append(record)
+        return record
+
+    def add_rule(self, rule: TransitionRule) -> None:
+        """Add a custom transition rule."""
+        self._rules.append(rule)
+        self._rule_index[(rule.from_status, rule.to_status)] = rule
+
+    def remove_rule(self, from_status: Any, to_status: Any) -> bool:
+        """Remove a transition rule. Returns True if a rule was removed."""
+        key = (from_status, to_status)
+        if key in self._rule_index:
+            rule = self._rule_index.pop(key)
+            self._rules.remove(rule)
+            return True
+        return False
+
+    # -- Serialization --
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the machine state for storage."""
+        return {
+            "order_id": self.order_id,
+            "status": self._status.value if hasattr(self._status, "value") else str(self._status),
+            "audit_log": self._audit.model_dump(mode="json"),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Default transition tables
+# ---------------------------------------------------------------------------
+
+
+def _build_deal_rules() -> list[TransitionRule]:
+    """Build the default transition rules for buyer deals."""
+    S = BuyerDealStatus
+    transitions: list[tuple[BuyerDealStatus, BuyerDealStatus, str]] = [
+        # Happy path
+        (S.QUOTED, S.NEGOTIATING, "Buyer initiates negotiation"),
+        (S.QUOTED, S.ACCEPTED, "Quote accepted without negotiation"),
+        (S.NEGOTIATING, S.ACCEPTED, "Deal terms accepted"),
+        (S.NEGOTIATING, S.QUOTED, "Counter-offer received, re-quoting"),
+        (S.ACCEPTED, S.BOOKING, "Booking process started"),
+        (S.BOOKING, S.BOOKED, "Booking confirmed by seller"),
+        (S.BOOKED, S.DELIVERING, "Campaign delivery started"),
+        (S.DELIVERING, S.COMPLETED, "Campaign delivery completed"),
+
+        # Failure from active states
+        (S.QUOTED, S.FAILED, "Quote processing failed"),
+        (S.NEGOTIATING, S.FAILED, "Negotiation failed"),
+        (S.BOOKING, S.FAILED, "Booking failed"),
+        (S.DELIVERING, S.FAILED, "Delivery failed"),
+
+        # Cancellation from non-terminal states
+        (S.QUOTED, S.CANCELLED, "Deal cancelled"),
+        (S.NEGOTIATING, S.CANCELLED, "Deal cancelled during negotiation"),
+        (S.ACCEPTED, S.CANCELLED, "Deal cancelled after acceptance"),
+        (S.BOOKING, S.CANCELLED, "Deal cancelled during booking"),
+        (S.BOOKED, S.CANCELLED, "Booked deal cancelled"),
+        (S.DELIVERING, S.CANCELLED, "Delivery cancelled"),
+
+        # Expiry
+        (S.QUOTED, S.EXPIRED, "Quote expired"),
+        (S.NEGOTIATING, S.EXPIRED, "Negotiation expired"),
+
+        # Linear TV extensions
+        (S.DELIVERING, S.MAKEGOOD_PENDING, "Makegood requested for under-delivery"),
+        (S.MAKEGOOD_PENDING, S.DELIVERING, "Makegood resolved, delivery resumed"),
+        (S.MAKEGOOD_PENDING, S.COMPLETED, "Makegood resolved, campaign complete"),
+        (S.MAKEGOOD_PENDING, S.FAILED, "Makegood could not be fulfilled"),
+        (S.BOOKED, S.PARTIALLY_CANCELED, "Partial cancellation of booked units"),
+        (S.PARTIALLY_CANCELED, S.DELIVERING, "Partially canceled deal begins delivery"),
+        (S.PARTIALLY_CANCELED, S.CANCELLED, "Remaining units cancelled"),
+    ]
+
+    return [
+        TransitionRule(from_status=f, to_status=t, description=d)
+        for f, t, d in transitions
+    ]
+
+
+def _build_campaign_rules() -> list[TransitionRule]:
+    """Build the default transition rules for buyer campaigns."""
+    S = BuyerCampaignStatus
+    transitions: list[tuple[BuyerCampaignStatus, BuyerCampaignStatus, str]] = [
+        # Happy path
+        (S.INITIALIZED, S.BRIEF_RECEIVED, "Campaign brief received"),
+        (S.BRIEF_RECEIVED, S.BUDGET_ALLOCATED, "Budget allocated across channels"),
+        (S.BRIEF_RECEIVED, S.VALIDATION_FAILED, "Brief validation failed"),
+        (S.BUDGET_ALLOCATED, S.RESEARCHING, "Channel research started"),
+        (S.RESEARCHING, S.AWAITING_APPROVAL, "Recommendations ready for approval"),
+        (S.AWAITING_APPROVAL, S.EXECUTING_BOOKINGS, "Approvals granted, executing"),
+        (S.EXECUTING_BOOKINGS, S.COMPLETED, "All bookings executed"),
+
+        # Failure from active states
+        (S.BRIEF_RECEIVED, S.FAILED, "Brief processing failed"),
+        (S.BUDGET_ALLOCATED, S.FAILED, "Budget allocation failed"),
+        (S.RESEARCHING, S.FAILED, "Research failed"),
+        (S.AWAITING_APPROVAL, S.FAILED, "Approval process failed"),
+        (S.EXECUTING_BOOKINGS, S.FAILED, "Booking execution failed"),
+
+        # Recovery
+        (S.VALIDATION_FAILED, S.INITIALIZED, "Reset after validation failure"),
+        (S.FAILED, S.INITIALIZED, "Reset after failure"),
+    ]
+
+    return [
+        TransitionRule(from_status=f, to_status=t, description=d)
+        for f, t, d in transitions
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Deal State Machine
+# ---------------------------------------------------------------------------
+
+
+class DealStateMachine(_BaseStateMachine):
+    """State machine for buyer deal lifecycle management.
+
+    Provides:
+    - Configurable transition rules with guard conditions
+    - Full audit trail of every state change
+    - Query helpers for allowed next states
+    - Linear TV extensions (makegood_pending, partially_canceled)
+    """
+
+    def __init__(
+        self,
+        order_id: str,
+        initial_status: BuyerDealStatus = BuyerDealStatus.QUOTED,
+        rules: Optional[list[TransitionRule]] = None,
+    ):
+        super().__init__(
+            order_id=order_id,
+            initial_status=initial_status,
+            rules=rules if rules is not None else _build_deal_rules(),
+        )
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: dict[str, Any],
+        rules: Optional[list[TransitionRule]] = None,
+    ) -> "DealStateMachine":
+        """Restore a machine from stored state."""
+        machine = cls(
+            order_id=data["order_id"],
+            initial_status=BuyerDealStatus(data["status"]),
+            rules=rules,
+        )
+        audit_data = data.get("audit_log", {})
+        if audit_data:
+            machine._audit = OrderAuditLog(**audit_data)
+        return machine
+
+
+# ---------------------------------------------------------------------------
+# Campaign State Machine
+# ---------------------------------------------------------------------------
+
+
+class CampaignStateMachine(_BaseStateMachine):
+    """State machine for buyer campaign/booking lifecycle.
+
+    Maps to the existing ExecutionStatus-based flow in DealBookingFlow.
+    """
+
+    def __init__(
+        self,
+        order_id: str,
+        initial_status: BuyerCampaignStatus = BuyerCampaignStatus.INITIALIZED,
+        rules: Optional[list[TransitionRule]] = None,
+    ):
+        super().__init__(
+            order_id=order_id,
+            initial_status=initial_status,
+            rules=rules if rules is not None else _build_campaign_rules(),
+        )
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: dict[str, Any],
+        rules: Optional[list[TransitionRule]] = None,
+    ) -> "CampaignStateMachine":
+        """Restore a machine from stored state."""
+        machine = cls(
+            order_id=data["order_id"],
+            initial_status=BuyerCampaignStatus(data["status"]),
+            rules=rules,
+        )
+        audit_data = data.get("audit_log", {})
+        if audit_data:
+            machine._audit = OrderAuditLog(**audit_data)
+        return machine
+
+
+# ---------------------------------------------------------------------------
+# Mapping helpers -- bridge old enums to the new status enums
+# ---------------------------------------------------------------------------
+
+
+_EXECUTION_STATUS_MAP: dict[str, BuyerCampaignStatus] = {
+    "initialized": BuyerCampaignStatus.INITIALIZED,
+    "brief_received": BuyerCampaignStatus.BRIEF_RECEIVED,
+    "validation_failed": BuyerCampaignStatus.VALIDATION_FAILED,
+    "budget_allocated": BuyerCampaignStatus.BUDGET_ALLOCATED,
+    "researching": BuyerCampaignStatus.RESEARCHING,
+    "awaiting_approval": BuyerCampaignStatus.AWAITING_APPROVAL,
+    "executing_bookings": BuyerCampaignStatus.EXECUTING_BOOKINGS,
+    "completed": BuyerCampaignStatus.COMPLETED,
+    "failed": BuyerCampaignStatus.FAILED,
+}
+
+_DSP_FLOW_STATUS_MAP: dict[str, BuyerDealStatus] = {
+    "initialized": BuyerDealStatus.QUOTED,
+    "request_received": BuyerDealStatus.QUOTED,
+    "discovering_inventory": BuyerDealStatus.QUOTED,
+    "evaluating_pricing": BuyerDealStatus.NEGOTIATING,
+    "requesting_deal": BuyerDealStatus.BOOKING,
+    "deal_created": BuyerDealStatus.BOOKED,
+    "failed": BuyerDealStatus.FAILED,
+}
+
+
+def from_execution_status(value: str) -> BuyerCampaignStatus:
+    """Map a legacy ExecutionStatus value to BuyerCampaignStatus."""
+    return _EXECUTION_STATUS_MAP.get(value, BuyerCampaignStatus.INITIALIZED)
+
+
+def from_dsp_flow_status(value: str) -> BuyerDealStatus:
+    """Map a legacy DSPFlowStatus value to BuyerDealStatus."""
+    return _DSP_FLOW_STATUS_MAP.get(value, BuyerDealStatus.QUOTED)

--- a/src/ad_buyer/storage/deal_store.py
+++ b/src/ad_buyer/storage/deal_store.py
@@ -19,6 +19,11 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional
 
+from ..models.state_machine import (
+    BuyerDealStatus,
+    DealStateMachine,
+    InvalidTransitionError,
+)
 from .schema import initialize_schema
 
 logger = logging.getLogger(__name__)
@@ -222,6 +227,12 @@ class DealStore:
     ) -> bool:
         """Update a deal's status and log the transition.
 
+        When both the current status and new_status are valid
+        BuyerDealStatus values, the state machine enforces that only
+        allowed transitions are executed.  If the current status is not
+        a recognized BuyerDealStatus (e.g. a legacy value), the update
+        proceeds without validation for backward compatibility.
+
         Args:
             deal_id: The deal to update.
             new_status: Target status value.
@@ -229,7 +240,9 @@ class DealStore:
             notes: Optional note for the audit log.
 
         Returns:
-            True if the deal was found and updated.
+            True if the deal was found and updated, False if the deal
+            was not found or the transition was rejected by the state
+            machine.
         """
         now = _now_iso()
 
@@ -243,6 +256,27 @@ class DealStore:
                 return False
 
             old_status = row["status"]
+
+            # Enforce state machine if both statuses are known
+            try:
+                old_deal_status = BuyerDealStatus(old_status)
+                new_deal_status = BuyerDealStatus(new_status)
+                # Build a throwaway machine to validate the transition
+                sm = DealStateMachine(
+                    deal_id, initial_status=old_deal_status
+                )
+                if not sm.can_transition(new_deal_status):
+                    logger.warning(
+                        "Rejected transition for deal %s: %s -> %s",
+                        deal_id,
+                        old_status,
+                        new_status,
+                    )
+                    return False
+            except ValueError:
+                # One or both statuses are not BuyerDealStatus members;
+                # skip validation for backward compatibility.
+                pass
 
             self._conn.execute(
                 "UPDATE deals SET status = ?, updated_at = ? WHERE id = ?",

--- a/tests/unit/test_state_machine.py
+++ b/tests/unit/test_state_machine.py
@@ -1,0 +1,570 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Tests for buyer order state machine.
+
+Covers:
+- BuyerDealStatus enum completeness
+- BuyerCampaignStatus enum mapping to ExecutionStatus
+- Transition enforcement (valid and invalid)
+- Guard conditions
+- Audit trail recording
+- Linear TV lifecycle states
+- DealStore integration
+- Serialization round-trip
+"""
+
+import pytest
+
+from ad_buyer.models.state_machine import (
+    BuyerCampaignStatus,
+    BuyerDealStatus,
+    DealStateMachine,
+    CampaignStateMachine,
+    InvalidTransitionError,
+    StateTransition,
+    OrderAuditLog,
+    TransitionRule,
+    GuardFn,
+    from_execution_status,
+    from_dsp_flow_status,
+)
+
+
+# ---------------------------------------------------------------------------
+# BuyerDealStatus enum
+# ---------------------------------------------------------------------------
+
+
+class TestBuyerDealStatus:
+    """Test the BuyerDealStatus enum has all required states."""
+
+    def test_happy_path_states_exist(self):
+        """Verify all buyer deal lifecycle states are defined."""
+        expected = [
+            "quoted", "negotiating", "accepted", "booking",
+            "booked", "delivering", "completed",
+        ]
+        for state in expected:
+            assert hasattr(BuyerDealStatus, state.upper()), f"Missing state: {state}"
+
+    def test_terminal_states_exist(self):
+        """Verify terminal/error states are defined."""
+        for state in ["failed", "cancelled", "expired"]:
+            assert hasattr(BuyerDealStatus, state.upper()), f"Missing state: {state}"
+
+    def test_linear_tv_states_exist(self):
+        """Verify linear TV specific states are defined."""
+        assert hasattr(BuyerDealStatus, "MAKEGOOD_PENDING")
+        assert hasattr(BuyerDealStatus, "PARTIALLY_CANCELED")
+
+    def test_enum_values_are_lowercase(self):
+        """Ensure enum values are lowercase strings."""
+        for member in BuyerDealStatus:
+            assert member.value == member.value.lower()
+
+    def test_is_str_enum(self):
+        """BuyerDealStatus should be a str enum for serialization."""
+        assert isinstance(BuyerDealStatus.QUOTED, str)
+        assert BuyerDealStatus.QUOTED == "quoted"
+
+
+# ---------------------------------------------------------------------------
+# BuyerCampaignStatus enum
+# ---------------------------------------------------------------------------
+
+
+class TestBuyerCampaignStatus:
+    """Test the BuyerCampaignStatus enum maps to existing ExecutionStatus."""
+
+    def test_campaign_states_exist(self):
+        """Verify campaign lifecycle states exist."""
+        expected = [
+            "initialized", "brief_received", "budget_allocated",
+            "researching", "awaiting_approval", "executing_bookings",
+            "completed", "failed", "validation_failed",
+        ]
+        for state in expected:
+            assert hasattr(BuyerCampaignStatus, state.upper()), f"Missing state: {state}"
+
+    def test_is_str_enum(self):
+        """BuyerCampaignStatus should be a str enum."""
+        assert isinstance(BuyerCampaignStatus.INITIALIZED, str)
+
+
+# ---------------------------------------------------------------------------
+# DealStateMachine transitions
+# ---------------------------------------------------------------------------
+
+
+class TestDealStateMachineTransitions:
+    """Test valid and invalid state transitions for deals."""
+
+    def test_happy_path_quoted_to_completed(self):
+        """Walk the full happy path from quoted to completed."""
+        sm = DealStateMachine("deal-001")
+        assert sm.status == BuyerDealStatus.QUOTED
+
+        sm.transition(BuyerDealStatus.NEGOTIATING)
+        assert sm.status == BuyerDealStatus.NEGOTIATING
+
+        sm.transition(BuyerDealStatus.ACCEPTED)
+        assert sm.status == BuyerDealStatus.ACCEPTED
+
+        sm.transition(BuyerDealStatus.BOOKING)
+        assert sm.status == BuyerDealStatus.BOOKING
+
+        sm.transition(BuyerDealStatus.BOOKED)
+        assert sm.status == BuyerDealStatus.BOOKED
+
+        sm.transition(BuyerDealStatus.DELIVERING)
+        assert sm.status == BuyerDealStatus.DELIVERING
+
+        sm.transition(BuyerDealStatus.COMPLETED)
+        assert sm.status == BuyerDealStatus.COMPLETED
+
+    def test_quoted_directly_to_accepted(self):
+        """Auto-accept a quote without negotiation rounds."""
+        sm = DealStateMachine("deal-002")
+        sm.transition(BuyerDealStatus.ACCEPTED)
+        assert sm.status == BuyerDealStatus.ACCEPTED
+
+    def test_invalid_transition_raises(self):
+        """Transitioning from quoted directly to completed must fail."""
+        sm = DealStateMachine("deal-003")
+        with pytest.raises(InvalidTransitionError) as exc_info:
+            sm.transition(BuyerDealStatus.COMPLETED)
+        assert "deal-003" in str(exc_info.value)
+        assert "quoted" in str(exc_info.value)
+        assert "completed" in str(exc_info.value)
+
+    def test_invalid_transition_preserves_state(self):
+        """An invalid transition must NOT change the current state."""
+        sm = DealStateMachine("deal-004")
+        with pytest.raises(InvalidTransitionError):
+            sm.transition(BuyerDealStatus.DELIVERING)
+        assert sm.status == BuyerDealStatus.QUOTED
+
+    def test_cancellation_from_active_states(self):
+        """Cancellation should be allowed from any non-terminal state."""
+        cancellable_states = [
+            BuyerDealStatus.QUOTED,
+            BuyerDealStatus.NEGOTIATING,
+            BuyerDealStatus.ACCEPTED,
+            BuyerDealStatus.BOOKING,
+            BuyerDealStatus.BOOKED,
+        ]
+        for idx, state in enumerate(cancellable_states):
+            sm = DealStateMachine(f"deal-cancel-{idx}", initial_status=state)
+            sm.transition(BuyerDealStatus.CANCELLED)
+            assert sm.status == BuyerDealStatus.CANCELLED
+
+    def test_failure_from_booking(self):
+        """Booking can fail."""
+        sm = DealStateMachine("deal-fail-booking", initial_status=BuyerDealStatus.BOOKING)
+        sm.transition(BuyerDealStatus.FAILED)
+        assert sm.status == BuyerDealStatus.FAILED
+
+    def test_expiry_from_quoted(self):
+        """A quoted deal can expire."""
+        sm = DealStateMachine("deal-expire")
+        sm.transition(BuyerDealStatus.EXPIRED)
+        assert sm.status == BuyerDealStatus.EXPIRED
+
+    def test_cannot_transition_from_terminal_state(self):
+        """Once completed, no further transitions allowed (except by custom rule)."""
+        sm = DealStateMachine("deal-terminal", initial_status=BuyerDealStatus.COMPLETED)
+        with pytest.raises(InvalidTransitionError):
+            sm.transition(BuyerDealStatus.DELIVERING)
+
+    def test_allowed_transitions_from_quoted(self):
+        """Check the allowed next states from quoted."""
+        sm = DealStateMachine("deal-allowed")
+        allowed = sm.allowed_transitions()
+        assert BuyerDealStatus.NEGOTIATING in allowed
+        assert BuyerDealStatus.ACCEPTED in allowed
+        assert BuyerDealStatus.CANCELLED in allowed
+        assert BuyerDealStatus.EXPIRED in allowed
+        # Should NOT include terminal-only destinations
+        assert BuyerDealStatus.COMPLETED not in allowed
+
+    def test_can_transition_returns_bool(self):
+        """can_transition should return True/False without side effects."""
+        sm = DealStateMachine("deal-check")
+        assert sm.can_transition(BuyerDealStatus.NEGOTIATING) is True
+        assert sm.can_transition(BuyerDealStatus.COMPLETED) is False
+        # State unchanged
+        assert sm.status == BuyerDealStatus.QUOTED
+
+
+# ---------------------------------------------------------------------------
+# Linear TV states
+# ---------------------------------------------------------------------------
+
+
+class TestLinearTVLifecycle:
+    """Test linear TV specific transitions."""
+
+    def test_delivering_to_makegood_pending(self):
+        """A delivering deal can move to makegood_pending."""
+        sm = DealStateMachine("deal-tv-1", initial_status=BuyerDealStatus.DELIVERING)
+        sm.transition(BuyerDealStatus.MAKEGOOD_PENDING)
+        assert sm.status == BuyerDealStatus.MAKEGOOD_PENDING
+
+    def test_makegood_pending_to_delivering(self):
+        """After makegood resolved, return to delivering."""
+        sm = DealStateMachine("deal-tv-2", initial_status=BuyerDealStatus.MAKEGOOD_PENDING)
+        sm.transition(BuyerDealStatus.DELIVERING)
+        assert sm.status == BuyerDealStatus.DELIVERING
+
+    def test_booked_to_partially_canceled(self):
+        """A booked deal can be partially canceled."""
+        sm = DealStateMachine("deal-tv-3", initial_status=BuyerDealStatus.BOOKED)
+        sm.transition(BuyerDealStatus.PARTIALLY_CANCELED)
+        assert sm.status == BuyerDealStatus.PARTIALLY_CANCELED
+
+    def test_partially_canceled_to_delivering(self):
+        """A partially canceled deal can still deliver."""
+        sm = DealStateMachine("deal-tv-4", initial_status=BuyerDealStatus.PARTIALLY_CANCELED)
+        sm.transition(BuyerDealStatus.DELIVERING)
+        assert sm.status == BuyerDealStatus.DELIVERING
+
+
+# ---------------------------------------------------------------------------
+# Guard conditions
+# ---------------------------------------------------------------------------
+
+
+class TestGuardConditions:
+    """Test guard functions on transitions."""
+
+    def test_guard_blocks_transition(self):
+        """A guard returning False should block the transition."""
+        def reject_guard(order_id, from_s, to_s, ctx):
+            return False
+
+        rule = TransitionRule(
+            from_status=BuyerDealStatus.QUOTED,
+            to_status=BuyerDealStatus.NEGOTIATING,
+            guard=reject_guard,
+            description="Always reject",
+        )
+        sm = DealStateMachine("deal-guard-1", rules=[rule])
+        with pytest.raises(InvalidTransitionError) as exc_info:
+            sm.transition(BuyerDealStatus.NEGOTIATING)
+        assert "guard condition failed" in str(exc_info.value)
+
+    def test_guard_allows_transition(self):
+        """A guard returning True should allow the transition."""
+        def allow_guard(order_id, from_s, to_s, ctx):
+            return True
+
+        rule = TransitionRule(
+            from_status=BuyerDealStatus.QUOTED,
+            to_status=BuyerDealStatus.NEGOTIATING,
+            guard=allow_guard,
+            description="Always allow",
+        )
+        sm = DealStateMachine("deal-guard-2", rules=[rule])
+        sm.transition(BuyerDealStatus.NEGOTIATING)
+        assert sm.status == BuyerDealStatus.NEGOTIATING
+
+    def test_guard_receives_context(self):
+        """Guard should receive the context dict passed to transition()."""
+        received_ctx = {}
+
+        def capture_guard(order_id, from_s, to_s, ctx):
+            received_ctx.update(ctx)
+            return True
+
+        rule = TransitionRule(
+            from_status=BuyerDealStatus.QUOTED,
+            to_status=BuyerDealStatus.NEGOTIATING,
+            guard=capture_guard,
+            description="Captures context",
+        )
+        sm = DealStateMachine("deal-guard-3", rules=[rule])
+        sm.transition(BuyerDealStatus.NEGOTIATING, context={"budget": 50000})
+        assert received_ctx == {"budget": 50000}
+
+
+# ---------------------------------------------------------------------------
+# Audit trail
+# ---------------------------------------------------------------------------
+
+
+class TestAuditTrail:
+    """Test that every transition is recorded in the audit log."""
+
+    def test_single_transition_recorded(self):
+        """A single transition should produce one audit entry."""
+        sm = DealStateMachine("deal-audit-1")
+        sm.transition(BuyerDealStatus.NEGOTIATING, actor="agent:dsp", reason="Starting negotiation")
+
+        assert len(sm.history) == 1
+        entry = sm.history[0]
+        assert entry.from_status == BuyerDealStatus.QUOTED
+        assert entry.to_status == BuyerDealStatus.NEGOTIATING
+        assert entry.actor == "agent:dsp"
+        assert entry.reason == "Starting negotiation"
+
+    def test_multiple_transitions_recorded(self):
+        """Multiple transitions accumulate in the audit log."""
+        sm = DealStateMachine("deal-audit-2")
+        sm.transition(BuyerDealStatus.NEGOTIATING)
+        sm.transition(BuyerDealStatus.ACCEPTED)
+        sm.transition(BuyerDealStatus.BOOKING)
+
+        assert len(sm.history) == 3
+        assert sm.history[0].to_status == BuyerDealStatus.NEGOTIATING
+        assert sm.history[1].to_status == BuyerDealStatus.ACCEPTED
+        assert sm.history[2].to_status == BuyerDealStatus.BOOKING
+
+    def test_audit_log_current_status(self):
+        """audit_log.current_status should track the latest transition."""
+        sm = DealStateMachine("deal-audit-3")
+        sm.transition(BuyerDealStatus.NEGOTIATING)
+        sm.transition(BuyerDealStatus.ACCEPTED)
+
+        assert sm.audit_log.current_status == BuyerDealStatus.ACCEPTED
+
+    def test_transition_has_timestamp(self):
+        """Each transition record should have a timestamp."""
+        sm = DealStateMachine("deal-audit-4")
+        record = sm.transition(BuyerDealStatus.NEGOTIATING)
+        assert record.timestamp is not None
+
+    def test_transition_has_unique_id(self):
+        """Each transition record should have a unique ID."""
+        sm = DealStateMachine("deal-audit-5")
+        r1 = sm.transition(BuyerDealStatus.NEGOTIATING)
+        r2 = sm.transition(BuyerDealStatus.ACCEPTED)
+        assert r1.transition_id != r2.transition_id
+
+    def test_metadata_stored_in_transition(self):
+        """Custom metadata should be stored in the transition record."""
+        sm = DealStateMachine("deal-audit-6")
+        record = sm.transition(
+            BuyerDealStatus.NEGOTIATING,
+            metadata={"round": 1, "offer_cpm": 12.50},
+        )
+        assert record.metadata == {"round": 1, "offer_cpm": 12.50}
+
+    def test_failed_transition_not_recorded(self):
+        """Invalid transitions should NOT create audit entries."""
+        sm = DealStateMachine("deal-audit-7")
+        with pytest.raises(InvalidTransitionError):
+            sm.transition(BuyerDealStatus.COMPLETED)
+        assert len(sm.history) == 0
+
+
+# ---------------------------------------------------------------------------
+# CampaignStateMachine
+# ---------------------------------------------------------------------------
+
+
+class TestCampaignStateMachine:
+    """Test campaign lifecycle state machine."""
+
+    def test_happy_path(self):
+        """Walk through the campaign booking flow happy path."""
+        sm = CampaignStateMachine("campaign-001")
+        assert sm.status == BuyerCampaignStatus.INITIALIZED
+
+        sm.transition(BuyerCampaignStatus.BRIEF_RECEIVED)
+        sm.transition(BuyerCampaignStatus.BUDGET_ALLOCATED)
+        sm.transition(BuyerCampaignStatus.RESEARCHING)
+        sm.transition(BuyerCampaignStatus.AWAITING_APPROVAL)
+        sm.transition(BuyerCampaignStatus.EXECUTING_BOOKINGS)
+        sm.transition(BuyerCampaignStatus.COMPLETED)
+
+        assert sm.status == BuyerCampaignStatus.COMPLETED
+        assert len(sm.history) == 6
+
+    def test_validation_failure(self):
+        """Brief received can go to validation_failed."""
+        sm = CampaignStateMachine("campaign-002")
+        sm.transition(BuyerCampaignStatus.BRIEF_RECEIVED)
+        sm.transition(BuyerCampaignStatus.VALIDATION_FAILED)
+        assert sm.status == BuyerCampaignStatus.VALIDATION_FAILED
+
+    def test_failure_during_execution(self):
+        """Execution bookings can fail."""
+        sm = CampaignStateMachine(
+            "campaign-003",
+            initial_status=BuyerCampaignStatus.EXECUTING_BOOKINGS,
+        )
+        sm.transition(BuyerCampaignStatus.FAILED)
+        assert sm.status == BuyerCampaignStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# Mapping helpers
+# ---------------------------------------------------------------------------
+
+
+class TestMappingHelpers:
+    """Test legacy enum mapping functions."""
+
+    def test_from_execution_status_initialized(self):
+        """Map ExecutionStatus.INITIALIZED to campaign status."""
+        result = from_execution_status("initialized")
+        assert result == BuyerCampaignStatus.INITIALIZED
+
+    def test_from_execution_status_completed(self):
+        result = from_execution_status("completed")
+        assert result == BuyerCampaignStatus.COMPLETED
+
+    def test_from_execution_status_unknown_returns_initialized(self):
+        """Unknown values should default to INITIALIZED."""
+        result = from_execution_status("unknown_value")
+        assert result == BuyerCampaignStatus.INITIALIZED
+
+    def test_from_dsp_flow_status_deal_created(self):
+        """Map DSPFlowStatus values to deal states."""
+        result = from_dsp_flow_status("deal_created")
+        assert result == BuyerDealStatus.BOOKED
+
+    def test_from_dsp_flow_status_failed(self):
+        result = from_dsp_flow_status("failed")
+        assert result == BuyerDealStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    """Test state machine serialization/deserialization."""
+
+    def test_round_trip(self):
+        """Serialize and deserialize a machine with history."""
+        sm = DealStateMachine("deal-serial-1")
+        sm.transition(BuyerDealStatus.NEGOTIATING, actor="test")
+        sm.transition(BuyerDealStatus.ACCEPTED, reason="Price agreed")
+
+        data = sm.to_dict()
+        restored = DealStateMachine.from_dict(data)
+
+        assert restored.order_id == "deal-serial-1"
+        assert restored.status == BuyerDealStatus.ACCEPTED
+        assert len(restored.history) == 2
+        assert restored.history[0].actor == "test"
+        assert restored.history[1].reason == "Price agreed"
+
+    def test_to_dict_structure(self):
+        """Verify the dict structure from to_dict()."""
+        sm = DealStateMachine("deal-serial-2")
+        data = sm.to_dict()
+
+        assert "order_id" in data
+        assert "status" in data
+        assert "audit_log" in data
+        assert data["status"] == "quoted"
+
+    def test_add_and_remove_rule(self):
+        """Test adding and removing custom rules."""
+        sm = DealStateMachine("deal-rules-1")
+        # Add a custom rule from completed back to quoted (normally not allowed)
+        custom_rule = TransitionRule(
+            from_status=BuyerDealStatus.COMPLETED,
+            to_status=BuyerDealStatus.QUOTED,
+            description="Re-quote after completion",
+        )
+        sm.add_rule(custom_rule)
+        assert sm.can_transition(BuyerDealStatus.COMPLETED) is False  # still at quoted
+        # Navigate to completed
+        sm2 = DealStateMachine("deal-rules-2", initial_status=BuyerDealStatus.COMPLETED)
+        sm2.add_rule(custom_rule)
+        assert sm2.can_transition(BuyerDealStatus.QUOTED) is True
+
+        # Remove the custom rule
+        removed = sm2.remove_rule(BuyerDealStatus.COMPLETED, BuyerDealStatus.QUOTED)
+        assert removed is True
+        assert sm2.can_transition(BuyerDealStatus.QUOTED) is False
+
+    def test_remove_nonexistent_rule_returns_false(self):
+        """Removing a rule that doesn't exist returns False."""
+        sm = DealStateMachine("deal-rules-3")
+        result = sm.remove_rule(BuyerDealStatus.COMPLETED, BuyerDealStatus.QUOTED)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# DealStore integration
+# ---------------------------------------------------------------------------
+
+
+class TestDealStoreIntegration:
+    """Test state machine enforcement in DealStore.update_deal_status()."""
+
+    def _make_store(self):
+        """Create an in-memory DealStore."""
+        from ad_buyer.storage.deal_store import DealStore
+        store = DealStore("sqlite:///:memory:")
+        store.connect()
+        return store
+
+    def test_valid_transition_succeeds(self):
+        """A valid transition via DealStore should update status."""
+        store = self._make_store()
+        deal_id = store.save_deal(
+            seller_url="http://seller.example.com",
+            product_id="prod_1",
+            status="quoted",
+        )
+        result = store.update_deal_status(deal_id, "negotiating")
+        assert result is True
+
+        deal = store.get_deal(deal_id)
+        assert deal["status"] == "negotiating"
+        store.disconnect()
+
+    def test_invalid_transition_rejected(self):
+        """An invalid transition via DealStore should be rejected."""
+        store = self._make_store()
+        deal_id = store.save_deal(
+            seller_url="http://seller.example.com",
+            product_id="prod_2",
+            status="quoted",
+        )
+        result = store.update_deal_status(deal_id, "completed")
+        assert result is False
+
+        # Status should remain unchanged
+        deal = store.get_deal(deal_id)
+        assert deal["status"] == "quoted"
+        store.disconnect()
+
+    def test_transition_audit_recorded_in_store(self):
+        """Valid transitions should be recorded in the status_transitions table."""
+        store = self._make_store()
+        deal_id = store.save_deal(
+            seller_url="http://seller.example.com",
+            product_id="prod_3",
+            status="quoted",
+        )
+        store.update_deal_status(deal_id, "negotiating", triggered_by="agent:dsp")
+        history = store.get_status_history("deal", deal_id)
+        # Initial creation + one transition
+        assert len(history) >= 2
+        last = history[-1]
+        assert last["from_status"] == "quoted"
+        assert last["to_status"] == "negotiating"
+        assert last["triggered_by"] == "agent:dsp"
+        store.disconnect()
+
+    def test_unknown_status_treated_as_unvalidated(self):
+        """Deals with non-BuyerDealStatus values bypass validation gracefully."""
+        store = self._make_store()
+        deal_id = store.save_deal(
+            seller_url="http://seller.example.com",
+            product_id="prod_4",
+            status="custom_legacy_status",
+        )
+        # When the current status is not a known BuyerDealStatus, the store
+        # should still allow the update (backward compatibility).
+        result = store.update_deal_status(deal_id, "completed")
+        assert result is True
+        store.disconnect()


### PR DESCRIPTION
## Summary
- Add formal state machine framework for buyer deal lifecycle (quoted -> negotiating -> accepted -> booking -> booked -> delivering -> completed, plus failed/cancelled/expired)
- Add campaign lifecycle state machine mapping to existing ExecutionStatus enum
- Add linear TV extension states: makegood_pending, partially_canceled
- Wire state machine enforcement into DealStore.update_deal_status() with backward compatibility for legacy statuses
- Wire into DealBookingFlow and DSPDealFlow persistence helpers

## Test plan
- [x] 47 new tests covering: enum completeness, happy path transitions, invalid transition rejection, guard conditions, audit trail recording, linear TV lifecycle, serialization round-trip, DealStore integration, backward compatibility
- [x] Full suite regression check: 1063 passed (6 pre-existing failures in test_agent_hierarchy.py unrelated to this change)
- [x] TDD workflow followed: tests written first, verified failing, then implemented

bead: buyer-5er

Generated with [Claude Code](https://claude.com/claude-code)