### PR TITLE
docs: Replace state machine and event bus stubs with full documentation

### DIFF
--- a/docs/architecture/event-bus.md
+++ b/docs/architecture/event-bus.md
@@ -1,51 +1,484 @@
 # Event Bus
 
-!!! info "Coming Soon"
-    The event bus is planned for the buyer agent, based on the seller agent's implementation. This page describes the planned immutable event logging system for observability and auditability.
-
-The event bus provides an immutable, append-only event log for all significant actions within the buyer agent. Every deal quote, negotiation round, booking, state transition, and budget reallocation is recorded as an event — giving operators full observability into what the buyer agent did, when, and why.
+The event bus provides structured, append-only event logging for all significant actions in the buyer agent. Every quote request, negotiation round, deal booking, and budget allocation is recorded as a typed event --- giving operators full observability into what the buyer did, when, and why.
 
 ## Why an Event Bus
 
-The buyer agent currently logs actions through standard Python logging and persists deal state in the [DealStore](deal-store.md). An event bus adds structured, queryable event records that serve multiple purposes:
+Standard Python logging captures text messages. The event bus captures structured records that can be filtered, queried, and subscribed to programmatically:
 
-- **Auditability** — Regulators, advertisers, and agency partners can trace every action the buyer agent took on their behalf
-- **Debugging** — Reconstruct the exact sequence of events that led to a deal outcome
-- **Analytics** — Query historical events for reporting (e.g., average negotiation rounds, win rates by seller, time-to-book)
-- **Integration** — External systems can subscribe to events for real-time dashboards, alerting, or downstream processing
+- **Auditability** --- Regulators, advertisers, and agency partners can trace every action the buyer agent took on their behalf.
+- **Debugging** --- Reconstruct the exact sequence of events that led to a deal outcome by querying `flow_id` or `deal_id`.
+- **Analytics** --- Query historical events for reporting (e.g., average negotiation rounds, win rates by seller, time-to-book).
+- **Integration** --- External systems can subscribe to events for real-time dashboards, alerting, or downstream processing.
 
-## Planned Event Types
+!!! info "Fail-open by design"
+    Event emission never blocks or breaks the calling flow. If the bus is unavailable, the helpers log a warning and return `None`. Deal execution always takes priority over observability.
 
-| Event Type | Emitted When | Example Payload |
-|------------|-------------|-----------------|
-| `quote.requested` | Quote request sent to seller | `{seller_url, product_id, target_cpm}` |
-| `quote.received` | Quote response received | `{quote_id, final_cpm, expires_at}` |
-| `negotiation.started` | Negotiation session opened | `{proposal_id, strategy, opening_offer}` |
-| `negotiation.round` | Each negotiation round completes | `{round_number, buyer_price, seller_price, action}` |
-| `negotiation.completed` | Negotiation session ended | `{outcome, final_price, rounds_count}` |
-| `deal.booked` | Deal booking confirmed | `{deal_id, quote_id, final_cpm}` |
-| `deal.state_changed` | Deal status transition | `{deal_id, from_state, to_state, reason}` |
-| `budget.reallocation` | Budget shifted between deals/channels | `{from_deal, to_deal, amount, reason}` |
-| `creative.validated` | Creative spec validation completed | `{creative_id, format, result, violations}` |
+---
 
-## Seller Event Bus Reference
+## Event Model
 
-The seller agent already implements an event bus for server-side observability. The buyer's event bus will follow the same architectural pattern — immutable append-only log with structured events — applied to buyer-side actions.
+Every event is a Pydantic `Event` instance with the following fields:
 
-See the seller's event bus documentation: [Seller Event Bus](https://iabtechlab.github.io/seller-agent/event-bus/overview/)
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `event_id` | `str` | Auto-generated UUID | Unique identifier for this event |
+| `event_type` | `EventType` | *(required)* | Enum value identifying what happened |
+| `timestamp` | `datetime` | `datetime.utcnow()` | When the event was created |
+| `flow_id` | `str` | `""` | ID of the flow instance that produced this event |
+| `flow_type` | `str` | `""` | Type of flow (e.g., `"dsp_deal"`, `"deal_booking"`) |
+| `deal_id` | `str` | `""` | Associated deal ID, if applicable |
+| `session_id` | `str` | `""` | Associated session ID, if applicable |
+| `payload` | `dict[str, Any]` | `{}` | Event-specific data (see per-type examples below) |
+| `metadata` | `dict[str, Any]` | `{}` | Additional context passed via `**kwargs` to helpers |
 
-## Key Planned Functionality
+### Correlation
 
