### PR TITLE
Add Coming Soon admonitions for Reporting Agent

### DIFF
--- a/docs/architecture/agent-hierarchy.md
+++ b/docs/architecture/agent-hierarchy.md
@@ -22,7 +22,7 @@ graph TB
         AUD["Audience Planner<br/>(UCP)"]
         RES["Research Agent<br/>(inventory)"]
         EXEC["Execution Agent<br/>(orders / lines)"]
-        REP["Reporting Agent<br/>(stats / analysis)"]
+        REP["Reporting Agent<br/>(stats / analysis)<br/><i>Coming Soon</i>"]
     end
 
     PM -->|budget allocation| BR
@@ -238,6 +238,9 @@ Handles the OpenDirect booking lifecycle.
 **Tools used:** `CreateOrderTool`, `CreateLineTool`, `ReserveLineTool`, `BookLineTool`
 
 ### Reporting Agent
+
+!!! info "Coming Soon"
+    The Reporting Agent (buyer-brn) is planned for a future phase. This section describes the planned reporting functionality.
 
 **File:** `src/ad_buyer/agents/level3/reporting_agent.py`
 

--- a/docs/architecture/tools.md
+++ b/docs/architecture/tools.md
@@ -30,7 +30,7 @@ graph LR
         AC[AvailsCheckTool]
     end
 
-    subgraph Reporting["Reporting Tools"]
+    subgraph Reporting["Reporting Tools (Coming Soon)"]
         GS[GetStatsTool]
     end
 ```
@@ -41,7 +41,7 @@ graph LR
 | **DSP** | DiscoverInventory, GetPricing, RequestDeal | DSP Specialist |
 | **Execution** | CreateOrder, CreateLine, ReserveLine, BookLine | Execution Agent |
 | **Research** | ProductSearch, AvailsCheck | Research Agent |
-| **Reporting** | GetStats | Reporting Agent |
+| **Reporting** | GetStats | Reporting Agent (Coming Soon) |
 
 ---
 
@@ -436,6 +436,9 @@ Checks real-time availability and pricing for a specific product during a flight
 ---
 
 ## Reporting Tools
+
+!!! info "Coming Soon"
+    The Reporting Agent and its tools (buyer-brn) are planned for a future phase. This section describes the planned reporting functionality.
 
 **Package:** `src/ad_buyer/tools/reporting/`
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -101,7 +101,7 @@ While `LLM_TEMPERATURE` sets the global default, each agent type uses a tuned te
 | Channel Specialists (L2) | 0.5 | Creative inventory selection |
 | Audience Planner (L3) | 0.3 | Precise audience strategy |
 | Research Agent (L3) | 0.2 | Data-focused, minimal creativity |
-| Reporting Agent (L3) | 0.2 | Analytical precision |
+| Reporting Agent (L3) (Coming Soon) | 0.2 | Analytical precision |
 | Execution Agent (L3) | 0.1 | Precise booking execution |
 
 ---


### PR DESCRIPTION
## Summary
- Adds "Coming Soon" admonitions to all documentation pages that reference the Reporting Agent, which has not been built yet
- Follows the existing convention used for other Coming Soon features (e.g., Creative Management, Multi-Seller Orchestration)
- Touches three docs files: `tools.md`, `agent-hierarchy.md`, `configuration.md`

## Changes
- **docs/architecture/tools.md**: Added "(Coming Soon)" to the Mermaid diagram subgraph label, the summary table Reporting row, and a full admonition block above the Reporting Tools section
- **docs/architecture/agent-hierarchy.md**: Added "*Coming Soon*" annotation in the Mermaid diagram for the Reporting Agent node, and a full admonition block above the Reporting Agent subsection
- **docs/guides/configuration.md**: Added "(Coming Soon)" to the Reporting Agent row in the agent temperature table

## Test plan
- [x] `mkdocs build --strict` passes with no errors
- [x] Full test suite: 1064 passed (21 failures + 11 errors are pre-existing on main, unrelated to docs)

bead: buyer-89x

🤖 Generated with [Claude Code](https://claude.com/claude-code)