### PR TITLE
Add buyer event bus framework

### DIFF
--- a/src/ad_buyer/events/__init__.py
+++ b/src/ad_buyer/events/__init__.py
@@ -1,0 +1,19 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Event bus for buyer workflow observability and control."""
+
+from .bus import EventBus, InMemoryEventBus, close_event_bus, get_event_bus
+from .helpers import emit_event, emit_event_sync
+from .models import Event, EventType
+
+__all__ = [
+    "Event",
+    "EventType",
+    "EventBus",
+    "InMemoryEventBus",
+    "get_event_bus",
+    "close_event_bus",
+    "emit_event",
+    "emit_event_sync",
+]

--- a/src/ad_buyer/events/bus.py
+++ b/src/ad_buyer/events/bus.py
@@ -1,0 +1,129 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Event bus implementations for the buyer system.
+
+Provides abstract EventBus interface with InMemoryEventBus backend
+for development and testing. Pure stdlib + Pydantic, no external deps.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Callable, Optional
+
+from .models import Event
+
+logger = logging.getLogger(__name__)
+
+Subscriber = Callable[[Event], None]
+
+
+class EventBus(ABC):
+    """Abstract event bus interface."""
+
+    @abstractmethod
+    async def publish(self, event: Event) -> None:
+        """Publish an event."""
+
+    @abstractmethod
+    async def subscribe(self, event_type: str, callback: Subscriber) -> None:
+        """Subscribe to events of a given type.
+
+        Args:
+            event_type: EventType value or "*" for all events.
+            callback: Function called when matching event arrives.
+        """
+
+    @abstractmethod
+    async def get_event(self, event_id: str) -> Optional[Event]:
+        """Retrieve a persisted event by ID."""
+
+    @abstractmethod
+    async def list_events(
+        self,
+        flow_id: Optional[str] = None,
+        event_type: Optional[str] = None,
+        session_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> list[Event]:
+        """List persisted events, optionally filtered."""
+
+
+class InMemoryEventBus(EventBus):
+    """In-memory event bus for development and testing.
+
+    Events stored in a list. Subscribers called synchronously.
+    No persistence across restarts.
+    """
+
+    def __init__(self) -> None:
+        self._events: list[Event] = []
+        self._subscribers: dict[str, list[Subscriber]] = {}
+
+    async def publish(self, event: Event) -> None:
+        self._events.append(event)
+        logger.info("Event published: %s (id=%s)", event.event_type, event.event_id)
+        for cb in self._subscribers.get(event.event_type.value, []):
+            try:
+                cb(event)
+            except Exception as e:
+                logger.error("Subscriber error for %s: %s", event.event_type, e)
+        for cb in self._subscribers.get("*", []):
+            try:
+                cb(event)
+            except Exception as e:
+                logger.error("Subscriber error (wildcard): %s", e)
+
+    async def subscribe(self, event_type: str, callback: Subscriber) -> None:
+        self._subscribers.setdefault(event_type, []).append(callback)
+
+    async def get_event(self, event_id: str) -> Optional[Event]:
+        for ev in self._events:
+            if ev.event_id == event_id:
+                return ev
+        return None
+
+    async def list_events(
+        self,
+        flow_id: Optional[str] = None,
+        event_type: Optional[str] = None,
+        session_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> list[Event]:
+        results = self._events
+        if flow_id:
+            results = [e for e in results if e.flow_id == flow_id]
+        if event_type:
+            results = [e for e in results if e.event_type.value == event_type]
+        if session_id:
+            results = [e for e in results if e.session_id == session_id]
+        return results[-limit:]
+
+
+# ---------------------------------------------------------------------------
+# Factory / singleton
+# ---------------------------------------------------------------------------
+
+_event_bus_instance: Optional[EventBus] = None
+
+
+async def get_event_bus() -> EventBus:
+    """Get or create the global event bus instance.
+
+    Returns an InMemoryEventBus by default. The buyer system does not
+    currently have a shared storage backend like the seller, so we
+    always use the in-memory implementation.
+    """
+    global _event_bus_instance
+
+    if _event_bus_instance is not None:
+        return _event_bus_instance
+
+    _event_bus_instance = InMemoryEventBus()
+    return _event_bus_instance
+
+
+async def close_event_bus() -> None:
+    """Reset the global event bus instance."""
+    global _event_bus_instance
+    _event_bus_instance = None

--- a/src/ad_buyer/events/helpers.py
+++ b/src/ad_buyer/events/helpers.py
@@ -1,0 +1,110 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Helper functions for emitting events from flows.
+
+Thin wrappers that flows call. If the event bus is not configured
+or fails, they log and continue (fail-open).
+
+Provides both async (emit_event) and sync (emit_event_sync) variants.
+The sync variant is needed because CrewAI flow methods run synchronously
+in worker threads that may not have an asyncio event loop.
+"""
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+from .models import Event, EventType
+
+logger = logging.getLogger(__name__)
+
+
+async def emit_event(
+    event_type: EventType,
+    flow_id: str = "",
+    flow_type: str = "",
+    deal_id: str = "",
+    session_id: str = "",
+    payload: Optional[dict[str, Any]] = None,
+    **kwargs: Any,
+) -> Optional[Event]:
+    """Emit an event to the event bus. Fail-open: logs on error.
+
+    Returns the Event if published, None if the bus was unavailable.
+    """
+    try:
+        from .bus import get_event_bus
+
+        bus = await get_event_bus()
+        event = Event(
+            event_type=event_type,
+            flow_id=flow_id,
+            flow_type=flow_type,
+            deal_id=deal_id,
+            session_id=session_id,
+            payload=payload or {},
+            metadata=kwargs,
+        )
+        await bus.publish(event)
+        return event
+    except Exception as e:
+        logger.warning("Failed to emit event %s: %s", event_type, e)
+        return None
+
+
+def emit_event_sync(
+    event_type: EventType,
+    flow_id: str = "",
+    flow_type: str = "",
+    deal_id: str = "",
+    session_id: str = "",
+    payload: Optional[dict[str, Any]] = None,
+    **kwargs: Any,
+) -> Optional[Event]:
+    """Synchronous wrapper around emit_event for use in CrewAI flows.
+
+    CrewAI flow methods run synchronously in worker threads. This helper
+    handles the asyncio plumbing so callers don't have to.
+
+    Fail-open: never raises, returns None on error.
+    """
+    try:
+        from .bus import InMemoryEventBus, _event_bus_instance
+
+        # Fast path: if the singleton is an InMemoryEventBus, call
+        # publish directly via a new event loop to avoid issues with
+        # nested loops in worker threads.
+        bus = _event_bus_instance
+        if bus is None:
+            bus = InMemoryEventBus()
+            import ad_buyer.events.bus as bus_mod
+            bus_mod._event_bus_instance = bus
+
+        event = Event(
+            event_type=event_type,
+            flow_id=flow_id,
+            flow_type=flow_type,
+            deal_id=deal_id,
+            session_id=session_id,
+            payload=payload or {},
+            metadata=kwargs,
+        )
+
+        # Run the async publish in a new event loop (safe from worker threads)
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                # Already in an async context -- schedule on the running loop
+                import concurrent.futures
+                asyncio.ensure_future(bus.publish(event))
+            else:
+                loop.run_until_complete(bus.publish(event))
+        except RuntimeError:
+            # No event loop at all -- create one
+            asyncio.run(bus.publish(event))
+
+        return event
+    except Exception as e:
+        logger.warning("Failed to emit event (sync) %s: %s", event_type, e)
+        return None