-- **Immutable event log** — Append-only storage; events are never modified or deleted
-- **Structured events** — Each event has a type, timestamp, actor, and typed payload
-- **Queryable history** — Filter and search events by type, time range, deal ID, seller, or actor
-- **Event subscriptions** — Register handlers that fire when specific event types are emitted
-- **Correlation IDs** — Trace a chain of related events across a multi-step workflow (e.g., from quote request through negotiation to booking)
-- **Retention policies** — Configurable retention periods for compliance and storage management
+Events can be correlated across a workflow using three keys:
+
+- **`flow_id`** --- Groups all events from a single flow execution.
+- **`deal_id`** --- Groups all events related to a specific deal across multiple flows.
+- **`session_id`** --- Groups all events within a user session.
+
+---
+
+## Event Types
+
+The `EventType` enum defines 13 event types organized by domain.
+
+### Quote Lifecycle
+
+| Event Type | Value | Emitted When | Example Payload |
+|------------|-------|--------------|-----------------|
+| `QUOTE_REQUESTED` | `quote.requested` | Quote request sent to seller | `{"request": "...", "deal_type": "PD"}` |
+| `QUOTE_RECEIVED` | `quote.received` | Pricing response received | `{"product_id": "prod-ctv-001"}` |
+
+### Deal Lifecycle
+
+| Event Type | Value | Emitted When | Example Payload |
+|------------|-------|--------------|-----------------|
+| `DEAL_BOOKED` | `deal.booked` | Deal booking confirmed | `{"product_id": "prod-001", "deal_id": "..."}` |
+| `DEAL_CANCELLED` | `deal.cancelled` | Deal cancelled | `{"deal_id": "...", "reason": "..."}` |
+
+### Campaign Lifecycle
+
+| Event Type | Value | Emitted When | Example Payload |
+|------------|-------|--------------|-----------------|
+| `CAMPAIGN_CREATED` | `campaign.created` | Campaign brief parsed | `{"name": "Q3 CTV", "budget": 50000}` |
+
+### Budget Lifecycle
+
+| Event Type | Value | Emitted When | Example Payload |
+|------------|-------|--------------|-----------------|
+| `BUDGET_ALLOCATED` | `budget.allocated` | Budget distributed across channels | `{"channels": ["ctv", "mobile"], "total_budget": 50000}` |
+
+### Booking Lifecycle
+
+| Event Type | Value | Emitted When | Example Payload |
+|------------|-------|--------------|-----------------|
+| `BOOKING_SUBMITTED` | `booking.submitted` | Booking request sent to seller | `{"order_id": "...", "line_id": "..."}` |
+
+### Inventory Lifecycle
+
+| Event Type | Value | Emitted When | Example Payload |
+|------------|-------|--------------|-----------------|
+| `INVENTORY_DISCOVERED` | `inventory.discovered` | Seller inventory query returned results | `{"query": "..."}` |
+
+### Negotiation Lifecycle
+
+| Event Type | Value | Emitted When | Example Payload |
+|------------|-------|--------------|-----------------|
+| `NEGOTIATION_STARTED` | `negotiation.started` | Negotiation session opened | `{"proposal_id": "...", "strategy": "anchor_high"}` |
+| `NEGOTIATION_ROUND` | `negotiation.round` | A negotiation round completed | `{"round": 2, "buyer_price": 12.0, "seller_price": 15.0}` |
+| `NEGOTIATION_CONCLUDED` | `negotiation.concluded` | Negotiation session ended | `{"outcome": "accepted", "final_price": 14.0}` |
+
+### Session Lifecycle
+
+| Event Type | Value | Emitted When | Example Payload |
+|------------|-------|--------------|-----------------|
+| `SESSION_CREATED` | `session.created` | New buyer session started | `{"session_id": "..."}` |
+| `SESSION_CLOSED` | `session.closed` | Buyer session ended | `{"session_id": "...", "deals_count": 3}` |
+
+---
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph Flows
+        DSP["DSPDealFlow"]
+        DBF["DealBookingFlow"]
+    end
+
+    subgraph "Event Helpers"
+        ES["emit_event_sync()"]
+        EA["emit_event()"]
+    end
+
+    subgraph "Event Bus"
+        BUS["InMemoryEventBus"]
+        SUBS["Subscribers"]
+    end
+
+    subgraph "Persistence"
+        STORE["DealStore.save_event()"]
+        DB[("SQLite events table")]
+    end
+
+    subgraph "API Layer"
+        LIST["/events"]
+        GET["/events/{event_id}"]
+    end
+
+    DSP -->|sync calls| ES
+    DBF -->|sync calls| ES
+    EA --> BUS
+    ES -->|async bridge| BUS
+    BUS -->|notify| SUBS
+    BUS --> LIST
+    BUS --> GET
+    STORE --> DB
+```
+
+---
+
+## InMemoryEventBus
+
+The `InMemoryEventBus` is the default (and currently only) backend. It stores events in a Python list and dispatches to subscribers synchronously during `publish()`.
+
+### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `publish` | `async (event: Event) -> None` | Append event to store, notify subscribers |
+| `subscribe` | `async (event_type: str, callback: Subscriber) -> None` | Register a callback for a specific event type or `"*"` for all |
+| `get_event` | `async (event_id: str) -> Event \| None` | Look up a single event by ID |
+| `list_events` | `async (flow_id?, event_type?, session_id?, limit=50) -> list[Event]` | Query events with optional filters |
+
+### Subscriber Dispatch
+
+When `publish()` is called:
+
+1. The event is appended to the internal list.
+2. All callbacks registered for the event's type are invoked.
+3. All callbacks registered for `"*"` (wildcard) are invoked.
+4. If a subscriber raises an exception, it is logged and the next subscriber is called. One failing subscriber never blocks others.
+
+```python
+from ad_buyer.events import get_event_bus, EventType, Event
+
+bus = await get_event_bus()
+
+# Subscribe to all deal.booked events
+async def on_deal_booked(event: Event):
+    print(f"Deal booked: {event.deal_id}")
+
+await bus.subscribe("deal.booked", on_deal_booked)
+
+# Subscribe to ALL events
+async def audit_logger(event: Event):
+    print(f"[AUDIT] {event.event_type}: {event.payload}")
+
+await bus.subscribe("*", audit_logger)
+```
+
+### Singleton Access
+
+The module provides a singleton factory:
+
+```python
+from ad_buyer.events.bus import get_event_bus, close_event_bus
+
+bus = await get_event_bus()   # Creates InMemoryEventBus on first call
+bus2 = await get_event_bus()  # Returns same instance
+assert bus is bus2
+
+await close_event_bus()       # Resets the singleton (for testing)
+```
+
+!!! warning "No persistence across restarts"
+    `InMemoryEventBus` stores events in a Python list. Events are lost when the process exits. For durable storage, events are separately persisted to the SQLite `events` table via `DealStore.save_event()`.
+
+---
+
+## Emitting Events
+
+Two helper functions make it easy to emit events from any code path. Both follow the fail-open pattern: they catch all exceptions, log a warning, and return `None`.
+
+### `emit_event()` --- Async
+
+Use in async code (FastAPI endpoints, async handlers):
+
+```python
+from ad_buyer.events.helpers import emit_event
+from ad_buyer.events.models import EventType
+
+event = await emit_event(
+    EventType.DEAL_BOOKED,
+    flow_id="flow-abc-123",
+    flow_type="dsp_deal",
+    deal_id="deal-456",
+    payload={
+        "product_id": "prod-ctv-sports-001",
+        "final_cpm": 14.50,
+    },
+)
+# event is an Event instance, or None if the bus was unavailable
+```
+
+### `emit_event_sync()` --- Synchronous
+
+Use in synchronous code, particularly CrewAI flow methods that run in worker threads without an asyncio event loop:
+
+```python
+from ad_buyer.events.helpers import emit_event_sync
+from ad_buyer.events.models import EventType
+
+event = emit_event_sync(
+    EventType.CAMPAIGN_CREATED,
+    flow_type="deal_booking",
+    payload={"name": "Q3 CTV Campaign", "budget": 50000},
+)
+```
+
+!!! tip "When to use which"
+    Use `emit_event_sync()` in CrewAI flow methods (`@listen`, `@start`, `@router` decorated methods). Use `emit_event()` in FastAPI endpoints and other async contexts. When in doubt, `emit_event_sync()` works everywhere.
+
+### How `emit_event_sync()` Works
+
+CrewAI runs flow steps in worker threads that may not have an asyncio event loop. The sync helper handles three scenarios:
+
+1. **Running event loop detected** --- Schedules the publish as a future on the existing loop.
+2. **Event loop exists but is not running** --- Calls `loop.run_until_complete()`.
+3. **No event loop at all** --- Creates a new loop via `asyncio.run()`.
+
+If the singleton bus does not exist yet, `emit_event_sync()` creates an `InMemoryEventBus` directly (bypassing the async `get_event_bus()` factory).
+
+### Helper Parameters
+
+Both `emit_event()` and `emit_event_sync()` accept the same parameters:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `event_type` | `EventType` | *(required)* | The type of event to emit |
+| `flow_id` | `str` | `""` | Flow instance identifier |
+| `flow_type` | `str` | `""` | Flow type name |
+| `deal_id` | `str` | `""` | Associated deal ID |
+| `session_id` | `str` | `""` | Associated session ID |
+| `payload` | `dict` | `None` | Event-specific data |
+| `**kwargs` | `Any` | --- | Extra key-value pairs stored in `metadata` |
+
+---
+
+## SQLite Persistence
+
+Events are persisted to a SQLite `events` table managed by the [DealStore](deal-store.md). This provides durability across process restarts, independent of the in-memory bus.
+
+### Events Table Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS events (
+    id              TEXT PRIMARY KEY,
+    event_type      TEXT NOT NULL,
+    flow_id         TEXT NOT NULL DEFAULT '',
+    flow_type       TEXT NOT NULL DEFAULT '',
+    deal_id         TEXT NOT NULL DEFAULT '',
+    session_id      TEXT NOT NULL DEFAULT '',
+    payload         TEXT DEFAULT '{}',
+    metadata        TEXT DEFAULT '{}',
+    created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+```
+
+### Indexes
+
+| Index | Column(s) | Purpose |
+|-------|-----------|---------|
+| `idx_events_type` | `event_type` | Filter by event type |
+| `idx_events_flow_id` | `flow_id` | Correlate events within a flow |
+| `idx_events_deal_id` | `deal_id` | Find all events for a deal |
+| `idx_events_session_id` | `session_id` | Find all events in a session |
+| `idx_events_created_at` | `created_at` | Time-range queries |
+
+### DealStore Event Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `save_event` | `(**kwargs) -> str` | Insert an event row. Returns the event ID (auto-generated if not provided). |
+| `get_event` | `(event_id: str) -> dict \| None` | Retrieve a single event by ID. |
+| `list_events` | `(event_type?, flow_id?, session_id?, limit=50) -> list[dict]` | Query events with optional filters, ordered by `created_at` descending. |
+
+```python
+from ad_buyer.storage.deal_store import DealStore
+import json
+
+store = DealStore("sqlite:///./ad_buyer.db")
+store.connect()
+
+# Persist an event
+event_id = store.save_event(
+    event_type="deal.booked",
+    flow_id="flow-abc",
+    deal_id="deal-456",
+    payload=json.dumps({"product_id": "prod-001", "cpm": 14.50}),
+)
+
+# Query events for a deal
+events = store.list_events(flow_id="flow-abc")
+```
+
+---
+
+## API Endpoints
+
+Two REST endpoints expose events from the in-memory bus.
+
+### `GET /events`
+
+List events with optional filters.
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `event_type` | `str` | `None` | Filter by event type value (e.g., `"deal.booked"`) |
+| `flow_id` | `str` | `None` | Filter by flow ID |
+| `session_id` | `str` | `None` | Filter by session ID |
+| `limit` | `int` | `50` | Maximum number of events to return |
+
+**Response:**
+
+```json
+{
+  "events": [
+    {
+      "event_id": "a1b2c3d4-...",
+      "event_type": "deal.booked",
+      "timestamp": "2026-03-11T14:30:00Z",
+      "flow_id": "flow-abc-123",
+      "flow_type": "dsp_deal",
+      "deal_id": "deal-456",
+      "session_id": "",
+      "payload": {"product_id": "prod-001", "final_cpm": 14.50},
+      "metadata": {}
+    }
+  ],
+  "total": 1
+}
+```
+
+### `GET /events/{event_id}`
+
+Retrieve a single event by ID.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `event_id` | `str` | The event's UUID |
+
+**Response:** The event object (same shape as array elements above).
+
+**Errors:** Returns `404` if the event ID is not found.
+
+!!! note "In-memory only"
+    These endpoints query the `InMemoryEventBus`, not the SQLite `events` table. Events are available only for the lifetime of the current process. For historical queries across restarts, query the DealStore directly.
+
+---
+
+## Event Flow Diagram
+
+This sequence diagram shows how events flow through the system during a typical DSP deal:
+
+```mermaid
+sequenceDiagram
+    participant Flow as DSPDealFlow
+    participant Helper as emit_event_sync()
+    participant Bus as InMemoryEventBus
+    participant Sub as Subscribers
+    participant API as GET /events
+
+    Flow->>Helper: emit_event_sync(QUOTE_REQUESTED, ...)
+    Helper->>Bus: publish(event)
+    Bus->>Bus: Append to event list
+    Bus->>Sub: Notify type subscribers
+    Bus->>Sub: Notify wildcard subscribers
+
+    Note over Flow: Seller responds...
+
+    Flow->>Helper: emit_event_sync(QUOTE_RECEIVED, ...)
+    Helper->>Bus: publish(event)
+
+    Note over Flow: Deal negotiated and booked...
+
+    Flow->>Helper: emit_event_sync(DEAL_BOOKED, ...)
+    Helper->>Bus: publish(event)
+
+    API->>Bus: list_events(flow_id=...)
+    Bus-->>API: [event1, event2, event3]
+```
+
+---
+
+## Usage Examples
+
+### Emitting Events from a Flow
+
+```python
+from ad_buyer.events.helpers import emit_event_sync
+from ad_buyer.events.models import EventType
+
+# In a CrewAI flow method
+def negotiate_price(self):
+    # ... negotiation logic ...
+
+    emit_event_sync(
+        EventType.NEGOTIATION_ROUND,
+        flow_id=self.state.flow_id,
+        flow_type="dsp_deal",
+        deal_id=self.state.deal_id,
+        payload={
+            "round": round_number,
+            "buyer_price": our_offer,
+            "seller_price": their_ask,
+            "action": "counter",
+        },
+    )
+```
+
+### Subscribing to Events
+
+```python
+from ad_buyer.events import get_event_bus, Event
+
+bus = await get_event_bus()
+
+def on_deal_booked(event: Event):
+    """React to deal bookings (e.g., update a dashboard)."""
+    print(f"New deal: {event.deal_id} at {event.payload.get('final_cpm')}")
+
+await bus.subscribe("deal.booked", on_deal_booked)
+```
+
+### Querying Events via API
+
+```bash
+# All events for a specific flow
+curl "http://localhost:8002/events?flow_id=flow-abc-123"
+
+# All deal.booked events
+curl "http://localhost:8002/events?event_type=deal.booked"
+
+# A specific event
+curl "http://localhost:8002/events/a1b2c3d4-5678-..."
+```
+
+---
 
 ## Related
 