--- a/src/ad_buyer/events/models.py
+++ b/src/ad_buyer/events/models.py
@@ -1,0 +1,62 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Event data models for the buyer event bus.
+
+Defines buyer-specific event types and the Event model used across
+the event bus, helpers, and API endpoints.
+"""
+
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class EventType(str, Enum):
+    """Types of events emitted by the buyer system."""
+
+    # Quote lifecycle
+    QUOTE_REQUESTED = "quote.requested"
+    QUOTE_RECEIVED = "quote.received"
+
+    # Deal lifecycle
+    DEAL_BOOKED = "deal.booked"
+    DEAL_CANCELLED = "deal.cancelled"
+
+    # Campaign lifecycle
+    CAMPAIGN_CREATED = "campaign.created"
+
+    # Budget lifecycle
+    BUDGET_ALLOCATED = "budget.allocated"
+
+    # Booking lifecycle
+    BOOKING_SUBMITTED = "booking.submitted"
+
+    # Inventory lifecycle
+    INVENTORY_DISCOVERED = "inventory.discovered"
+
+    # Negotiation lifecycle
+    NEGOTIATION_STARTED = "negotiation.started"
+    NEGOTIATION_ROUND = "negotiation.round"
+    NEGOTIATION_CONCLUDED = "negotiation.concluded"
+
+    # Session lifecycle
+    SESSION_CREATED = "session.created"
+    SESSION_CLOSED = "session.closed"
+
+
+class Event(BaseModel):
+    """An event emitted by the buyer system."""
+
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    event_type: EventType
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    flow_id: str = ""
+    flow_type: str = ""
+    deal_id: str = ""
+    session_id: str = ""
+    payload: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/src/ad_buyer/flows/deal_booking_flow.py
+++ b/src/ad_buyer/flows/deal_booking_flow.py
@@ -29,6 +29,8 @@ from ..models.flow_state import (
 )
 from ..models.state_machine import BuyerDealStatus, DealStateMachine, InvalidTransitionError
 from ..models.ucp import AudiencePlan, SignalType, UCPConsent
+from ..events.helpers import emit_event_sync
+from ..events.models import EventType
 from ..storage.deal_store import DealStore
 
 logger = logging.getLogger(__name__)
@@ -141,6 +143,13 @@ class DealBookingFlow(Flow[BookingState]):
 
         self.state.execution_status = ExecutionStatus.BRIEF_RECEIVED
         self.state.updated_at = datetime.utcnow()
+
+        # Emit campaign.created event
+        emit_event_sync(
+            EventType.CAMPAIGN_CREATED,
+            flow_type="deal_booking",
+            payload={"name": brief.get("name", ""), "budget": brief.get("budget", 0)},
+        )
 
         return {"status": "success", "brief": brief}
 
@@ -308,6 +317,16 @@ class DealBookingFlow(Flow[BookingState]):
 
             self.state.execution_status = ExecutionStatus.BUDGET_ALLOCATED
             self.state.updated_at = datetime.utcnow()
+
+            # Emit budget.allocated event
+            emit_event_sync(
+                EventType.BUDGET_ALLOCATED,
+                flow_type="deal_booking",
+                payload={
+                    "channels": list(self.state.budget_allocations.keys()),
+                    "total_budget": self.state.campaign_brief.get("budget", 0),
+                },
+            )
 
             return {
                 "status": "success",
@@ -630,6 +649,20 @@ class DealBookingFlow(Flow[BookingState]):
 
         self.state.execution_status = ExecutionStatus.COMPLETED
         self.state.updated_at = datetime.utcnow()
+
+        # Emit deal.booked event for each booked line
+        for booked in self.state.booked_lines:
+            emit_event_sync(
+                EventType.DEAL_BOOKED,
+                flow_type="deal_booking",
+                deal_id=getattr(booked, "line_id", ""),
+                payload={
+                    "product_id": booked.product_id,
+                    "channel": booked.channel,
+                    "impressions": booked.impressions,
+                    "cost": booked.cost,
+                },
+            )
 
         return {
             "status": "success",

--- a/src/ad_buyer/flows/dsp_deal_flow.py
+++ b/src/ad_buyer/flows/dsp_deal_flow.py
@@ -22,6 +22,8 @@ from ..models.buyer_identity import (
     DealResponse,
     DealType,
 )
+from ..events.helpers import emit_event_sync
+from ..events.models import EventType
 from ..models.state_machine import BuyerDealStatus, DealStateMachine, InvalidTransitionError
 from ..storage.deal_store import DealStore
 from ..tools.dsp import DiscoverInventoryTool, GetPricingTool, RequestDealTool
@@ -234,6 +236,18 @@ class DSPDealFlow(Flow[DSPFlowState]):
         self.state.status = DSPFlowStatus.REQUEST_RECEIVED
         self.state.updated_at = datetime.utcnow()
 
+        # Emit quote.requested event
+        emit_event_sync(
+            EventType.QUOTE_REQUESTED,
+            flow_type="dsp_deal",
+            payload={
+                "request": request[:200],
+                "deal_type": self.state.deal_type.value,
+                "impressions": self.state.impressions,
+                "max_cpm": self.state.max_cpm,
+            },
+        )
+
         # Persist initial deal record
         import json as _json
 
@@ -278,6 +292,13 @@ class DSPDealFlow(Flow[DSPFlowState]):
             # Parse discovery results (simplified - in production would parse structured data)
             # For now, store raw results and let the agent process
             self.state.updated_at = datetime.utcnow()
+
+            # Emit inventory.discovered event
+            emit_event_sync(
+                EventType.INVENTORY_DISCOVERED,
+                flow_type="dsp_deal",
+                payload={"query": self.state.request[:200]},
+            )
 
             return {
                 "status": "success",
@@ -341,6 +362,13 @@ Return the product_id of the best matching product and explain why.""",
             if product_id:
                 self.state.selected_product_id = product_id
                 self._persist_deal_status("evaluating_pricing")
+
+                # Emit quote.received event
+                emit_event_sync(
+                    EventType.QUOTE_RECEIVED,
+                    flow_type="dsp_deal",
+                    payload={"product_id": product_id},
+                )
 
                 # Get detailed pricing
                 pricing_result = self._pricing_tool._run(
@@ -414,6 +442,17 @@ Return the product_id of the best matching product and explain why.""",
 
             # Persist deal creation status
             self._persist_deal_status("deal_created")
+
+            # Emit deal.booked event
+            emit_event_sync(
+                EventType.DEAL_BOOKED,
+                flow_type="dsp_deal",
+                deal_id=self._store_deal_id or "",
+                payload={
+                    "product_id": product_id,
+                    "deal_type": self.state.deal_type.value,
+                },
+            )
 
             return {
                 "status": "success",

--- a/src/ad_buyer/interfaces/api/main.py
+++ b/src/ad_buyer/interfaces/api/main.py
@@ -47,6 +47,7 @@ app = FastAPI(
         {"name": "Health", "description": "Service health and readiness"},
         {"name": "Bookings", "description": "Campaign booking workflow lifecycle"},
         {"name": "Products", "description": "Seller inventory product search"},
+        {"name": "Events", "description": "Event bus query endpoints"},
     ],
 )
 
@@ -407,6 +408,50 @@ async def search_products(request: ProductSearchRequest) -> dict[str, Any]:
     )
 
     return {"results": result}
+
+
+# ---------------------------------------------------------------------------
+# Event endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.get("/events", tags=["Events"])
+async def list_events(
+    event_type: Optional[str] = None,
+    flow_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """List events from the event bus.
+
+    Queries the in-memory event bus for recent events, with optional
+    filtering by event_type, flow_id, or session_id.
+    """
+    from ...events.bus import get_event_bus
+
+    bus = await get_event_bus()
+    events = await bus.list_events(
+        flow_id=flow_id,
+        event_type=event_type,
+        session_id=session_id,
+        limit=limit,
+    )
+    return {
+        "events": [e.model_dump(mode="json") for e in events],
+        "total": len(events),
+    }
+
+
+@app.get("/events/{event_id}", tags=["Events"])
+async def get_event(event_id: str) -> dict[str, Any]:
+    """Retrieve a single event by ID."""
+    from ...events.bus import get_event_bus
+
+    bus = await get_event_bus()
+    event = await bus.get_event(event_id)
+    if event is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return event.model_dump(mode="json")
 
 
 async def _run_booking_flow(job_id: str, request: BookingRequest) -> None:

--- a/src/ad_buyer/storage/deal_store.py
+++ b/src/ad_buyer/storage/deal_store.py
@@ -573,6 +573,121 @@ class DealStore:
         return results
 
     # ------------------------------------------------------------------
+    # Events
+    # ------------------------------------------------------------------
+
+    def save_event(
+        self,
+        *,
+        event_id: Optional[str] = None,
+        event_type: str,
+        flow_id: str = "",
+        flow_type: str = "",
+        deal_id: str = "",
+        session_id: str = "",
+        payload: Optional[str] = None,
+        metadata: Optional[str] = None,
+    ) -> str:
+        """Persist an event to the events table.
+
+        Args:
+            event_id: Optional UUID. Generated if not provided.
+            event_type: Event type string (e.g. "deal.booked").
+            flow_id: Flow that produced this event.
+            flow_type: Type of flow (e.g. "deal_booking").
+            deal_id: Associated deal ID.
+            session_id: Associated session ID.
+            payload: JSON-serialized payload.
+            metadata: JSON-serialized metadata.
+
+        Returns:
+            The event ID (generated or provided).
+        """
+        if event_id is None:
+            event_id = str(uuid.uuid4())
+
+        with self._lock:
+            self._conn.execute(
+                """INSERT INTO events
+                   (id, event_type, flow_id, flow_type, deal_id,
+                    session_id, payload, metadata)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    event_id,
+                    event_type,
+                    flow_id,
+                    flow_type,
+                    deal_id,
+                    session_id,
+                    payload or "{}",
+                    metadata or "{}",
+                ),
+            )
+            self._conn.commit()
+
+        return event_id
+
+    def get_event(self, event_id: str) -> Optional[dict[str, Any]]:
+        """Retrieve an event by ID.
+
+        Args:
+            event_id: The event's primary key.
+
+        Returns:
+            Event as a dict, or None if not found.
+        """
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM events WHERE id = ?", (event_id,)
+            )
+            row = cursor.fetchone()
+        return dict(row) if row else None
+
+    def list_events(
+        self,
+        *,
+        event_type: Optional[str] = None,
+        flow_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """List events with optional filters.
+
+        Args:
+            event_type: Filter by event type.
+            flow_id: Filter by flow ID.
+            session_id: Filter by session ID.
+            limit: Maximum rows to return.
+
+        Returns:
+            List of event dicts ordered by created_at descending.
+        """
+        clauses: list[str] = []
+        params: list[Any] = []
+
+        if event_type is not None:
+            clauses.append("event_type = ?")
+            params.append(event_type)
+        if flow_id is not None:
+            clauses.append("flow_id = ?")
+            params.append(flow_id)
+        if session_id is not None:
+            clauses.append("session_id = ?")
+            params.append(session_id)
+
+        where = ""
+        if clauses:
+            where = "WHERE " + " AND ".join(clauses)
+
+        query = f"SELECT * FROM events {where} ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
+
+        with self._lock:
+            cursor = self._conn.execute(query, params)
+            rows = cursor.fetchall()
+        return [dict(r) for r in rows]
+
+    # ------------------------------------------------------------------
     # Status Transitions
     # ------------------------------------------------------------------
 

--- a/src/ad_buyer/storage/schema.py
+++ b/src/ad_buyer/storage/schema.py
@@ -3,12 +3,13 @@
 
 """Database schema definitions and migration runner for deal state persistence.
 
-Defines 5 relational tables for the deal lifecycle:
+Defines 6 relational tables for the deal lifecycle:
 - deals: Central deal tracking
 - negotiation_rounds: Per-round audit trail
 - booking_records: Booked line items
 - jobs: API-initiated booking jobs (replaces in-memory dict)
 - status_transitions: Append-only audit log
+- events: Event bus event persistence
 
 Uses a schema_version table for forward-compatible migrations.
 """
@@ -125,6 +126,28 @@ JOBS_INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_jobs_created_at ON jobs(created_at);",
 ]
 