-- [Deal Store](deal-store.md) — Current deal persistence (event bus complements, does not replace)
-- [Order State Machine](state-machine.md) — State transitions emit events to the event bus
-- [Architecture Overview](overview.md) — System architecture context
-- [Seller Event Bus](https://iabtechlab.github.io/seller-agent/event-bus/overview/) — Seller-side event bus implementation
+- [Deal Store](deal-store.md) --- SQLite persistence layer including the `events` table
+- [Order State Machine](state-machine.md) --- State transitions emit events for observability
+- [Architecture Overview](overview.md) --- System architecture context
+- [Booking Flow](booking-flow.md) --- End-to-end workflow that emits campaign and deal events
+- [Seller Event Bus](https://iabtechlab.github.io/seller-agent/event-bus/overview/) --- Seller-side event bus implementation

--- a/docs/architecture/state-machine.md
+++ b/docs/architecture/state-machine.md
@@ -1,56 +1,455 @@
 # Order State Machine
 
-!!! info "Coming Soon"
-    The formal order state machine is planned for the buyer agent, based on the seller agent's proven implementation. This page describes the planned state transition enforcement for the deal lifecycle.
-
-The order state machine enforces valid state transitions for deals as they move through their lifecycle — from initial quote through booking, activation, and completion. By formalizing state transitions, the buyer agent can guarantee that deals never enter invalid states and that every transition is auditable.
+The buyer agent enforces deal and campaign lifecycle transitions through a formal state machine. Every status change is validated against declared transition rules, optionally gated by guard conditions, and recorded in an immutable audit trail. Invalid transitions are rejected before they reach the database.
 
 ## Why a State Machine
 
-Today, deal status transitions in the buyer agent are tracked via the [DealStore](deal-store.md) and updated based on seller responses. The status field is a string that can be set freely. A formal state machine adds:
+Without transition enforcement, any code path can set a deal to any status --- a completed deal could accidentally revert to "quoted," or a cancelled deal could resume delivery. The state machine prevents this class of bugs at the model layer:
 
-- **Transition validation** — Only defined transitions are allowed (e.g., a `completed` deal cannot move back to `proposed`)
-- **Guard conditions** — Transitions can require preconditions (e.g., a deal cannot move to `active` without confirmed creative assets)
-- **Transition hooks** — Actions triggered automatically on state change (e.g., notify the campaign manager when a deal moves to `active`)
-- **Audit trail** — Every transition is logged with timestamp, actor, and reason
+- **Transition validation** --- Only declared `(from, to)` pairs are allowed. Everything else raises `InvalidTransitionError`.
+- **Guard conditions** --- A transition rule can attach an arbitrary predicate. The transition is blocked if the guard returns `False`.
+- **Audit trail** --- Every successful transition is appended to an `OrderAuditLog` with timestamp, actor, reason, and metadata.
+- **DealStore enforcement** --- `update_deal_status()` instantiates a throwaway `DealStateMachine` to validate the transition before writing to SQLite.
 
-## Planned State Transitions
+!!! info "Pure Pydantic + stdlib"
+    The state machine has zero external dependencies beyond Pydantic. No workflow engine or state chart library is required.
 
-The buyer-side deal lifecycle will follow these states:
+---
+
+## BuyerDealStatus
+
+The `BuyerDealStatus` enum defines 12 states for the buyer-side deal lifecycle.
+
+| Status | Category | Description |
+|--------|----------|-------------|
+| `quoted` | Entry | Initial quote received from seller |
+| `negotiating` | Negotiation | Active price negotiation in progress |
+| `accepted` | Acceptance | Deal terms accepted by buyer |
+| `booking` | Booking | Booking request sent to seller |
+| `booked` | Booking | Booking confirmed by seller |
+| `delivering` | Delivery | Campaign delivery in progress |
+| `completed` | Terminal | Campaign delivery finished successfully |
+| `failed` | Terminal | Unrecoverable error at any active stage |
+| `cancelled` | Terminal | Deal cancelled by buyer or seller |
+| `expired` | Terminal | Quote or negotiation timed out |
+| `makegood_pending` | Linear TV | Under-delivery detected, makegood requested |
+| `partially_canceled` | Linear TV | Some booked units cancelled, remainder proceeds |
+
+### Happy Path
 
 ```
-quoted --> proposed --> active --> completed
-  |          |           |
-  v          v           v
-expired    rejected   cancelled
+quoted -> negotiating -> accepted -> booking -> booked -> delivering -> completed
 ```
 
-| From | To | Trigger | Guard |
-|------|----|---------|-------|
-| `quoted` | `proposed` | Buyer books the deal | Quote not expired |
-| `quoted` | `expired` | Quote TTL exceeded | — |
-| `proposed` | `active` | Seller activates the deal | — |
-| `proposed` | `rejected` | Seller rejects the booking | — |
-| `active` | `completed` | Impressions delivered / flight ended | — |
-| `active` | `cancelled` | Buyer or seller cancels | Cancellation policy allows |
+A deal can also skip negotiation entirely:
 
-## Seller State Machine Reference
+```
+quoted -> accepted -> booking -> booked -> delivering -> completed
+```
 
-The seller agent already implements a formal order lifecycle state machine. The buyer's state machine will complement the seller's, tracking the buyer-side view of the same deal lifecycle.
+### Terminal States
 
-See the seller's state machine documentation for the authoritative server-side implementation: [Seller Order Lifecycle](https://iabtechlab.github.io/seller-agent/state-machines/order-lifecycle/)
+`completed`, `failed`, `cancelled`, and `expired` are terminal --- no transitions leave them.
 
-## Key Planned Functionality
+### Linear TV Extensions
 
-- **Declarative state definitions** — States and transitions defined in configuration, not scattered through code
-- **Transition guards** — Precondition checks before allowing a state change
-- **Transition hooks** — Automatic side effects on state change (notifications, logging, metric updates)
-- **Immutable transition log** — Append-only record of all state changes with metadata
-- **Sync with seller state** — Map seller-side state changes to buyer-side transitions when the seller reports status updates
+Two additional states handle scenarios specific to linear television buying:
+
+- **`makegood_pending`** --- Entered from `delivering` when the seller under-delivers against guaranteed impressions. Resolves back to `delivering`, or directly to `completed` or `failed`.
+- **`partially_canceled`** --- Entered from `booked` when the buyer cancels some (but not all) units. The remaining units can proceed to `delivering`, or the deal can be fully `cancelled`.
+
+---
+
+## BuyerCampaignStatus
+
+The `BuyerCampaignStatus` enum defines 9 states for the campaign/booking workflow. It maps to the existing `ExecutionStatus` enum used by `DealBookingFlow`.
+
+| Status | Description |
+|--------|-------------|
+| `initialized` | Campaign object created |
+| `brief_received` | Campaign brief parsed and validated |
+| `validation_failed` | Brief validation failed (recoverable) |
+| `budget_allocated` | Budget distributed across channels |
+| `researching` | Channel research and inventory discovery in progress |
+| `awaiting_approval` | Recommendations ready, waiting for human approval |
+| `executing_bookings` | Booking requests being submitted to sellers |
+| `completed` | All bookings executed successfully |
+| `failed` | Unrecoverable error (recoverable via reset to `initialized`) |
+
+### Campaign Happy Path
+
+```
+initialized -> brief_received -> budget_allocated -> researching ->
+awaiting_approval -> executing_bookings -> completed
+```
+
+### Recovery Paths
+
+Both `validation_failed` and `failed` can transition back to `initialized`, allowing the campaign to be retried from scratch.
+
+---
+
+## Transition Rules
+
+Every permitted transition is declared as a `TransitionRule` with a `(from_status, to_status)` pair and an optional guard function. The default rule sets are built by `_build_deal_rules()` and `_build_campaign_rules()`.
+
+### Deal Transitions
+
+| From | To | Description |
+|------|----|-------------|
+| `quoted` | `negotiating` | Buyer initiates negotiation |
+| `quoted` | `accepted` | Quote accepted without negotiation |
+| `negotiating` | `accepted` | Deal terms accepted |
+| `negotiating` | `quoted` | Counter-offer received, re-quoting |
+| `accepted` | `booking` | Booking process started |
+| `booking` | `booked` | Booking confirmed by seller |
+| `booked` | `delivering` | Campaign delivery started |
+| `delivering` | `completed` | Campaign delivery completed |
+| `quoted` | `failed` | Quote processing failed |
+| `negotiating` | `failed` | Negotiation failed |
+| `booking` | `failed` | Booking failed |
+| `delivering` | `failed` | Delivery failed |
+| `quoted` | `cancelled` | Deal cancelled |
+| `negotiating` | `cancelled` | Deal cancelled during negotiation |
+| `accepted` | `cancelled` | Deal cancelled after acceptance |
+| `booking` | `cancelled` | Deal cancelled during booking |
+| `booked` | `cancelled` | Booked deal cancelled |
+| `delivering` | `cancelled` | Delivery cancelled |
+| `quoted` | `expired` | Quote expired |
+| `negotiating` | `expired` | Negotiation expired |
+| `delivering` | `makegood_pending` | Makegood requested for under-delivery |
+| `makegood_pending` | `delivering` | Makegood resolved, delivery resumed |
+| `makegood_pending` | `completed` | Makegood resolved, campaign complete |
+| `makegood_pending` | `failed` | Makegood could not be fulfilled |
+| `booked` | `partially_canceled` | Partial cancellation of booked units |
+| `partially_canceled` | `delivering` | Partially canceled deal begins delivery |
+| `partially_canceled` | `cancelled` | Remaining units cancelled |
+
+### Campaign Transitions
+
+| From | To | Description |
+|------|----|-------------|
+| `initialized` | `brief_received` | Campaign brief received |
+| `brief_received` | `budget_allocated` | Budget allocated across channels |
+| `brief_received` | `validation_failed` | Brief validation failed |
+| `budget_allocated` | `researching` | Channel research started |
+| `researching` | `awaiting_approval` | Recommendations ready for approval |
+| `awaiting_approval` | `executing_bookings` | Approvals granted, executing |
+| `executing_bookings` | `completed` | All bookings executed |
+| `brief_received` | `failed` | Brief processing failed |
+| `budget_allocated` | `failed` | Budget allocation failed |
+| `researching` | `failed` | Research failed |
+| `awaiting_approval` | `failed` | Approval process failed |
+| `executing_bookings` | `failed` | Booking execution failed |
+| `validation_failed` | `initialized` | Reset after validation failure |
+| `failed` | `initialized` | Reset after failure |
+
+---
+
+## Deal Lifecycle Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> quoted
+
+    quoted --> negotiating : Initiate negotiation
+    quoted --> accepted : Accept without negotiation
+    quoted --> failed
+    quoted --> cancelled
+    quoted --> expired
+
+    negotiating --> accepted : Terms accepted
+    negotiating --> quoted : Counter-offer / re-quote
+    negotiating --> failed
+    negotiating --> cancelled
+    negotiating --> expired
+
+    accepted --> booking : Start booking
+    accepted --> cancelled
+
+    booking --> booked : Seller confirms
+    booking --> failed
+    booking --> cancelled
+
+    booked --> delivering : Delivery starts
+    booked --> partially_canceled : Partial cancellation
+    booked --> cancelled
+
+    delivering --> completed : Delivery finished
+    delivering --> makegood_pending : Under-delivery
+    delivering --> failed
+    delivering --> cancelled
+
+    makegood_pending --> delivering : Makegood resolved
+    makegood_pending --> completed : Resolved + complete
+    makegood_pending --> failed
+
+    partially_canceled --> delivering : Remaining units deliver
+    partially_canceled --> cancelled : Full cancellation
+
+    completed --> [*]
+    failed --> [*]
+    cancelled --> [*]
+    expired --> [*]
+```
+
+---
+
+## Campaign Lifecycle Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> initialized
+
+    initialized --> brief_received : Brief parsed
+
+    brief_received --> budget_allocated : Budget distributed
+    brief_received --> validation_failed : Validation error
+    brief_received --> failed
+
+    validation_failed --> initialized : Retry
+
+    budget_allocated --> researching : Research starts
+    budget_allocated --> failed
+
+    researching --> awaiting_approval : Recommendations ready
+    researching --> failed
+
+    awaiting_approval --> executing_bookings : Approved
+    awaiting_approval --> failed
+
+    executing_bookings --> completed : All booked
+    executing_bookings --> failed
+
+    failed --> initialized : Reset
+
+    completed --> [*]
+```
+
+---
+
+## Guard Conditions
+
+A `TransitionRule` can include an optional `guard` function. The guard receives four arguments and must return a boolean:
+
+```python
+def my_guard(
+    order_id: str,
+    from_status: BuyerDealStatus,
+    to_status: BuyerDealStatus,
+    context: dict[str, Any],
+) -> bool:
+    """Return True to allow the transition, False to block it."""
+    return context.get("budget_approved", False)
+```
+
+If the guard returns `False`, the state machine raises `InvalidTransitionError` with the reason `"guard condition failed"`.
+
+!!! tip "Default rules have no guards"
+    The built-in deal and campaign transition rules ship without guard functions. Add guards when your application needs business-rule enforcement (e.g., "cannot move to `booking` without a confirmed budget").
+
+---
+
+## Audit Trail
+
+Every successful transition appends a `StateTransition` record to the machine's `OrderAuditLog`.
+
+### StateTransition Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `transition_id` | `str` | UUID, auto-generated |
+| `from_status` | `str` | Previous status value |
+| `to_status` | `str` | New status value |
+| `timestamp` | `datetime` | UTC timestamp of the transition |
+| `actor` | `str` | Who triggered it: `"system"`, `"human:<user_id>"`, or `"agent:<agent_id>"` |
+| `reason` | `str` | Explanation (defaults to the rule's description) |
+| `metadata` | `dict` | Arbitrary key-value pairs for context |
+
+### OrderAuditLog
+
+The `OrderAuditLog` is an append-only container tied to one entity:
+
+| Property / Method | Description |
+|-------------------|-------------|
+| `order_id` | The entity's identifier |
+| `transitions` | List of `StateTransition` records |
+| `current_status` | The `to_status` of the most recent transition (or `None`) |
+| `append(transition)` | Add a transition record |
+
+---
+
+## Integration with DealStore
+
+The `DealStore.update_deal_status()` method enforces the state machine automatically. On every status update:
+
+1. The current status is read from SQLite.
+2. A throwaway `DealStateMachine` is created at the current status.
+3. `can_transition()` checks whether the requested transition is permitted.
+4. If not permitted, the update is rejected and the method returns `False`.
+5. If permitted, the status is written to the `deals` table and a row is appended to `status_transitions`.
+
+```python
+from ad_buyer.storage.deal_store import DealStore
+
+store = DealStore("sqlite:///./ad_buyer.db")
+store.connect()
+
+# This succeeds: quoted -> negotiating is a valid transition
+store.update_deal_status(
+    "deal-123",
+    "negotiating",
+    triggered_by="agent",
+    notes="Starting negotiation",
+)
+
+# This fails silently (returns False): completed -> quoted is not valid
+result = store.update_deal_status(
+    "deal-123",
+    "quoted",
+    triggered_by="agent",
+    notes="Trying to revert a completed deal",
+)
+assert result is False
+```
+
+!!! warning "Backward compatibility"
+    If either the old or new status is not a valid `BuyerDealStatus` member, the state machine validation is skipped. This preserves compatibility with legacy status strings that predate the formal enum.
+
+---
+
+## Using the State Machine Directly
+
+For workflows that need fine-grained control, use `DealStateMachine` or `CampaignStateMachine` directly.
+
+### Creating a Machine
+
+```python
+from ad_buyer.models.state_machine import (
+    BuyerDealStatus,
+    DealStateMachine,
+    InvalidTransitionError,
+)
+
+# New deal starts at "quoted" by default
+machine = DealStateMachine(order_id="deal-abc")
+print(machine.status)  # BuyerDealStatus.QUOTED
+```
+
+### Executing Transitions
+
+```python
+# Move through the happy path
+record = machine.transition(
+    BuyerDealStatus.NEGOTIATING,
+    actor="agent:buyer-01",
+    reason="Opening negotiation with seller",
+)
+print(record.transition_id)  # UUID of this transition
+print(machine.status)        # BuyerDealStatus.NEGOTIATING
+```
+
+### Querying Allowed Transitions
+
+```python
+# What states can we reach from here?
+allowed = machine.allowed_transitions()
+# [BuyerDealStatus.ACCEPTED, BuyerDealStatus.QUOTED,
+#  BuyerDealStatus.FAILED, BuyerDealStatus.CANCELLED,
+#  BuyerDealStatus.EXPIRED]
+
+# Check a specific transition
+can_book = machine.can_transition(BuyerDealStatus.BOOKING)  # False
+can_accept = machine.can_transition(BuyerDealStatus.ACCEPTED)  # True
+```
+
+### Handling Invalid Transitions
+
+```python
+try:
+    machine.transition(BuyerDealStatus.COMPLETED)
+except InvalidTransitionError as e:
+    print(e)
+    # "Cannot transition order deal-abc from negotiating to completed:
+    #  no matching transition rule"
+```
+
+### Adding Custom Rules with Guards
+
+```python
+from ad_buyer.models.state_machine import TransitionRule
+
+def require_budget(order_id, from_s, to_s, context):
+    return context.get("budget_confirmed", False)
+
+machine.add_rule(TransitionRule(
+    from_status=BuyerDealStatus.ACCEPTED,
+    to_status=BuyerDealStatus.BOOKING,
+    guard=require_budget,
+    description="Booking requires confirmed budget",
+))
+
+# Transition with context
+machine.transition(
+    BuyerDealStatus.ACCEPTED,
+    actor="agent:buyer-01",
+)
+machine.transition(
+    BuyerDealStatus.BOOKING,
+    context={"budget_confirmed": True},
+    actor="agent:buyer-01",
+)
+```
+
+### Inspecting the Audit Log
+
+```python
+for t in machine.history:
+    print(f"{t.from_status} -> {t.to_status} by {t.actor} at {t.timestamp}")
+```
+
+### Serialization and Restoration
+
+```python
+# Save state for persistence
+data = machine.to_dict()
+# {"order_id": "deal-abc", "status": "booking", "audit_log": {...}}
+
+# Restore later
+restored = DealStateMachine.from_dict(data)
+print(restored.status)  # BuyerDealStatus.BOOKING
+```
+
+---
+
+## Legacy Status Mapping
+
+Two helper functions bridge the old enum values to the new `BuyerDealStatus` and `BuyerCampaignStatus` enums:
+
+### `from_dsp_flow_status(value) -> BuyerDealStatus`
+
+Maps legacy `DSPFlowStatus` values used in `DSPDealFlow`:
+
+| Legacy Value | Maps To |
+|-------------|---------|
+| `initialized` | `quoted` |
+| `request_received` | `quoted` |
+| `discovering_inventory` | `quoted` |
+| `evaluating_pricing` | `negotiating` |
+| `requesting_deal` | `booking` |
+| `deal_created` | `booked` |
+| `failed` | `failed` |
+
+### `from_execution_status(value) -> BuyerCampaignStatus`
+
+Maps legacy `ExecutionStatus` values used in `DealBookingFlow`. The mapping is one-to-one since `BuyerCampaignStatus` was designed to mirror `ExecutionStatus`.
+
+---
 
 ## Related
 
-- [Deal Store](deal-store.md) — Current deal persistence (state machine builds on this)
-- [Deals API](../api/deals.md) — Deal lifecycle statuses
-- [Event Bus](event-bus.md) — Planned event logging (state transitions emit events)
-- [Seller Order Lifecycle](https://iabtechlab.github.io/seller-agent/state-machines/order-lifecycle/) — Seller-side state machine
+- [Deal Store](deal-store.md) --- Persistence layer; enforces state machine on `update_deal_status()`
+- [Event Bus](event-bus.md) --- State transitions emit events for observability
+- [Booking Flow](booking-flow.md) --- End-to-end campaign workflow using the state machine
+- [Deals API](../api/deals.md) --- Deal lifecycle statuses exposed via REST
+- [Seller Order Lifecycle](https://iabtechlab.github.io/seller-agent/state-machines/order-lifecycle/) --- Seller-side state machine (buyer states complement these)


### PR DESCRIPTION
## Summary
- Replaced the "Coming Soon" stub for `docs/architecture/state-machine.md` with comprehensive documentation covering `BuyerDealStatus` (12 states), `BuyerCampaignStatus` (9 states), all transition rules, guard conditions, audit trail, Linear TV extensions, DealStore integration, legacy status mapping, Mermaid state diagrams, and code examples.
- Replaced the "Coming Soon" stub for `docs/architecture/event-bus.md` with comprehensive documentation covering `EventType` (13 types), `Event` model, `InMemoryEventBus` implementation, `emit_event`/`emit_event_sync` helpers with fail-open pattern, SQLite persistence via DealStore, REST API endpoints (`GET /events`, `GET /events/{id}`), architecture and sequence diagrams, and usage examples.
- Both pages match the tone and formatting of the existing `deal-store.md` reference (MkDocs admonitions, Mermaid diagrams, parameter tables, code examples, Related section).

bead: buyer-5e9

## Test plan
- [x] `mkdocs build --strict` passes with zero warnings
- [x] Mermaid diagrams detected by mermaid2 plugin (2 in state-machine, 2 in event-bus)
- [x] No nav changes needed (entries already existed in mkdocs.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)