+EVENTS_TABLE = """
+CREATE TABLE IF NOT EXISTS events (
+    id              TEXT PRIMARY KEY,
+    event_type      TEXT NOT NULL,
+    flow_id         TEXT NOT NULL DEFAULT '',
+    flow_type       TEXT NOT NULL DEFAULT '',
+    deal_id         TEXT NOT NULL DEFAULT '',
+    session_id      TEXT NOT NULL DEFAULT '',
+    payload         TEXT DEFAULT '{}',
+    metadata        TEXT DEFAULT '{}',
+    created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+"""
+
+EVENTS_INDEXES = [
+    "CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type);",
+    "CREATE INDEX IF NOT EXISTS idx_events_flow_id ON events(flow_id);",
+    "CREATE INDEX IF NOT EXISTS idx_events_deal_id ON events(deal_id);",
+    "CREATE INDEX IF NOT EXISTS idx_events_session_id ON events(session_id);",
+    "CREATE INDEX IF NOT EXISTS idx_events_created_at ON events(created_at);",
+]
+
 STATUS_TRANSITIONS_TABLE = """
 CREATE TABLE IF NOT EXISTS status_transitions (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -161,6 +184,7 @@ def create_tables(conn: sqlite3.Connection) -> None:
         NEGOTIATION_ROUNDS_TABLE,
         BOOKING_RECORDS_TABLE,
         JOBS_TABLE,
+        EVENTS_TABLE,
         STATUS_TRANSITIONS_TABLE,
     ]:
         cursor.execute(ddl)
@@ -171,6 +195,7 @@ def create_tables(conn: sqlite3.Connection) -> None:
         NEGOTIATION_ROUNDS_INDEXES,
         BOOKING_RECORDS_INDEXES,
         JOBS_INDEXES,
+        EVENTS_INDEXES,
         STATUS_TRANSITIONS_INDEXES,
     ]:
         for idx in index_list:

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -1,0 +1,480 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Tests for buyer event bus: models, bus, helpers, and API endpoints."""
+
+import asyncio
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# EventType enum tests
+# ---------------------------------------------------------------------------
+
+
+class TestEventType:
+    """Tests for buyer-specific EventType enum."""
+
+    def test_event_type_values_exist(self):
+        """All buyer event types must be defined."""
+        from ad_buyer.events.models import EventType
+
+        expected = [
+            "quote.requested",
+            "quote.received",
+            "deal.booked",
+            "deal.cancelled",
+            "campaign.created",
+            "budget.allocated",
+            "booking.submitted",
+            "inventory.discovered",
+            "negotiation.started",
+            "negotiation.round",
+            "negotiation.concluded",
+            "session.created",
+            "session.closed",
+        ]
+        actual_values = [e.value for e in EventType]
+        for val in expected:
+            assert val in actual_values, f"Missing EventType value: {val}"
+
+    def test_event_type_is_string_enum(self):
+        """EventType should be a str Enum for JSON serialization."""
+        from ad_buyer.events.models import EventType
+
+        assert isinstance(EventType.QUOTE_REQUESTED, str)
+        assert EventType.QUOTE_REQUESTED == "quote.requested"
+
+
+# ---------------------------------------------------------------------------
+# Event model tests
+# ---------------------------------------------------------------------------
+
+
+class TestEventModel:
+    """Tests for the Event Pydantic model."""
+
+    def test_event_creation_defaults(self):
+        """Event should auto-generate id and timestamp."""
+        from ad_buyer.events.models import Event, EventType
+
+        event = Event(event_type=EventType.DEAL_BOOKED)
+        assert event.event_id  # non-empty
+        assert isinstance(event.timestamp, datetime)
+        assert event.flow_id == ""
+        assert event.payload == {}
+
+    def test_event_creation_with_values(self):
+        """Event can be created with all fields."""
+        from ad_buyer.events.models import Event, EventType
+
+        event = Event(
+            event_type=EventType.QUOTE_REQUESTED,
+            flow_id="flow-1",
+            flow_type="deal_booking",
+            deal_id="deal-42",
+            session_id="sess-7",
+            payload={"amount": 1000},
+            metadata={"source": "test"},
+        )
+        assert event.event_type == EventType.QUOTE_REQUESTED
+        assert event.flow_id == "flow-1"
+        assert event.deal_id == "deal-42"
+        assert event.payload["amount"] == 1000
+
+    def test_event_serialization(self):
+        """Event should serialize to dict for storage."""
+        from ad_buyer.events.models import Event, EventType
+
+        event = Event(event_type=EventType.CAMPAIGN_CREATED, payload={"name": "Q1"})
+        data = event.model_dump(mode="json")
+        assert data["event_type"] == "campaign.created"
+        assert isinstance(data["timestamp"], str)
+
+
+# ---------------------------------------------------------------------------
+# InMemoryEventBus tests
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryEventBus:
+    """Tests for the InMemoryEventBus implementation."""
+
+    @pytest.fixture
+    def bus(self):
+        from ad_buyer.events.bus import InMemoryEventBus
+
+        return InMemoryEventBus()
+
+    def test_publish_stores_event(self, bus):
+        """Published event should be stored."""
+        from ad_buyer.events.models import Event, EventType
+
+        event = Event(event_type=EventType.DEAL_BOOKED)
+        asyncio.get_event_loop().run_until_complete(bus.publish(event))
+        assert len(bus._events) == 1
+        assert bus._events[0].event_id == event.event_id
+
+    def test_subscribe_receives_event(self, bus):
+        """Subscriber should be called on matching event type."""
+        from ad_buyer.events.models import Event, EventType
+
+        received = []
+        callback = lambda e: received.append(e)
+
+        asyncio.get_event_loop().run_until_complete(
+            bus.subscribe("deal.booked", callback)
+        )
+
+        event = Event(event_type=EventType.DEAL_BOOKED)
+        asyncio.get_event_loop().run_until_complete(bus.publish(event))
+
+        assert len(received) == 1
+        assert received[0].event_id == event.event_id
+
+    def test_wildcard_subscriber(self, bus):
+        """Wildcard subscriber should receive all events."""
+        from ad_buyer.events.models import Event, EventType
+
+        received = []
+        asyncio.get_event_loop().run_until_complete(
+            bus.subscribe("*", lambda e: received.append(e))
+        )
+
+        e1 = Event(event_type=EventType.DEAL_BOOKED)
+        e2 = Event(event_type=EventType.CAMPAIGN_CREATED)
+        asyncio.get_event_loop().run_until_complete(bus.publish(e1))
+        asyncio.get_event_loop().run_until_complete(bus.publish(e2))
+
+        assert len(received) == 2
+
+    def test_subscriber_error_does_not_break_bus(self, bus):
+        """Subscriber error should be caught; bus continues."""
+        from ad_buyer.events.models import Event, EventType
+
+        def bad_callback(e):
+            raise RuntimeError("boom")
+
+        asyncio.get_event_loop().run_until_complete(
+            bus.subscribe("deal.booked", bad_callback)
+        )
+
+        event = Event(event_type=EventType.DEAL_BOOKED)
+        # Should not raise
+        asyncio.get_event_loop().run_until_complete(bus.publish(event))
+        assert len(bus._events) == 1
+
+    def test_get_event(self, bus):
+        """Should retrieve a stored event by ID."""
+        from ad_buyer.events.models import Event, EventType
+
+        event = Event(event_type=EventType.BUDGET_ALLOCATED)
+        asyncio.get_event_loop().run_until_complete(bus.publish(event))
+
+        found = asyncio.get_event_loop().run_until_complete(
+            bus.get_event(event.event_id)
+        )
+        assert found is not None
+        assert found.event_id == event.event_id
+
+    def test_get_event_not_found(self, bus):
+        """Should return None for unknown event ID."""
+        result = asyncio.get_event_loop().run_until_complete(
+            bus.get_event("nonexistent")
+        )
+        assert result is None
+
+    def test_list_events_no_filter(self, bus):
+        """Should list all events with no filter."""
+        from ad_buyer.events.models import Event, EventType
+
+        for _ in range(3):
+            asyncio.get_event_loop().run_until_complete(
+                bus.publish(Event(event_type=EventType.DEAL_BOOKED))
+            )
+
+        events = asyncio.get_event_loop().run_until_complete(bus.list_events())
+        assert len(events) == 3
+
+    def test_list_events_by_flow_id(self, bus):
+        """Should filter events by flow_id."""
+        from ad_buyer.events.models import Event, EventType
+
+        asyncio.get_event_loop().run_until_complete(
+            bus.publish(Event(event_type=EventType.DEAL_BOOKED, flow_id="f1"))
+        )
+        asyncio.get_event_loop().run_until_complete(
+            bus.publish(Event(event_type=EventType.DEAL_BOOKED, flow_id="f2"))
+        )
+
+        events = asyncio.get_event_loop().run_until_complete(
+            bus.list_events(flow_id="f1")
+        )
+        assert len(events) == 1
+        assert events[0].flow_id == "f1"
+
+    def test_list_events_by_event_type(self, bus):
+        """Should filter events by event_type."""
+        from ad_buyer.events.models import Event, EventType
+
+        asyncio.get_event_loop().run_until_complete(
+            bus.publish(Event(event_type=EventType.DEAL_BOOKED))
+        )
+        asyncio.get_event_loop().run_until_complete(
+            bus.publish(Event(event_type=EventType.CAMPAIGN_CREATED))
+        )
+
+        events = asyncio.get_event_loop().run_until_complete(
+            bus.list_events(event_type="deal.booked")
+        )
+        assert len(events) == 1
+
+    def test_list_events_by_session_id(self, bus):
+        """Should filter events by session_id."""
+        from ad_buyer.events.models import Event, EventType
+
+        asyncio.get_event_loop().run_until_complete(
+            bus.publish(Event(event_type=EventType.SESSION_CREATED, session_id="s1"))
+        )
+        asyncio.get_event_loop().run_until_complete(
+            bus.publish(Event(event_type=EventType.SESSION_CLOSED, session_id="s2"))
+        )
+
+        events = asyncio.get_event_loop().run_until_complete(
+            bus.list_events(session_id="s1")
+        )
+        assert len(events) == 1
+
+    def test_list_events_limit(self, bus):
+        """Should respect the limit parameter."""
+        from ad_buyer.events.models import Event, EventType
+
+        for _ in range(10):
+            asyncio.get_event_loop().run_until_complete(
+                bus.publish(Event(event_type=EventType.DEAL_BOOKED))
+            )
+
+        events = asyncio.get_event_loop().run_until_complete(bus.list_events(limit=3))
+        assert len(events) == 3
+
+
+# ---------------------------------------------------------------------------
+# emit_event helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestEmitEvent:
+    """Tests for the fail-open emit_event helper."""
+
+    def test_emit_event_success(self):
+        """emit_event should publish and return the Event."""
+        from ad_buyer.events.helpers import emit_event
+        from ad_buyer.events.models import EventType
+
+        # Reset singleton
+        import ad_buyer.events.bus as bus_mod
+
+        bus_mod._event_bus_instance = None
+
+        event = asyncio.get_event_loop().run_until_complete(
+            emit_event(
+                event_type=EventType.DEAL_BOOKED,
+                flow_id="f1",
+                deal_id="d1",
+                payload={"price": 15.0},
+            )
+        )
+        assert event is not None
+        assert event.event_type == EventType.DEAL_BOOKED
+        assert event.deal_id == "d1"
+
+        # Cleanup
+        bus_mod._event_bus_instance = None
+
+    def test_emit_event_fail_open(self):
+        """emit_event should return None on failure, not raise."""
+        from ad_buyer.events.helpers import emit_event
+        from ad_buyer.events.models import EventType
+
+        import ad_buyer.events.bus as bus_mod
+
+        bus_mod._event_bus_instance = None
+
+        with patch(
+            "ad_buyer.events.bus.get_event_bus",
+            side_effect=RuntimeError("bus down"),
+        ):
+            result = asyncio.get_event_loop().run_until_complete(
+                emit_event(event_type=EventType.DEAL_BOOKED)
+            )
+            assert result is None
+
+        bus_mod._event_bus_instance = None
+
+
+# ---------------------------------------------------------------------------
+# get_event_bus singleton tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetEventBus:
+    """Tests for the get_event_bus factory."""
+
+    def test_returns_in_memory_bus(self):
+        """Should return an InMemoryEventBus by default."""
+        from ad_buyer.events.bus import InMemoryEventBus, get_event_bus
+
+        import ad_buyer.events.bus as bus_mod
+
+        bus_mod._event_bus_instance = None
+
+        bus = asyncio.get_event_loop().run_until_complete(get_event_bus())
+        assert isinstance(bus, InMemoryEventBus)
+
+        bus_mod._event_bus_instance = None
+
+    def test_returns_same_instance(self):
+        """Should return the same singleton instance."""
+        from ad_buyer.events.bus import get_event_bus
+
+        import ad_buyer.events.bus as bus_mod
+
+        bus_mod._event_bus_instance = None
+
+        bus1 = asyncio.get_event_loop().run_until_complete(get_event_bus())
+        bus2 = asyncio.get_event_loop().run_until_complete(get_event_bus())
+        assert bus1 is bus2
+
+        bus_mod._event_bus_instance = None
+
+    def test_close_resets_singleton(self):
+        """close_event_bus should reset the singleton."""
+        from ad_buyer.events.bus import close_event_bus, get_event_bus
+
+        import ad_buyer.events.bus as bus_mod
+
+        bus_mod._event_bus_instance = None
+
+        bus1 = asyncio.get_event_loop().run_until_complete(get_event_bus())
+        asyncio.get_event_loop().run_until_complete(close_event_bus())
+
+        bus2 = asyncio.get_event_loop().run_until_complete(get_event_bus())
+        assert bus1 is not bus2
+
+        bus_mod._event_bus_instance = None
+
+
+# ---------------------------------------------------------------------------
+# Module __init__ exports
+# ---------------------------------------------------------------------------
+
+
+class TestModuleExports:
+    """Tests for events module public API."""
+
+    def test_public_api(self):
+        """Events module should export all key names."""
+        import ad_buyer.events as events_mod
+
+        assert hasattr(events_mod, "Event")
+        assert hasattr(events_mod, "EventType")
+        assert hasattr(events_mod, "EventBus")
+        assert hasattr(events_mod, "InMemoryEventBus")
+        assert hasattr(events_mod, "get_event_bus")
+        assert hasattr(events_mod, "close_event_bus")
+        assert hasattr(events_mod, "emit_event")
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestEventAPIEndpoints:
+    """Tests for GET /events and GET /events/{event_id} endpoints."""
+
+    @pytest.fixture
+    def client(self):
+        """Create a test client."""
+        from fastapi.testclient import TestClient
+
+        from ad_buyer.interfaces.api.main import app
+
+        return TestClient(app)
+
+    def test_get_events_empty(self, client):
+        """GET /events should return empty list when no events."""
+        response = client.get("/events")
+        assert response.status_code == 200
+        data = response.json()
+        assert "events" in data
+        assert isinstance(data["events"], list)
+
+    def test_get_event_not_found(self, client):
+        """GET /events/{event_id} should return 404 for unknown ID."""
+        response = client.get("/events/nonexistent-id")
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DealStore event persistence tests (optional feature)
+# ---------------------------------------------------------------------------
+
+
+class TestDealStoreEventPersistence:
+    """Tests for SQLite-backed event persistence via DealStore."""
+
+    @pytest.fixture
+    def store(self):
+        """Create an in-memory DealStore."""
+        from ad_buyer.storage.deal_store import DealStore
+
+        s = DealStore("sqlite:///:memory:")
+        s.connect()
+        yield s
+        s.disconnect()
+
+    def test_save_and_get_event(self, store):
+        """Should save and retrieve an event."""
+        event_id = store.save_event(
+            event_type="deal.booked",
+            flow_id="f1",
+            deal_id="d1",
+            payload='{"price": 15.0}',
+        )
+        assert event_id
+
+        event = store.get_event(event_id)
+        assert event is not None
+        assert event["event_type"] == "deal.booked"
+        assert event["flow_id"] == "f1"
+        assert event["deal_id"] == "d1"
+
+    def test_list_events_filtered(self, store):
+        """Should filter events by type and flow_id."""
+        store.save_event(event_type="deal.booked", flow_id="f1")
+        store.save_event(event_type="deal.cancelled", flow_id="f1")
+        store.save_event(event_type="deal.booked", flow_id="f2")
+
+        # Filter by type
+        events = store.list_events(event_type="deal.booked")
+        assert len(events) == 2
+
+        # Filter by flow_id
+        events = store.list_events(flow_id="f1")
+        assert len(events) == 2
+
+        # Filter by both
+        events = store.list_events(event_type="deal.booked", flow_id="f1")
+        assert len(events) == 1
+
+    def test_list_events_limit(self, store):
+        """Should respect limit parameter."""
+        for _ in range(10):
+            store.save_event(event_type="deal.booked")
+
+        events = store.list_events(limit=3)
+        assert len(events) == 3


### PR DESCRIPTION
## Summary
- Adds `src/ad_buyer/events/` module with buyer-specific EventType enum (13 event types), Event model, InMemoryEventBus, EventBus ABC, and fail-open emit helpers (async + sync)
- Adds GET /events and GET /events/{event_id} API endpoints for querying the event bus
- Adds SQLite-backed event persistence (events table in DealStore with save_event/get_event/list_events)
- Wires emit_event_sync calls into DealBookingFlow (campaign.created, budget.allocated, deal.booked) and DSPDealFlow (quote.requested, inventory.discovered, quote.received, deal.booked)
- 27 new tests covering models, bus, helpers, singleton lifecycle, API endpoints, and persistence

## Test plan
- [x] 27 new tests pass (models, bus, helpers, singleton, API, persistence)
- [x] Full regression suite: 1043/1043 pass (6 pre-existing known-issue failures unrelated)
- [x] No new dependencies added (pure Pydantic + stdlib)

bead: buyer-cjx