### PR TITLE
Update PROGRESS.md generator for DealJockey phases

### DIFF
--- a/.beads/PROGRESS.md
+++ b/.beads/PROGRESS.md
@@ -1,8 +1,8 @@
 # Buyer Agent V2 — Progress
 
-**34 open** | **0 in progress** | **10 closed** | **20 blocked** | 44 total
+**58 open** | **2 in progress** | **27 closed** | **42 blocked** | 87 total
 
-`[█████░░░░░░░░░░░░░░░] 23% (10/44)`
+`[██████░░░░░░░░░░░░░░] 31% (27/87)`
 
 ## Phase 1 — Seller Interoperability
 
@@ -43,35 +43,92 @@
 | \[!] | buyer-1o3 | 3F: Deployment & Operations Guide | P3 | buyer-j95 |  |
 | \[ ] | buyer-j95 | 3G: Infrastructure-as-Code Deployment (CloudFormation/Terraform) | P3 | — |  |
 
-## Phase 5 — Deal Jockey
+## DealJockey Phase 1 — Foundation
 
 | | ID | Task | Priority | Blockers | Done |
 |---|---|---|---|---|---|
-| \[ ] | buyer-e6a | 5A: Rename DSP Specialist to Deal Jockey Agent | P2 | — |  |
-| \[ ] | buyer-1q3 | 5B: Rename DSPDealFlow to DealJockeyFlow | P2 | — |  |
-| \[ ] | buyer-rsf | 5C: DealStore Schema v2 Migration | P2 | — |  |
-| \[!] | buyer-1kn | 5D: DealStore Methods for New Tables | P2 | buyer-rsf |  |
-| \[!] | buyer-aw4 | 5E: Deal Template and Supply Path Template Tools | P2 | buyer-1kn |  |
-| \[!] | buyer-hik | 5F: Analyze Supply Path Tool | P2 | buyer-1kn |  |
-| \[!] | buyer-4mt | 5G: Instantiate Deal From Template Tool | P2 | buyer-aw4 |  |
-| \[!] | buyer-h3r | 5H: Bulk Deal Operation Tool | P2 | buyer-1kn |  |
-| \[!] | buyer-shp | 5I: Get Deal Performance Tool | P2 | buyer-1kn |  |
-| \[!] | buyer-5b7 | 5J: Wire Deal Jockey Tools into Agent | P2 | buyer-4mt, buyer-h3r, buyer-shp, buyer-e6a, buyer-hik |  |
-| \[!] | buyer-8o3 | 5K: Track Cross-Platform Deal Tool | P2 | buyer-1kn |  |
-| \[!] | buyer-c68 | 5L: Migrate Deals Tool | P2 | buyer-4mt |  |
-| \[!] | buyer-omm | 5M: Expand DealJockeyFlow with Optimization Plugin Interface | P1 | buyer-5b7, buyer-1q3 |  |
-| \[ ] | buyer-91l | 5N: Deal Jockey Event Types | P2 | — |  |
-| \[!] | buyer-xgc | 5O: External Optimization Provider Registration | P2 | buyer-omm |  |
-| \[ ] | buyer-ez3 | 5P: IAB Deals API v1.0 Push Receiver | P2 | — |  |
-| \[!] | buyer-681 | 5Q: Curator Awareness in SPO | P2 | buyer-hik |  |
-| \[!] | buyer-5gp | 5R: Deal Jockey Example and Documentation | P3 | buyer-omm |  |
+| \[x] | buyer-te6b.1 | DealJockey Phase 1: Foundation | P1 | buyer-te6b | 2026-03-18 |
+| \[~] | buyer-087 | DealJockey Phase 1 demo dashboard | P1 | — |  |
+| \[x] | buyer-5tg | Deal library schema v2 (hybrid approach per D-4) | P1 | — | 2026-03-18 |
+| \[x] | buyer-8ap | Portfolio inspection tools | P1 | — | 2026-03-18 |
+| \[ ] | buyer-jpd | DealJockey Phase 1: Foundation | P1 | — |  |
+| \[x] | buyer-muf | Create DealJockey L2 agent in buyer hierarchy | P1 | — | 2026-03-18 |
+| \[x] | buyer-rna | Define DealJockey event types (Phase 1) | P1 | — | 2026-03-18 |
+| \[ ] | buyer-te6b.1.1 | Write DealJockey seller API contract (supply-chain, from-template, bulk, performance) | P1 | — |  |
+| \[!] | buyer-te6b.1.10 | [seller-dj4] Add GET /api/v1/deals/{id}/performance endpoint | P1 | buyer-te6b.1.1 |  |
+| \[x] | buyer-te6b.1.11 | [buyer-dj3] Deal library schema v2 (expanded per Section 6) | P1 | — | 2026-03-18 |
+| \[x] | buyer-te6b.1.12 | [buyer-dj4] Deal library CRUD operations | P1 | — | 2026-03-18 |
+| \[ ] | buyer-te6b.1.13 | [buyer-dj5] Deal template and supply path template CRUD | P1 | — |  |
+| \[x] | buyer-te6b.1.2 | Create DealJockey L2 agent in buyer hierarchy | P1 | — | 2026-03-18 |
+| \[x] | buyer-te6b.1.3 | Implement CSV deal import parser | P1 | — | 2026-03-18 |
+| \[x] | buyer-te6b.1.4 | Add manual deal entry to DealJockey | P1 | — | 2026-03-18 |
+| \[x] | buyer-te6b.1.5 | Build portfolio inspection tools | P1 | — | 2026-03-18 |
+| \[ ] | buyer-te6b.1.6 | Organize internal deal-booking modules (consolidate per ar-fad) | P1 | — |  |
+| \[x] | buyer-te6b.1.7 | Define DealJockey event types (Phase 1) | P1 | — | 2026-03-18 |
+| \[!] | buyer-te6b.1.8 | [seller-dj2] Add GET /api/v1/supply-chain endpoint | P1 | buyer-te6b.1.1 |  |
+| \[!] | buyer-te6b.1.9 | [seller-dj3] Add POST /api/v1/deals/from-template endpoint | P1 | buyer-te6b.1.1 |  |
+| \[x] | buyer-vbh | Manual deal entry | P1 | — | 2026-03-18 |
+| \[x] | buyer-vjc | Deal library CRUD operations | P1 | — | 2026-03-18 |
+| \[x] | buyer-ymj | CSV deal import parser | P1 | — | 2026-03-18 |
+
+## DealJockey Phase 2 — Intelligence
+
+| | ID | Task | Priority | Blockers | Done |
+|---|---|---|---|---|---|
+| \[!] | buyer-te6b.2 | DealJockey Phase 2: Intelligence | P2 | buyer-te6b |  |
+| \[!] | buyer-te6b.2.1 | Implement deal portfolio gap analysis | P2 | buyer-te6b.2 |  |
+| \[!] | buyer-te6b.2.10 | [buyer-dj9] GetDealPerformanceTool | P2 | buyer-te6b.2, buyer-te6b.1.10 |  |
+| \[!] | buyer-te6b.2.11 | [buyer-dj12] Deal migration tool (MigrateDealsTool) | P2 | buyer-te6b.2, buyer-te6b.1.6, buyer-te6b.1.8 |  |
+| \[!] | buyer-te6b.2.12 | Define DealJockey event types (Phase 2) | P2 | buyer-te6b.2 |  |
+| \[!] | buyer-te6b.2.13 | [seller-dj5] Enhanced supply-chain with sellers.json and schain | P2 | buyer-te6b.2, buyer-te6b.1.8 |  |
+| \[!] | buyer-te6b.2.14 | [seller-dj6] Add POST /api/v1/deals/bulk endpoint | P2 | buyer-te6b.2, buyer-te6b.1.1 |  |
+| \[!] | buyer-te6b.2.2 | Build cross-path price comparison tool | P2 | buyer-te6b.2, buyer-te6b.1.8 |  |
+| \[!] | buyer-te6b.2.3 | Implement deal duplication for new advertisers | P2 | buyer-te6b.2, buyer-te6b.1.13, buyer-te6b.1.6 |  |
+| \[!] | buyer-te6b.2.4 | Build deal deprecation analysis and execution | P2 | buyer-te6b.2, buyer-te6b.1.10 |  |
+| \[!] | buyer-te6b.2.5 | Implement portfolio health reporting | P2 | buyer-te6b.2, buyer-te6b.1.10 |  |
+| \[!] | buyer-te6b.2.6 | Build human instructions adapter for manual deal migration | P2 | buyer-te6b.2 |  |
+| \[!] | buyer-te6b.2.7 | [buyer-dj6] AnalyzeSupplyPathTool | P2 | buyer-te6b.2, buyer-te6b.1.13 |  |
+| \[!] | buyer-te6b.2.8 | [buyer-dj7] InstantiateDealFromTemplateTool | P2 | buyer-te6b.2, buyer-te6b.1.13, buyer-te6b.1.6 |  |
+| \[!] | buyer-te6b.2.9 | [buyer-dj8] BulkDealOperationTool | P2 | buyer-te6b.2, buyer-te6b.2.14 |  |
+
+## DealJockey Phase 3 — Platform Integrations
+
+| | ID | Task | Priority | Blockers | Done |
+|---|---|---|---|---|---|
+| \[!] | buyer-te6b.3 | DealJockey Phase 3: Platform Integrations | P3 | buyer-te6b |  |
+| \[!] | buyer-te6b.3.1 | TTD API connector for deal import | P3 | buyer-te6b.3 |  |
+| \[!] | buyer-te6b.3.2 | DV360 API connector for deal import | P3 | buyer-te6b.3 |  |
+| \[!] | buyer-te6b.3.3 | Xandr API connector for deal import | P3 | buyer-te6b.3 |  |
+| \[!] | buyer-te6b.3.4 | Amazon DSP API connector for deal import | P3 | buyer-te6b.3 |  |
+| \[!] | buyer-te6b.3.5 | Mediaocean Prisma export parser | P3 | buyer-te6b.3 |  |
+| \[!] | buyer-te6b.3.6 | Mediaocean Lumina export parser | P3 | buyer-te6b.3 |  |
+| \[!] | buyer-te6b.3.7 | [buyer-dj11] Cross-platform deal activation tracker | P3 | buyer-te6b.3 |  |
+| \[!] | buyer-te6b.3.8 | Cross-platform deal deduplication | P3 | buyer-te6b.3, buyer-te6b.2.2 |  |
+
+## DealJockey Phase 4 — External Model Integration
+
+| | ID | Task | Priority | Blockers | Done |
+|---|---|---|---|---|---|
+| \[!] | buyer-te6b.4 | DealJockey Phase 4: Agent Range Integration | P3 | buyer-te6b, buyer-te6b.2 |  |
+| \[!] | buyer-te6b.4.1 | [buyer-dj14] Event system (Phase 4: optimization events) | P3 | buyer-te6b.4 |  |
+| \[!] | buyer-te6b.4.2 | [buyer-dj15] Receive IAB Deals API v1.0 push updates | P3 | buyer-te6b.4 |  |
+| \[!] | buyer-te6b.4.3 | [buyer-dj16] Curator awareness in SPO | P3 | buyer-te6b.4 |  |
+| \[!] | buyer-te6b.4.4 | Add Agent Range optimization hooks to DealJockey | P3 | buyer-te6b.4, buyer-te6b.2.5, buyer-te6b.2.11 |  |
+| \[!] | buyer-te6b.4.5 | ML-tuned supply path scoring | P3 | buyer-te6b.4, buyer-te6b.2.7 |  |
+| \[!] | buyer-te6b.4.6 | [seller-dj7] Curator support (OpenDirect 3.0) | P3 | buyer-te6b.4, buyer-te6b.1.8 |  |
 
 ## Other
 
 | | ID | Task | Priority | Blockers | Done |
 |---|---|---|---|---|---|
+| \[x] | buyer-9js | Architecture review: reconcile Phase 2 buyer plan with DealJockey strategic plan | P1 | — | 2026-03-18 |
+| \[ ] | buyer-fcq | Coordinate schema migration versioning across DealJockey and Phase 2 | P1 | — |  |
+| \[!] | buyer-e6f | DealJockey Epic | P1 | buyer-jpd |  |
 | \[ ] | buyer-brn | Epic: Buyer reporting agent | P3 | — |  |
+| \[~] | buyer-nm8 | Migrate ar-te6b DealJockey beads from parent repo to buyer repo | P0 | — |  |
 | \[ ] | buyer-nz9 | Order Status & Audit API Integration | P2 | — |  |
+| \[ ] | buyer-0no | Schedule ar-te6b.1.6 (deal-booking modules consolidation) before buyer-8ih | P1 | — |  |
+| \[x] | buyer-e3f | Session pickup - 2026-03-17: Docs revamp needs tab fix, Deal Jockey design in progress | P1 | — | 2026-03-17 |
 
 ---
-*Last updated: 2026-03-18 12:16 UTC — auto-generated by beads*
+*Last updated: 2026-03-19 01:07 UTC — auto-generated by beads*

--- a/.beads/generate_progress.py
+++ b/.beads/generate_progress.py
@@ -11,13 +11,20 @@ BEADS_DIR = Path(__file__).parent
 JSONL_PATH = BEADS_DIR / "issues.jsonl"
 OUTPUT_PATH = BEADS_DIR / "PROGRESS.md"
 
-# Phase grouping by title prefix
+# Phase grouping by title prefix (numbered phases like "1A:", "2B:")
 PHASE_MAP = {
     "1": ("Phase 1", "Seller Interoperability"),
     "2": ("Phase 2", "Campaign Automation"),
     "3": ("Phase 3", "Platform & Infrastructure"),
     "4": ("Phase 4", "Production Hardening"),
-    "5": ("Phase 5", "Deal Jockey"),
+}
+
+# DealJockey phases mapped by bead ID pattern (buyer-te6b.N.*)
+DJ_PHASE_MAP = {
+    "1": ("DealJockey Phase 1", "Foundation"),
+    "2": ("DealJockey Phase 2", "Intelligence"),
+    "3": ("DealJockey Phase 3", "Platform Integrations"),
+    "4": ("DealJockey Phase 4", "External Model Integration"),
 }
 
 
@@ -166,11 +173,55 @@ def generate():
     blocked = len([i for i in issues if i.get("status") not in ("closed",) and is_blocked(i, closed_ids, all_ids)])
     open_count = total - closed - in_progress
 
-    # Group by phase
+    # Filter out LEGACY beads
+    issues = [i for i in issues if "[LEGACY]" not in i.get("title", "")]
+
+    # Recalculate stats after filtering
+    total = len(issues)
+    closed = len([i for i in issues if i.get("status") == "closed"])
+    in_progress = len([i for i in issues if i.get("status") == "in_progress"])
+    closed_ids = {i["id"] for i in issues if i.get("status") == "closed"}
+    all_ids = {i["id"] for i in issues}
+    blocked = len([i for i in issues if i.get("status") not in ("closed",) and is_blocked(i, closed_ids, all_ids)])
+    open_count = total - closed - in_progress
+
+    # Group by phase (numbered) or DealJockey phase (by bead ID)
     phases = {}
+    dj_phases = {}
+    dj_epics = []  # top-level DealJockey epics
     ungrouped = []
     for issue in issues:
-        phase = get_phase(issue.get("title", ""))
+        iid = issue.get("id", "")
+        title = issue.get("title", "")
+
+        # DealJockey beads: buyer-te6b, buyer-te6b.N, buyer-te6b.N.M
+        if iid.startswith("buyer-te6b"):
+            # Top-level epic or phase epic
+            if iid == "buyer-te6b":
+                dj_epics.append(issue)
+            elif re.match(r"buyer-te6b\.\d+$", iid):
+                # Phase epic like buyer-te6b.2
+                phase_num = iid.split(".")[-1]
+                dj_phases.setdefault(phase_num, []).insert(0, issue)
+            elif re.match(r"buyer-te6b\.\d+\.\d+", iid):
+                # Task like buyer-te6b.2.3
+                phase_num = iid.split(".")[1]
+                dj_phases.setdefault(phase_num, []).append(issue)
+            else:
+                ungrouped.append(issue)
+            continue
+
+        # DealJockey Phase 1 execution beads (buyer-5tg, buyer-muf, etc.)
+        # These are grouped under DealJockey Phase 1 by checking title/description
+        dj_p1_titles = ["Deal library schema", "DealJockey L2 agent", "DealJockey event types",
+                        "Deal library CRUD", "CSV deal import", "Manual deal entry",
+                        "Portfolio inspection", "DealJockey Phase 1"]
+        if any(t.lower() in title.lower() for t in dj_p1_titles):
+            dj_phases.setdefault("1", []).append(issue)
+            continue
+
+        # Numbered phase tasks (1A:, 2B:, etc.)
+        phase = get_phase(title)
         if phase:
             phases.setdefault(phase, []).append(issue)
         else:
@@ -232,6 +283,26 @@ def generate():
                     lines.append(f"| {sub_icon} | {sub_iid} | &nbsp;&nbsp;↳ {sub_title} | {sub_priority} | {sub_blocker_str} | {sub_done} |")
 
         lines.append("")
+
+    # Render DealJockey phases
+    if dj_phases or dj_epics:
+        for phase_num in sorted(dj_phases.keys()):
+            phase_name, phase_desc = DJ_PHASE_MAP.get(phase_num, (f"DealJockey Phase {phase_num}", ""))
+            lines.append(f"## {phase_name} — {phase_desc}\n")
+            lines.append("| | ID | Task | Priority | Blockers | Done |")
+            lines.append("|---|---|---|---|---|---|")
+
+            for issue in dj_phases[phase_num]:
+                icon = status_icon(issue, closed_ids, all_ids)
+                iid = issue["id"]
+                title = issue.get("title", "")
+                priority = f"P{issue.get('priority', '?')}"
+                blockers = get_blocker_ids(issue, all_ids)
+                unresolved = [b for b in blockers if b not in closed_ids]
+                blocker_str = ", ".join(unresolved) if unresolved else "—"
+                done = format_date(issue.get("closed_at", ""))
+                lines.append(f"| {icon} | {iid} | {title} | {priority} | {blocker_str} | {done} |")
+            lines.append("")
 
     # Ungrouped issues
     if ungrouped:

--- a/src/ad_buyer/agents/level2/__init__.py
+++ b/src/ad_buyer/agents/level2/__init__.py
@@ -9,6 +9,7 @@ from .ctv_agent import create_ctv_agent
 from .linear_tv_agent import create_linear_tv_agent
 from .performance_agent import create_performance_agent
 from .dsp_agent import create_dsp_agent
+from .deal_jockey_agent import create_deal_jockey_agent
 
 __all__ = [
     "create_branding_agent",
@@ -17,4 +18,5 @@ __all__ = [
     "create_linear_tv_agent",
     "create_performance_agent",
     "create_dsp_agent",
+    "create_deal_jockey_agent",
 ]

--- a/src/ad_buyer/agents/level2/deal_jockey_agent.py
+++ b/src/ad_buyer/agents/level2/deal_jockey_agent.py
@@ -1,0 +1,98 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""DealJockey agent - deal portfolio management specialist.
+
+DealJockey is an L2 agent in the buyer hierarchy that manages deal portfolios:
+importing, cataloging, inspecting, organizing, migrating, and optimizing deals
+across publishers, SSPs, and DSPs.
+
+L1 Routing Heuristics
+---------------------
+The L1 Portfolio Manager routes requests to DealJockey vs. Campaign flow using
+these heuristics (from DEAL_JOCKEY_STRATEGIC_PLAN.md Section 5.4):
+
+  -> DealJockey:
+     "portfolio", "existing deals", "my deals", "migrate", "clone",
+     "deprecate", "compare prices", "import", "catalog", "gap analysis",
+     "sunset"
+
+  -> Campaign flow (channel specialists):
+     "campaign", "book for campaign", "budget", "target audience",
+     "pacing", "flight dates", "launch"
+
+  -> Ambiguous (both signals or unclear intent):
+     L1 asks for clarification: "Are you looking to manage your existing
+     deal portfolio, or book deals for a specific campaign?"
+
+  -> Specific deal ID referenced:
+     Status check / inspection -> DealJockey
+     Activate for campaign -> Campaign flow
+"""
+
+from typing import Any
+
+from crewai import Agent, LLM
+
+from ...config.settings import settings
+
+
+def create_deal_jockey_agent(
+    tools: list[Any] | None = None,
+    verbose: bool = True,
+) -> Agent:
+    """Create the DealJockey agent.
+
+    The DealJockey agent focuses on deal portfolio management:
+    - Deal portfolio organization and cataloging
+    - CSV and bulk deal import/normalization
+    - Deal template creation and management
+    - Supply path analysis and optimization
+    - Cross-platform deal tracking (TTD, DV360, Xandr, Amazon DSP)
+    - Deal migration and deprecation workflows
+    - Price comparison across supply paths
+    - Gap analysis for portfolio coverage
+
+    Args:
+        tools: Optional list of tools for the agent
+        verbose: Whether to enable verbose logging
+
+    Returns:
+        Configured DealJockey Agent
+    """
+    return Agent(
+        role="Deal Jockey - Portfolio Manager",
+        goal="""Manage deal portfolios — import, catalog, inspect, organize,
+migrate, and optimize deals across publishers, SSPs, and DSPs. Treat deals
+as a managed asset class, ensuring the agency's deal inventory is current,
+well-organized, and aligned with campaign needs.""",
+        backstory="""You are a portfolio management specialist with deep expertise
+in programmatic deal operations across the ad tech ecosystem.
+
+Your expertise includes:
+- Deal portfolio organization and cataloging
+- CSV and bulk deal import/normalization
+- Deal template creation and management
+- Supply path analysis and optimization
+- Cross-platform deal tracking (TTD, DV360, Xandr, Amazon DSP)
+- Deal migration and deprecation workflows
+- Price comparison across supply paths
+- Gap analysis for portfolio coverage
+
+You work alongside channel specialists (Branding, CTV, Performance, Linear TV,
+DSP). You receive portfolio-related requests from the L1 Portfolio Manager. You
+delegate deal booking to internal deal-booking modules — your role is portfolio
+management, not campaign execution.
+
+When a deal needs to be booked for a campaign, you hand off to the appropriate
+campaign flow. When you detect underperforming deals or better supply paths, you
+propose changes that the campaign flow can execute.""",
+        llm=LLM(
+            model=settings.default_llm_model,
+            temperature=0.3,
+        ),
+        tools=tools or [],
+        allow_delegation=True,
+        verbose=verbose,
+        memory=True,
+    )

--- a/src/ad_buyer/demo/__init__.py
+++ b/src/ad_buyer/demo/__init__.py
@@ -1,0 +1,4 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Demo tools for the ad buyer system."""

--- a/src/ad_buyer/demo/__main__.py
+++ b/src/ad_buyer/demo/__main__.py
@@ -1,0 +1,8 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Allow running the demo dashboard via ``python -m ad_buyer.demo``."""
+
+from .dealjockey_dashboard import main
+
+main()

--- a/src/ad_buyer/demo/dealjockey_dashboard.py
+++ b/src/ad_buyer/demo/dealjockey_dashboard.py
@@ -1,0 +1,527 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""DealJockey Phase 1 demo dashboard.
+
+Standalone Flask app that exercises all Phase 1 capabilities:
+  - Schema status inspection
+  - Deal portfolio listing / filtering / search
+  - CSV deal import
+  - Manual deal entry
+  - Event log viewing
+  - Agent info display
+
+Run with:
+    cd ad_buyer_system && source venv/bin/activate
+    python -m ad_buyer.demo.dealjockey_dashboard
+    # Opens on http://localhost:5050
+"""
+
+import io
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from flask import Flask, jsonify, render_template, request
+
+from ..storage.deal_store import DealStore
+from ..storage.schema import SCHEMA_VERSION
+from ..tools.deal_import import parse_csv_deals
+from ..tools.deal_jockey.deal_entry import (
+    ManualDealEntry,
+    create_manual_deal,
+    VALID_DEAL_TYPES,
+    VALID_MEDIA_TYPES,
+    VALID_PRICE_MODELS,
+    VALID_SELLER_TYPES,
+)
+from .seed_data import seed_demo_data
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Flask app factory
+# ---------------------------------------------------------------------------
+
+_TEMPLATE_DIR = Path(__file__).parent / "templates"
+
+
+def create_app(database_url: str = "sqlite:///:memory:") -> Flask:
+    """Create and configure the dashboard Flask app.
+
+    Args:
+        database_url: SQLite connection string for the DealStore.
+
+    Returns:
+        Configured Flask application.
+    """
+    app = Flask(
+        __name__,
+        template_folder=str(_TEMPLATE_DIR),
+    )
+    app.config["DATABASE_URL"] = database_url
+
+    # Initialize store
+    store = DealStore(database_url)
+    store.connect()
+    app.config["DEAL_STORE"] = store
+
+    # Seed data on startup (only if the DB is empty)
+    existing = store.list_deals(limit=1)
+    if not existing:
+        seed_demo_data(store)
+        logger.info("Seeded demo data into the dashboard database")
+
+    # Register routes
+    _register_routes(app, store)
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
+def _register_routes(app: Flask, store: DealStore) -> None:
+    """Register all routes on the app."""
+
+    # -- Page ---------------------------------------------------------------
+
+    @app.route("/")
+    def index():
+        return render_template("dashboard.html")
+
+    # -- API: Schema --------------------------------------------------------
+
+    @app.route("/api/schema")
+    def api_schema():
+        """Return schema version and table info."""
+        conn = store._conn
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        )
+        tables = []
+        for row in cursor.fetchall():
+            name = row["name"] if isinstance(row, dict) else row[0]
+            count_cursor = conn.execute(f"SELECT COUNT(*) FROM [{name}]")
+            count = count_cursor.fetchone()[0]
+            tables.append({"name": name, "row_count": count})
+
+        # v2 columns on deals table
+        col_cursor = conn.execute("PRAGMA table_info(deals)")
+        all_cols = [r[1] if not isinstance(r, dict) else r["name"]
+                    for r in col_cursor.fetchall()]
+        v2_cols = [c for c in all_cols if c in store._V2_DEAL_COLUMNS]
+
+        return jsonify({
+            "schema_version": SCHEMA_VERSION,
+            "tables": tables,
+            "v2_columns": v2_cols,
+        })
+
+    # -- API: Deals ---------------------------------------------------------
+
+    @app.route("/api/deals")
+    def api_deals():
+        """List deals with optional query-param filters."""
+        filters: dict[str, Any] = {}
+        for key in ("status", "media_type", "deal_type", "seller_domain"):
+            val = request.args.get(key)
+            if val:
+                filters[key] = val
+
+        limit = request.args.get("limit", 200, type=int)
+        deals = store.list_deals(limit=limit, **filters)
+        return jsonify({"deals": deals, "count": len(deals)})
+
+    @app.route("/api/deals/<deal_id>")
+    def api_deal_detail(deal_id: str):
+        """Return full deal detail including metadata, activations, perf."""
+        deal = store.get_deal(deal_id)
+        if deal is None:
+            return jsonify({"error": "Deal not found"}), 404
+
+        metadata = store.get_portfolio_metadata(deal_id)
+        activations = store.get_deal_activations(deal_id)
+        perf = store.get_performance_cache(deal_id)
+
+        return jsonify({
+            "deal": deal,
+            "portfolio_metadata": metadata,
+            "activations": activations,
+            "performance_cache": perf,
+        })
+
+    # -- API: Create deal (manual entry) ------------------------------------
+
+    @app.route("/api/deals", methods=["POST"])
+    def api_create_deal():
+        """Create a deal from the manual entry form."""
+        data = request.get_json(silent=True) or {}
+
+        # Build ManualDealEntry from posted data
+        try:
+            entry = ManualDealEntry(**data)
+        except Exception as exc:
+            return jsonify({"success": False, "errors": [str(exc)]}), 400
+
+        result = create_manual_deal(entry)
+        if not result.success:
+            return jsonify({"success": False, "errors": result.errors}), 400
+
+        # Persist via DealStore.
+        # create_manual_deal packs v2 fields into the metadata JSON, but
+        # save_deal accepts them as direct kwargs too, so we pass them
+        # explicitly for proper column storage.
+        deal_data = result.deal_data
+        v2_extras: dict[str, Any] = {}
+        if entry.media_type is not None:
+            v2_extras["media_type"] = entry.media_type
+        if entry.display_name:
+            v2_extras["display_name"] = entry.display_name
+        if entry.seller_org is not None:
+            v2_extras["seller_org"] = entry.seller_org
+        if entry.seller_domain is not None:
+            v2_extras["seller_domain"] = entry.seller_domain
+        if entry.seller_type is not None:
+            v2_extras["seller_type"] = entry.seller_type
+        if entry.buyer_org is not None:
+            v2_extras["buyer_org"] = entry.buyer_org
+        if entry.description is not None:
+            v2_extras["description"] = entry.description
+        if entry.price_model is not None:
+            v2_extras["price_model"] = entry.price_model
+        if entry.fixed_price_cpm is not None:
+            v2_extras["fixed_price_cpm"] = entry.fixed_price_cpm
+        if entry.bid_floor_cpm is not None:
+            v2_extras["bid_floor_cpm"] = entry.bid_floor_cpm
+        v2_extras["currency"] = entry.currency
+
+        deal_id = store.save_deal(**deal_data, **v2_extras)
+
+        # Save portfolio metadata
+        if result.metadata:
+            tags_val = result.metadata.get("tags")
+            if isinstance(tags_val, list):
+                tags_val = json.dumps(tags_val)
+            store.save_portfolio_metadata(
+                deal_id=deal_id,
+                import_source=result.metadata.get("import_source", "MANUAL"),
+                import_date=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+                tags=tags_val,
+                advertiser_id=result.metadata.get("advertiser_id"),
+            )
+
+        # Emit event
+        store.save_event(
+            event_type="deal.imported",
+            deal_id=deal_id,
+            payload=json.dumps({
+                "import_source": "MANUAL",
+                "display_name": data.get("display_name", ""),
+            }),
+        )
+
+        return jsonify({"success": True, "deal_id": deal_id})
+
+    # -- API: CSV Import ----------------------------------------------------
+
+    @app.route("/api/import", methods=["POST"])
+    def api_import_csv():
+        """Parse an uploaded CSV file and return results (without saving)."""
+        if "file" not in request.files:
+            return jsonify({"error": "No file uploaded"}), 400
+
+        uploaded = request.files["file"]
+        if not uploaded.filename:
+            return jsonify({"error": "Empty filename"}), 400
+
+        # Save to a temp file for parse_csv_deals
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".csv", delete=False
+        ) as tmp:
+            uploaded.save(tmp)
+            tmp_path = tmp.name
+
+        try:
+            result = parse_csv_deals(tmp_path)
+        finally:
+            os.unlink(tmp_path)
+
+        errors_list = [
+            {
+                "row_number": e.row_number,
+                "field": e.field,
+                "value": e.value,
+                "message": e.message,
+            }
+            for e in result.errors
+        ]
+
+        return jsonify({
+            "total_rows": result.total_rows,
+            "successful": result.successful,
+            "failed": result.failed,
+            "skipped": result.skipped,
+            "deals": result.deals,
+            "errors": errors_list,
+        })
+
+    @app.route("/api/import/save", methods=["POST"])
+    def api_import_save():
+        """Save previously parsed deals to DealStore."""
+        data = request.get_json(silent=True) or {}
+        deals = data.get("deals", [])
+        if not deals:
+            return jsonify({"error": "No deals to save"}), 400
+
+        saved_ids = []
+        save_errors = []
+        for i, deal_dict in enumerate(deals):
+            try:
+                # Ensure required fields for save_deal
+                seller_url = deal_dict.pop("seller_url", "")
+                product_id = deal_dict.pop("product_id", "imported")
+                display_name = deal_dict.get("display_name") or deal_dict.pop(
+                    "product_name", "Imported Deal"
+                )
+
+                deal_id = store.save_deal(
+                    seller_url=seller_url or "https://imported.example.com",
+                    product_id=product_id,
+                    product_name=display_name,
+                    display_name=display_name,
+                    deal_type=deal_dict.get("deal_type", "PD"),
+                    status=deal_dict.get("status", "draft"),
+                    seller_deal_id=deal_dict.get("seller_deal_id"),
+                    seller_org=deal_dict.get("seller_org"),
+                    seller_domain=deal_dict.get("seller_domain"),
+                    media_type=deal_dict.get("media_type"),
+                    price=deal_dict.get("fixed_price_cpm") or deal_dict.get("bid_floor_cpm"),
+                    fixed_price_cpm=deal_dict.get("fixed_price_cpm"),
+                    bid_floor_cpm=deal_dict.get("bid_floor_cpm"),
+                    impressions=deal_dict.get("impressions"),
+                    flight_start=deal_dict.get("flight_start"),
+                    flight_end=deal_dict.get("flight_end"),
+                    currency=deal_dict.get("currency", "USD"),
+                    description=deal_dict.get("description"),
+                    buyer_org=deal_dict.get("buyer_org"),
+                )
+
+                # Save metadata
+                store.save_portfolio_metadata(
+                    deal_id=deal_id,
+                    import_source="CSV",
+                    import_date=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+                )
+
+                # Emit event
+                store.save_event(
+                    event_type="deal.imported",
+                    deal_id=deal_id,
+                    payload=json.dumps({
+                        "import_source": "CSV",
+                        "display_name": display_name,
+                    }),
+                )
+
+                saved_ids.append(deal_id)
+            except Exception as exc:
+                save_errors.append({"index": i, "error": str(exc)})
+
+        return jsonify({
+            "saved": len(saved_ids),
+            "errors": save_errors,
+            "deal_ids": saved_ids,
+        })
+
+    # -- API: Search --------------------------------------------------------
+
+    @app.route("/api/search")
+    def api_search():
+        """Search deals by free-text query."""
+        query = request.args.get("q", "").strip()
+        if not query:
+            return jsonify({"error": "Empty search query"}), 400
+
+        query_lower = query.lower()
+        deals = store.list_deals(limit=10000)
+        search_fields = [
+            "display_name", "product_name", "description",
+            "seller_org", "seller_domain",
+        ]
+
+        matches = []
+        for deal in deals:
+            for field in search_fields:
+                val = deal.get(field)
+                if val and query_lower in str(val).lower():
+                    matches.append(deal)
+                    break
+
+        return jsonify({"query": query, "results": matches, "count": len(matches)})
+
+    # -- API: Summary -------------------------------------------------------
+
+    @app.route("/api/summary")
+    def api_summary():
+        """Return portfolio aggregate statistics."""
+        deals = store.list_deals(limit=10000)
+        total = len(deals)
+
+        status_counts: dict[str, int] = {}
+        media_counts: dict[str, int] = {}
+        type_counts: dict[str, int] = {}
+        seller_counts: dict[str, int] = {}
+        total_value = 0.0
+        total_impressions = 0
+
+        for deal in deals:
+            s = deal.get("status", "unknown")
+            status_counts[s] = status_counts.get(s, 0) + 1
+
+            mt = deal.get("media_type") or "N/A"
+            media_counts[mt] = media_counts.get(mt, 0) + 1
+
+            dt = deal.get("deal_type", "unknown")
+            type_counts[dt] = type_counts.get(dt, 0) + 1
+
+            seller = deal.get("seller_org") or deal.get("seller_domain") or "Unknown"
+            seller_counts[seller] = seller_counts.get(seller, 0) + 1
+
+            price = deal.get("price")
+            imps = deal.get("impressions")
+            if price is not None and imps is not None:
+                total_value += price * imps / 1000.0
+            if imps is not None:
+                total_impressions += imps
+
+        top_sellers = sorted(
+            seller_counts.items(), key=lambda x: x[1], reverse=True
+        )[:5]
+
+        return jsonify({
+            "total_deals": total,
+            "total_value": round(total_value, 2),
+            "total_impressions": total_impressions,
+            "by_status": status_counts,
+            "by_media_type": media_counts,
+            "by_deal_type": type_counts,
+            "top_sellers": [{"seller": s, "count": c} for s, c in top_sellers],
+        })
+
+    # -- API: Events --------------------------------------------------------
+
+    @app.route("/api/events")
+    def api_events():
+        """Return recent Phase 1 events."""
+        phase1_types = [
+            "deal.imported",
+            "deal.template_created",
+            "portfolio.inspected",
+            "deal.manual_action_required",
+        ]
+        limit = request.args.get("limit", 50, type=int)
+
+        # Fetch all recent events and filter client-side for Phase 1 types
+        all_events = store.list_events(limit=limit * 4)
+        events = [
+            e for e in all_events
+            if e.get("event_type") in phase1_types
+        ][:limit]
+
+        return jsonify({"events": events, "count": len(events)})
+
+    # -- API: Agent info ----------------------------------------------------
+
+    @app.route("/api/agent-info")
+    def api_agent_info():
+        """Return DealJockey agent configuration (static, no instantiation)."""
+        # Read from the module docstring and create_deal_jockey_agent
+        from ..agents.level2.deal_jockey_agent import create_deal_jockey_agent
+
+        # Extract the Agent kwargs without actually creating the agent
+        # (which would require LLM config). Instead, read the source.
+        info = {
+            "role": "Deal Jockey - Portfolio Manager",
+            "goal": (
+                "Manage deal portfolios -- import, catalog, inspect, organize, "
+                "migrate, and optimize deals across publishers, SSPs, and DSPs. "
+                "Treat deals as a managed asset class, ensuring the agency's deal "
+                "inventory is current, well-organized, and aligned with campaign needs."
+            ),
+            "backstory_summary": (
+                "Portfolio management specialist with deep expertise in "
+                "programmatic deal operations across the ad tech ecosystem. "
+                "Capabilities: deal portfolio organization, CSV/bulk import, "
+                "template creation, supply path analysis, cross-platform tracking "
+                "(TTD, DV360, Xandr, Amazon DSP), migration workflows, price "
+                "comparison, and gap analysis."
+            ),
+            "l1_routing": {
+                "deal_jockey_keywords": [
+                    "portfolio", "existing deals", "my deals", "migrate",
+                    "clone", "deprecate", "compare prices", "import",
+                    "catalog", "gap analysis", "sunset",
+                ],
+                "campaign_flow_keywords": [
+                    "campaign", "book for campaign", "budget",
+                    "target audience", "pacing", "flight dates", "launch",
+                ],
+                "ambiguous_response": (
+                    "Are you looking to manage your existing deal portfolio, "
+                    "or book deals for a specific campaign?"
+                ),
+            },
+            "phase1_tools": [
+                "list_portfolio", "search_portfolio",
+                "portfolio_summary", "inspect_deal",
+                "manual_deal_entry", "csv_deal_import",
+            ],
+            "phase1_event_types": [
+                "deal.imported", "deal.template_created",
+                "portfolio.inspected", "deal.manual_action_required",
+            ],
+        }
+        return jsonify(info)
+
+    # -- API: Enum values (for form dropdowns) ------------------------------
+
+    @app.route("/api/enums")
+    def api_enums():
+        """Return valid enum values for form dropdowns."""
+        return jsonify({
+            "deal_types": sorted(VALID_DEAL_TYPES),
+            "media_types": sorted(VALID_MEDIA_TYPES),
+            "price_models": sorted(VALID_PRICE_MODELS),
+            "seller_types": sorted(VALID_SELLER_TYPES),
+            "statuses": ["draft", "active", "paused"],
+        })
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Run the dashboard development server."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    db_path = os.environ.get(
+        "DASHBOARD_DB", "sqlite:///dealjockey_demo.db"
+    )
+    app = create_app(database_url=db_path)
+
+    port = int(os.environ.get("DASHBOARD_PORT", "5050"))
+    print(f"\n  DealJockey Dashboard running at http://localhost:{port}\n")
+    app.run(host="0.0.0.0", port=port, debug=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ad_buyer/demo/seed_data.py
+++ b/src/ad_buyer/demo/seed_data.py
@@ -1,0 +1,550 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Seed data for the DealJockey demo dashboard.
+
+Populates the DealStore with 14 realistic sample deals spanning
+multiple media types, statuses, deal types, sellers, and price ranges.
+Also seeds portfolio_metadata, deal_activations, and performance_cache
+for selected deals to demonstrate the full v2 schema.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+
+from ..storage.deal_store import DealStore
+
+logger = logging.getLogger(__name__)
+
+# Convenience timestamp
+_NOW = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def seed_demo_data(store: DealStore) -> list[str]:
+    """Insert 14 example deals with related metadata into the store.
+
+    Returns:
+        List of created deal IDs.
+    """
+    deals = _build_deals()
+    created_ids: list[str] = []
+
+    for spec in deals:
+        # Extract ancillary data before saving the deal
+        meta = spec.pop("_portfolio_metadata", None)
+        activations = spec.pop("_activations", None)
+        perf = spec.pop("_performance_cache", None)
+
+        deal_id = store.save_deal(**spec)
+        created_ids.append(deal_id)
+
+        # Portfolio metadata
+        if meta:
+            tags_val = meta.get("tags")
+            if isinstance(tags_val, list):
+                tags_val = json.dumps(tags_val)
+            store.save_portfolio_metadata(
+                deal_id=deal_id,
+                import_source=meta.get("import_source", "SEED"),
+                import_date=_NOW[:10],
+                tags=tags_val,
+                advertiser_id=meta.get("advertiser_id"),
+                agency_id=meta.get("agency_id"),
+            )
+
+        # Deal activations
+        if activations:
+            for act in activations:
+                store.save_deal_activation(
+                    deal_id=deal_id,
+                    platform=act["platform"],
+                    platform_deal_id=act.get("platform_deal_id"),
+                    activation_status=act.get("activation_status", "ACTIVE"),
+                    last_sync_at=act.get("last_sync_at", _NOW),
+                )
+
+        # Performance cache
+        if perf:
+            store.save_performance_cache(
+                deal_id=deal_id,
+                impressions_delivered=perf.get("impressions_delivered"),
+                spend_to_date=perf.get("spend_to_date"),
+                fill_rate=perf.get("fill_rate"),
+                win_rate=perf.get("win_rate"),
+                avg_effective_cpm=perf.get("avg_effective_cpm"),
+                last_delivery_at=perf.get("last_delivery_at", _NOW),
+                performance_trend=perf.get("performance_trend", "STABLE"),
+                cached_at=_NOW,
+            )
+
+        # Emit a seed event
+        store.save_event(
+            event_type="deal.imported",
+            deal_id=deal_id,
+            payload=json.dumps({
+                "import_source": "SEED",
+                "display_name": spec.get("display_name", spec.get("product_name", "")),
+            }),
+        )
+
+    logger.info("Seeded %d demo deals", len(created_ids))
+    return created_ids
+
+
+def _build_deals() -> list[dict]:
+    """Return a list of deal kwargs dicts (with ancillary _* keys)."""
+    return [
+        # 1. DIGITAL / PG / active -- ESPN
+        {
+            "seller_url": "https://espn.seller.example.com",
+            "product_id": "espn-sports-pmp",
+            "product_name": "ESPN Sports PMP",
+            "display_name": "ESPN Sports PMP",
+            "deal_type": "PG",
+            "status": "active",
+            "seller_deal_id": "ESPN-2026-Q1-001",
+            "seller_org": "ESPN",
+            "seller_domain": "espn.com",
+            "seller_type": "PUBLISHER",
+            "media_type": "DIGITAL",
+            "price": 18.50,
+            "fixed_price_cpm": 18.50,
+            "price_model": "CPM",
+            "currency": "USD",
+            "impressions": 5000000,
+            "flight_start": "2026-01-01",
+            "flight_end": "2026-03-31",
+            "description": "Premium sports display inventory across ESPN.com and app.",
+            "geo_targets": "US",
+            "formats": "display,native",
+            "_portfolio_metadata": {
+                "tags": ["premium", "sports", "Q1-2026"],
+                "advertiser_id": "ADV-NIKE-001",
+                "agency_id": "AGY-MEDIACOM-001",
+                "import_source": "CSV",
+            },
+            "_activations": [
+                {"platform": "TTD", "platform_deal_id": "TTD-ESPN-7890", "activation_status": "ACTIVE"},
+                {"platform": "DV360", "platform_deal_id": "DV-ESPN-4521", "activation_status": "ACTIVE"},
+            ],
+            "_performance_cache": {
+                "impressions_delivered": 3250000,
+                "spend_to_date": 60125.00,
+                "fill_rate": 0.72,
+                "win_rate": 0.85,
+                "avg_effective_cpm": 18.50,
+                "performance_trend": "STABLE",
+            },
+        },
+        # 2. DIGITAL / PD / active -- NYT
+        {
+            "seller_url": "https://nyt.seller.example.com",
+            "product_id": "nyt-premium-news",
+            "product_name": "NYT Premium News",
+            "display_name": "NYT Premium News",
+            "deal_type": "PD",
+            "status": "active",
+            "seller_deal_id": "NYT-2026-Q1-042",
+            "seller_org": "The New York Times",
+            "seller_domain": "nytimes.com",
+            "seller_type": "PUBLISHER",
+            "media_type": "DIGITAL",
+            "price": 22.00,
+            "fixed_price_cpm": 22.00,
+            "price_model": "CPM",
+            "currency": "USD",
+            "impressions": 2000000,
+            "flight_start": "2026-02-01",
+            "flight_end": "2026-04-30",
+            "description": "High-viewability news content targeting.",
+            "content_categories": "IAB12,IAB12-1",
+            "_portfolio_metadata": {
+                "tags": ["news", "premium", "brand-safe"],
+                "advertiser_id": "ADV-AMEX-002",
+                "import_source": "CSV",
+            },
+            "_activations": [
+                {"platform": "TTD", "platform_deal_id": "TTD-NYT-1234", "activation_status": "ACTIVE"},
+            ],
+            "_performance_cache": {
+                "impressions_delivered": 800000,
+                "spend_to_date": 17600.00,
+                "fill_rate": 0.65,
+                "win_rate": 0.78,
+                "avg_effective_cpm": 22.00,
+                "performance_trend": "IMPROVING",
+            },
+        },
+        # 3. DIGITAL / PA / active -- Condé Nast
+        {
+            "seller_url": "https://condenast.seller.example.com",
+            "product_id": "cn-lifestyle",
+            "product_name": "Condé Nast Lifestyle",
+            "display_name": "Condé Nast Lifestyle PMP",
+            "deal_type": "PA",
+            "status": "active",
+            "seller_deal_id": "CN-2026-LF-005",
+            "seller_org": "Condé Nast",
+            "seller_domain": "condenast.com",
+            "seller_type": "PUBLISHER",
+            "media_type": "DIGITAL",
+            "price": 15.00,
+            "bid_floor_cpm": 12.00,
+            "price_model": "CPM",
+            "currency": "USD",
+            "impressions": 3000000,
+            "flight_start": "2026-01-15",
+            "flight_end": "2026-06-30",
+            "description": "Lifestyle and fashion inventory across Vogue, GQ, Vanity Fair.",
+            "content_categories": "IAB18,IAB9",
+            "_portfolio_metadata": {
+                "tags": ["lifestyle", "fashion", "premium"],
+                "advertiser_id": "ADV-LVMH-003",
+                "import_source": "MANUAL",
+            },
+        },
+        # 4. DIGITAL / PG / active -- BuzzFeed
+        {
+            "seller_url": "https://buzzfeed.seller.example.com",
+            "product_id": "bf-entertainment",
+            "product_name": "BuzzFeed Entertainment",
+            "display_name": "BuzzFeed Entertainment Package",
+            "deal_type": "PG",
+            "status": "active",
+            "seller_deal_id": "BF-2026-ENT-010",
+            "seller_org": "BuzzFeed",
+            "seller_domain": "buzzfeed.com",
+            "seller_type": "PUBLISHER",
+            "media_type": "DIGITAL",
+            "price": 8.50,
+            "fixed_price_cpm": 8.50,
+            "price_model": "CPM",
+            "currency": "USD",
+            "impressions": 10000000,
+            "flight_start": "2026-03-01",
+            "flight_end": "2026-05-31",
+            "description": "High-volume entertainment and quiz content.",
+        },
+        # 5. CTV / PG / active -- Hulu
+        {
+            "seller_url": "https://hulu.seller.example.com",
+            "product_id": "hulu-premium-ctv",
+            "product_name": "Hulu Premium CTV",
+            "display_name": "Hulu Premium CTV Package",
+            "deal_type": "PG",
+            "status": "active",
+            "seller_deal_id": "HULU-2026-CTV-003",
+            "seller_org": "Hulu",
+            "seller_domain": "hulu.com",
+            "seller_type": "PUBLISHER",
+            "media_type": "CTV",
+            "price": 35.00,
+            "fixed_price_cpm": 35.00,
+            "price_model": "CPM",
+            "currency": "USD",
+            "impressions": 1500000,
+            "flight_start": "2026-01-01",
+            "flight_end": "2026-06-30",
+            "description": "Premium CTV spots across Hulu originals and live TV.",
+            "formats": "video_15s,video_30s",
+            "_portfolio_metadata": {
+                "tags": ["ctv", "premium", "streaming"],
+                "advertiser_id": "ADV-TOYOTA-004",
+                "import_source": "CSV",
+            },
+            "_activations": [
+                {"platform": "TTD", "platform_deal_id": "TTD-HULU-5678", "activation_status": "ACTIVE"},
+                {"platform": "DV360", "platform_deal_id": "DV-HULU-9012", "activation_status": "PENDING"},
+            ],
+            "_performance_cache": {
+                "impressions_delivered": 420000,
+                "spend_to_date": 14700.00,
+                "fill_rate": 0.88,
+                "win_rate": 0.92,
+                "avg_effective_cpm": 35.00,
+                "performance_trend": "IMPROVING",
+            },
+        },
+        # 6. CTV / PD / draft -- Peacock
+        {
+            "seller_url": "https://peacock.seller.example.com",
+            "product_id": "peacock-ctv-sports",
+            "product_name": "Peacock CTV Sports",
+            "display_name": "Peacock CTV Sports Bundle",
+            "deal_type": "PD",
+            "status": "draft",
+            "seller_deal_id": "PCOK-2026-SPT-007",
+            "seller_org": "Peacock / NBCU",
+            "seller_domain": "peacocktv.com",
+            "seller_type": "PUBLISHER",
+            "media_type": "CTV",
+            "price": 42.00,
+            "fixed_price_cpm": 42.00,
+            "price_model": "CPM",
+            "currency": "USD",
+            "impressions": 800000,
+            "flight_start": "2026-04-01",
+            "flight_end": "2026-06-30",
+            "description": "Live sports and Olympics content on Peacock.",
+            "_portfolio_metadata": {
+                "tags": ["ctv", "sports", "olympics"],
+                "advertiser_id": "ADV-COCA-COLA-005",
+                "import_source": "MANUAL",
+            },
+        },
+        # 7. CTV / PA / draft -- Pluto TV
+        {
+            "seller_url": "https://pluto.seller.example.com",
+            "product_id": "pluto-ctv-entertainment",
+            "product_name": "Pluto TV Entertainment",
+            "display_name": "Pluto TV FAST Channels",
+            "deal_type": "PA",
+            "status": "draft",
+            "seller_deal_id": "PLUTO-2026-FAST-012",
+            "seller_org": "Pluto TV",
+            "seller_domain": "pluto.tv",
+            "seller_type": "SSP",
+            "media_type": "CTV",
+            "price": 12.00,
+            "bid_floor_cpm": 8.00,
+            "price_model": "CPM",
+            "currency": "USD",
+            "impressions": 5000000,
+            "flight_start": "2026-04-15",
+            "flight_end": "2026-07-31",
+            "description": "FAST channel inventory across entertainment verticals.",
+        },
+        # 8. LINEAR_TV / PG / draft -- NBCUniversal
+        {
+            "seller_url": "https://nbcu.seller.example.com",
+            "product_id": "nbcu-primetime-linear",
+            "product_name": "NBCU Primetime Linear",
+            "display_name": "NBCU Primetime Upfront 2026",
+            "deal_type": "PG",
+            "status": "draft",
+            "seller_deal_id": "NBCU-2026-UPF-001",
+            "seller_org": "NBCUniversal",
+            "seller_domain": "nbcuniversal.com",
+            "seller_type": "PUBLISHER",
+            "media_type": "LINEAR_TV",
+            "price": 45.00,
+            "cpp": 45.00,
+            "guaranteed_grps": 150.0,
+            "price_model": "CPP",
+            "currency": "USD",
+            "impressions": 20000000,
+            "flight_start": "2026-09-01",
+            "flight_end": "2026-12-31",
+            "description": "Primetime upfront commitment across NBC, USA, and Bravo.",
+            "dayparts": "primetime",
+            "networks": "NBC,USA,Bravo",
+            "makegood_provisions": "Standard ADU makegoods within 4 weeks",
+            "cancellation_window": "14 days",
+            "audience_guarantee": "A18-49",
+            "_portfolio_metadata": {
+                "tags": ["linear", "upfront", "primetime"],
+                "advertiser_id": "ADV-PG-006",
+                "agency_id": "AGY-MINDSHARE-002",
+                "import_source": "MANUAL",
+            },
+        },
+        # 9. LINEAR_TV / PD / paused -- Fox
+        {
+            "seller_url": "https://fox.seller.example.com",
+            "product_id": "fox-scatter-sports",
+            "product_name": "Fox Scatter Sports",
+            "display_name": "Fox Sports Scatter Q2",
+            "deal_type": "PD",
+            "status": "paused",
+            "seller_deal_id": "FOX-2026-SCT-015",
+            "seller_org": "Fox Corporation",
+            "seller_domain": "fox.com",
+            "seller_type": "PUBLISHER",
+            "media_type": "LINEAR_TV",
+            "price": 38.00,
+            "cpp": 38.00,
+            "price_model": "CPP",
+            "currency": "USD",
+            "impressions": 8000000,
+            "flight_start": "2026-04-01",
+            "flight_end": "2026-06-30",
+            "description": "Scatter sports inventory on Fox broadcast and FS1.",
+            "networks": "FOX,FS1",
+            "_portfolio_metadata": {
+                "tags": ["linear", "scatter", "sports"],
+                "advertiser_id": "ADV-BUDWEISER-007",
+                "import_source": "CSV",
+            },
+        },
+        # 10. AUDIO / PD / active -- Spotify
+        {
+            "seller_url": "https://spotify.seller.example.com",
+            "product_id": "spotify-podcast-audio",
+            "product_name": "Spotify Podcast Audio",
+            "display_name": "Spotify Podcast Network",
+            "deal_type": "PD",
+            "status": "paused",
+            "seller_deal_id": "SPOT-2026-POD-020",
+            "seller_org": "Spotify",
+            "seller_domain": "spotify.com",
+            "seller_type": "PUBLISHER",
+            "media_type": "AUDIO",
+            "price": 25.00,
+            "fixed_price_cpm": 25.00,
+            "price_model": "CPM",
+            "currency": "USD",
+            "impressions": 2000000,
+            "flight_start": "2026-02-01",
+            "flight_end": "2026-05-31",
+            "description": "Premium podcast ad placements across Spotify exclusive shows.",
+            "audience_segments": "podcast_listeners,music_enthusiasts",
+            "_portfolio_metadata": {
+                "tags": ["audio", "podcast", "premium"],
+                "advertiser_id": "ADV-SAMSUNG-008",
+                "import_source": "CSV",
+            },
+            "_activations": [
+                {"platform": "TTD", "platform_deal_id": "TTD-SPOT-3456", "activation_status": "PAUSED"},
+            ],
+            "_performance_cache": {
+                "impressions_delivered": 650000,
+                "spend_to_date": 16250.00,
+                "fill_rate": 0.55,
+                "win_rate": 0.70,
+                "avg_effective_cpm": 25.00,
+                "performance_trend": "DECLINING",
+            },
+        },
+        # 11. AUDIO / PA / expired -- iHeartMedia
+        {
+            "seller_url": "https://iheart.seller.example.com",
+            "product_id": "iheart-streaming-audio",
+            "product_name": "iHeart Streaming Audio",
+            "display_name": "iHeart Digital Audio PMP",
+            "deal_type": "PA",
+            "status": "expired",
+            "seller_deal_id": "IHM-2025-Q4-030",
+            "seller_org": "iHeartMedia",
+            "seller_domain": "iheart.com",
+            "seller_type": "PUBLISHER",
+            "media_type": "AUDIO",
+            "price": 10.00,
+            "bid_floor_cpm": 7.50,
+            "price_model": "CPM",
+            "currency": "USD",
+            "impressions": 4000000,
+            "flight_start": "2025-10-01",
+            "flight_end": "2025-12-31",
+            "description": "Streaming audio across iHeart stations and podcasts.",
+        },
+        # 12. DOOH / PD / canceled -- Clear Channel
+        {
+            "seller_url": "https://clearchannel.seller.example.com",
+            "product_id": "cc-dooh-airports",
+            "product_name": "Clear Channel DOOH Airports",
+            "display_name": "Clear Channel Airport DOOH",
+            "deal_type": "PD",
+            "status": "canceled",
+            "seller_deal_id": "CC-2026-APT-008",
+            "seller_org": "Clear Channel Outdoor",
+            "seller_domain": "clearchannel.com",
+            "seller_type": "SSP",
+            "media_type": "DOOH",
+            "price": 5.50,
+            "fixed_price_cpm": 5.50,
+            "price_model": "CPM",
+            "currency": "USD",
+            "impressions": 15000000,
+            "flight_start": "2026-01-01",
+            "flight_end": "2026-06-30",
+            "description": "Digital screens in major US airports (JFK, LAX, ORD, ATL).",
+            "geo_targets": "US-NY,US-CA,US-IL,US-GA",
+            "_portfolio_metadata": {
+                "tags": ["dooh", "airports", "travel"],
+                "advertiser_id": "ADV-MARRIOTT-009",
+                "import_source": "MANUAL",
+            },
+        },
+        # 13. DIGITAL / PG / active -- The Washington Post
+        {
+            "seller_url": "https://washpost.seller.example.com",
+            "product_id": "wapo-politics",
+            "product_name": "WaPo Politics",
+            "display_name": "Washington Post Politics PMP",
+            "deal_type": "PG",
+            "status": "active",
+            "seller_deal_id": "WAPO-2026-POL-003",
+            "seller_org": "The Washington Post",
+            "seller_domain": "washingtonpost.com",
+            "seller_type": "PUBLISHER",
+            "media_type": "DIGITAL",
+            "price": 28.00,
+            "fixed_price_cpm": 28.00,
+            "price_model": "CPM",
+            "currency": "USD",
+            "impressions": 1500000,
+            "flight_start": "2026-01-01",
+            "flight_end": "2026-04-15",
+            "description": "Political news and analysis sections, high engagement.",
+            "content_categories": "IAB11,IAB11-4",
+            "_activations": [
+                {"platform": "DV360", "platform_deal_id": "DV-WAPO-6789", "activation_status": "ACTIVE"},
+            ],
+            "_performance_cache": {
+                "impressions_delivered": 1100000,
+                "spend_to_date": 30800.00,
+                "fill_rate": 0.80,
+                "win_rate": 0.88,
+                "avg_effective_cpm": 28.00,
+                "performance_trend": "STABLE",
+            },
+        },
+        # 14. CTV / PD / active -- Roku (via Magnite SSP)
+        {
+            "seller_url": "https://magnite.seller.example.com",
+            "product_id": "roku-magnite-ctv",
+            "product_name": "Roku via Magnite CTV",
+            "display_name": "Roku Channel via Magnite",
+            "deal_type": "PD",
+            "status": "active",
+            "seller_deal_id": "MAG-ROKU-2026-009",
+            "seller_org": "Magnite (Roku Channel)",
+            "seller_domain": "magnite.com",
+            "seller_type": "SSP",
+            "media_type": "CTV",
+            "price": 20.00,
+            "fixed_price_cpm": 20.00,
+            "bid_floor_cpm": 15.00,
+            "price_model": "CPM",
+            "currency": "USD",
+            "impressions": 3000000,
+            "flight_start": "2026-02-15",
+            "flight_end": "2026-05-15",
+            "description": "Roku Channel CTV supply via Magnite SSP.",
+            "formats": "video_15s,video_30s",
+            "schain_complete": 1,
+            "schain_nodes": json.dumps([
+                {"asi": "magnite.com", "sid": "12345", "hp": 1},
+                {"asi": "roku.com", "sid": "67890", "hp": 1},
+            ]),
+            "is_direct": 0,
+            "hop_count": 2,
+            "_portfolio_metadata": {
+                "tags": ["ctv", "ssp", "roku"],
+                "advertiser_id": "ADV-GEICO-010",
+                "import_source": "TTD_API",
+            },
+            "_activations": [
+                {"platform": "TTD", "platform_deal_id": "TTD-ROKU-MAG-111", "activation_status": "ACTIVE"},
+            ],
+            "_performance_cache": {
+                "impressions_delivered": 950000,
+                "spend_to_date": 19000.00,
+                "fill_rate": 0.60,
+                "win_rate": 0.75,
+                "avg_effective_cpm": 20.00,
+                "performance_trend": "STABLE",
+            },
+        },
+    ]

--- a/src/ad_buyer/demo/templates/dashboard.html
+++ b/src/ad_buyer/demo/templates/dashboard.html
@@ -1,0 +1,907 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DealJockey Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YcnS/pqFESY2zCNG0no9aIi7INnWk6cl+Qhc"
+        crossorigin="anonymous">
+  <style>
+    :root {
+      --dj-primary: #2563eb;
+      --dj-dark: #1e293b;
+      --dj-light: #f8fafc;
+    }
+    body { background: var(--dj-light); }
+    .navbar { background: var(--dj-dark) !important; }
+    .navbar-brand { font-weight: 700; letter-spacing: .5px; }
+
+    .section-card { margin-bottom: 1.5rem; }
+    .section-card .card-header {
+      font-weight: 600;
+      font-size: .95rem;
+      background: #e2e8f0;
+    }
+
+    /* Status badges */
+    .badge-active   { background: #16a34a; }
+    .badge-draft    { background: #ca8a04; }
+    .badge-paused   { background: #ea580c; }
+    .badge-expired  { background: #dc2626; }
+    .badge-canceled { background: #6b7280; }
+    .badge-imported { background: #7c3aed; }
+
+    /* Sortable column headers */
+    th.sortable { cursor: pointer; user-select: none; }
+    th.sortable:hover { color: var(--dj-primary); }
+    th.sortable::after { content: ' \25B4\25BE'; font-size: .7em; opacity: .4; }
+
+    /* Deal detail modal */
+    .detail-label { font-weight: 600; color: #475569; min-width: 160px; }
+
+    /* Agent sidebar */
+    .agent-sidebar { font-size: .88rem; }
+    .agent-sidebar .badge { font-size: .75rem; }
+
+    /* Schema panel mini table */
+    .schema-table td { padding: .25rem .5rem; font-size: .85rem; }
+
+    /* Clickable row */
+    .deal-row { cursor: pointer; }
+    .deal-row:hover { background: #e0e7ff !important; }
+
+    /* Import results */
+    .import-results { max-height: 400px; overflow-y: auto; }
+
+    /* Event log */
+    .event-log { max-height: 350px; overflow-y: auto; }
+    .event-entry { font-size: .85rem; border-bottom: 1px solid #e2e8f0; padding: .4rem 0; }
+  </style>
+</head>
+<body>
+
+<!-- Navbar -->
+<nav class="navbar navbar-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand">DealJockey <small class="text-secondary">Phase 1 Dashboard</small></span>
+    <span class="text-light small" id="nav-deal-count"></span>
+  </div>
+</nav>
+
+<div class="container-fluid mt-3">
+<div class="row">
+
+<!-- ============================================================ -->
+<!-- LEFT COLUMN: Main content -->
+<!-- ============================================================ -->
+<div class="col-lg-9">
+
+  <!-- Section 1: Schema Status -->
+  <div class="card section-card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      Schema Status
+      <button class="btn btn-sm btn-outline-secondary" onclick="loadSchema()">Refresh</button>
+    </div>
+    <div class="card-body p-2">
+      <div class="row">
+        <div class="col-md-3">
+          <strong>Schema Version:</strong> <span id="schema-version" class="badge bg-primary">--</span>
+        </div>
+        <div class="col-md-4">
+          <strong>Tables:</strong>
+          <table class="table table-sm schema-table mb-0 mt-1" id="schema-tables">
+            <tbody></tbody>
+          </table>
+        </div>
+        <div class="col-md-5">
+          <strong>v2 Deal Columns:</strong>
+          <div id="v2-columns" class="mt-1" style="font-size:.82rem; max-height:120px; overflow-y:auto;"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Section 2 & 3: Filters + Deal Table -->
+  <div class="card section-card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      Deal Portfolio
+      <div>
+        <button class="btn btn-sm btn-outline-primary me-1" onclick="showSummaryModal()">Summary</button>
+        <button class="btn btn-sm btn-outline-secondary" onclick="loadDeals()">Refresh</button>
+      </div>
+    </div>
+    <div class="card-body">
+      <!-- Filters row -->
+      <div class="row g-2 mb-3" id="filters-row">
+        <div class="col-auto">
+          <select class="form-select form-select-sm" id="filter-status">
+            <option value="">All Statuses</option>
+            <option value="active">Active</option>
+            <option value="draft">Draft</option>
+            <option value="paused">Paused</option>
+            <option value="expired">Expired</option>
+            <option value="canceled">Canceled</option>
+          </select>
+        </div>
+        <div class="col-auto">
+          <select class="form-select form-select-sm" id="filter-media-type">
+            <option value="">All Media Types</option>
+          </select>
+        </div>
+        <div class="col-auto">
+          <select class="form-select form-select-sm" id="filter-deal-type">
+            <option value="">All Deal Types</option>
+          </select>
+        </div>
+        <div class="col-auto">
+          <select class="form-select form-select-sm" id="filter-seller">
+            <option value="">All Sellers</option>
+          </select>
+        </div>
+        <div class="col-auto flex-grow-1">
+          <div class="input-group input-group-sm">
+            <input type="text" class="form-control" id="search-box" placeholder="Search deals...">
+            <button class="btn btn-outline-primary" onclick="searchDeals()">Search</button>
+          </div>
+        </div>
+        <div class="col-auto">
+          <button class="btn btn-sm btn-primary" onclick="applyFilters()">Apply</button>
+          <button class="btn btn-sm btn-outline-secondary" onclick="clearFilters()">Clear</button>
+        </div>
+      </div>
+
+      <!-- Deal table -->
+      <div class="table-responsive">
+        <table class="table table-sm table-hover align-middle" id="deal-table">
+          <thead class="table-light">
+            <tr>
+              <th class="sortable" data-col="display_name">Name</th>
+              <th class="sortable" data-col="seller_org">Seller</th>
+              <th class="sortable" data-col="deal_type">Type</th>
+              <th class="sortable" data-col="media_type">Media</th>
+              <th class="sortable" data-col="status">Status</th>
+              <th class="sortable" data-col="price">Price</th>
+              <th class="sortable" data-col="flight_start">Flight Start</th>
+              <th class="sortable" data-col="flight_end">Flight End</th>
+            </tr>
+          </thead>
+          <tbody id="deal-tbody"></tbody>
+        </table>
+      </div>
+      <div id="deal-count-info" class="text-muted small"></div>
+    </div>
+  </div>
+
+  <!-- Section 4: CSV Import -->
+  <div class="card section-card">
+    <div class="card-header">CSV Import</div>
+    <div class="card-body">
+      <form id="csv-form" enctype="multipart/form-data">
+        <div class="row g-2 align-items-end">
+          <div class="col-auto flex-grow-1">
+            <label class="form-label form-label-sm mb-0">CSV File</label>
+            <input type="file" class="form-control form-control-sm" id="csv-file" accept=".csv">
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-sm btn-primary">Parse CSV</button>
+          </div>
+        </div>
+      </form>
+      <div id="import-results" class="mt-3 d-none">
+        <div class="row">
+          <div class="col-auto">
+            <span class="badge bg-success" id="import-success">0 successful</span>
+            <span class="badge bg-danger" id="import-errors">0 errors</span>
+            <span class="badge bg-warning text-dark" id="import-skipped">0 skipped</span>
+          </div>
+          <div class="col-auto">
+            <button class="btn btn-sm btn-success" id="save-import-btn" onclick="saveImportedDeals()">
+              Save to Portfolio
+            </button>
+          </div>
+        </div>
+        <div class="import-results mt-2">
+          <div id="import-deals-table"></div>
+          <div id="import-errors-table" class="mt-2"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Section 5: Manual Entry -->
+  <div class="card section-card">
+    <div class="card-header">Manual Deal Entry</div>
+    <div class="card-body">
+      <form id="manual-form">
+        <div class="row g-2">
+          <div class="col-md-4">
+            <label class="form-label form-label-sm mb-0">Display Name *</label>
+            <input type="text" class="form-control form-control-sm" name="display_name" required>
+          </div>
+          <div class="col-md-4">
+            <label class="form-label form-label-sm mb-0">Seller URL *</label>
+            <input type="text" class="form-control form-control-sm" name="seller_url" required
+                   placeholder="https://seller.example.com">
+          </div>
+          <div class="col-md-2">
+            <label class="form-label form-label-sm mb-0">Deal Type</label>
+            <select class="form-select form-select-sm" name="deal_type" id="manual-deal-type"></select>
+          </div>
+          <div class="col-md-2">
+            <label class="form-label form-label-sm mb-0">Status</label>
+            <select class="form-select form-select-sm" name="status">
+              <option value="draft" selected>Draft</option>
+              <option value="active">Active</option>
+              <option value="paused">Paused</option>
+            </select>
+          </div>
+        </div>
+        <div class="row g-2 mt-1">
+          <div class="col-md-3">
+            <label class="form-label form-label-sm mb-0">Seller Org</label>
+            <input type="text" class="form-control form-control-sm" name="seller_org">
+          </div>
+          <div class="col-md-3">
+            <label class="form-label form-label-sm mb-0">Seller Domain</label>
+            <input type="text" class="form-control form-control-sm" name="seller_domain"
+                   placeholder="example.com">
+          </div>
+          <div class="col-md-2">
+            <label class="form-label form-label-sm mb-0">Seller Type</label>
+            <select class="form-select form-select-sm" name="seller_type" id="manual-seller-type">
+              <option value="">--</option>
+            </select>
+          </div>
+          <div class="col-md-2">
+            <label class="form-label form-label-sm mb-0">Media Type</label>
+            <select class="form-select form-select-sm" name="media_type" id="manual-media-type">
+              <option value="">--</option>
+            </select>
+          </div>
+          <div class="col-md-2">
+            <label class="form-label form-label-sm mb-0">Price Model</label>
+            <select class="form-select form-select-sm" name="price_model" id="manual-price-model">
+              <option value="">--</option>
+            </select>
+          </div>
+        </div>
+        <div class="row g-2 mt-1">
+          <div class="col-md-2">
+            <label class="form-label form-label-sm mb-0">Price (CPM)</label>
+            <input type="number" step="0.01" class="form-control form-control-sm" name="price">
+          </div>
+          <div class="col-md-2">
+            <label class="form-label form-label-sm mb-0">Impressions</label>
+            <input type="number" class="form-control form-control-sm" name="impressions">
+          </div>
+          <div class="col-md-2">
+            <label class="form-label form-label-sm mb-0">Flight Start</label>
+            <input type="date" class="form-control form-control-sm" name="flight_start">
+          </div>
+          <div class="col-md-2">
+            <label class="form-label form-label-sm mb-0">Flight End</label>
+            <input type="date" class="form-control form-control-sm" name="flight_end">
+          </div>
+          <div class="col-md-2">
+            <label class="form-label form-label-sm mb-0">Advertiser ID</label>
+            <input type="text" class="form-control form-control-sm" name="advertiser_id">
+          </div>
+          <div class="col-md-2">
+            <label class="form-label form-label-sm mb-0">Tags (comma-sep)</label>
+            <input type="text" class="form-control form-control-sm" name="tags" placeholder="premium,sports">
+          </div>
+        </div>
+        <div class="row g-2 mt-1">
+          <div class="col-md-8">
+            <label class="form-label form-label-sm mb-0">Description</label>
+            <input type="text" class="form-control form-control-sm" name="description">
+          </div>
+          <div class="col-md-2">
+            <label class="form-label form-label-sm mb-0">Seller Deal ID</label>
+            <input type="text" class="form-control form-control-sm" name="seller_deal_id">
+          </div>
+          <div class="col-md-2 d-flex align-items-end">
+            <button type="submit" class="btn btn-sm btn-primary w-100">Create Deal</button>
+          </div>
+        </div>
+      </form>
+      <div id="manual-result" class="mt-2"></div>
+    </div>
+  </div>
+
+  <!-- Section 6: Event Log -->
+  <div class="card section-card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      Event Log <small class="text-muted">(Phase 1 events)</small>
+      <button class="btn btn-sm btn-outline-secondary" onclick="loadEvents()">Refresh</button>
+    </div>
+    <div class="card-body p-2">
+      <div class="event-log" id="event-log"></div>
+    </div>
+  </div>
+
+</div><!-- /col-lg-9 -->
+
+<!-- ============================================================ -->
+<!-- RIGHT COLUMN: Agent Info Sidebar -->
+<!-- ============================================================ -->
+<div class="col-lg-3">
+  <div class="card section-card agent-sidebar">
+    <div class="card-header">DealJockey Agent</div>
+    <div class="card-body" id="agent-info">
+      <div class="text-muted small">Loading...</div>
+    </div>
+  </div>
+</div>
+
+</div><!-- /row -->
+</div><!-- /container -->
+
+<!-- Deal Detail Modal -->
+<div class="modal fade" id="dealModal" tabindex="-1">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="dealModalTitle">Deal Detail</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body" id="dealModalBody"></div>
+    </div>
+  </div>
+</div>
+
+<!-- Summary Modal -->
+<div class="modal fade" id="summaryModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Portfolio Summary</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body" id="summaryModalBody">
+        <div class="text-center text-muted">Loading...</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+        crossorigin="anonymous"></script>
+<script>
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+let allDeals = [];
+let parsedImportDeals = [];
+let sortCol = 'display_name';
+let sortAsc = true;
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+document.addEventListener('DOMContentLoaded', () => {
+  loadSchema();
+  loadEnums();
+  loadDeals();
+  loadEvents();
+  loadAgentInfo();
+
+  // Sort headers
+  document.querySelectorAll('th.sortable').forEach(th => {
+    th.addEventListener('click', () => {
+      const col = th.dataset.col;
+      if (sortCol === col) { sortAsc = !sortAsc; }
+      else { sortCol = col; sortAsc = true; }
+      renderDeals(allDeals);
+    });
+  });
+
+  // CSV form
+  document.getElementById('csv-form').addEventListener('submit', e => {
+    e.preventDefault();
+    uploadCSV();
+  });
+
+  // Manual form
+  document.getElementById('manual-form').addEventListener('submit', e => {
+    e.preventDefault();
+    createManualDeal();
+  });
+
+  // Search on Enter
+  document.getElementById('search-box').addEventListener('keydown', e => {
+    if (e.key === 'Enter') { e.preventDefault(); searchDeals(); }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+async function api(url, opts) {
+  const resp = await fetch(url, opts);
+  return resp.json();
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+async function loadSchema() {
+  const data = await api('/api/schema');
+  document.getElementById('schema-version').textContent = 'v' + data.schema_version;
+
+  const tbody = document.querySelector('#schema-tables tbody');
+  tbody.innerHTML = data.tables.map(t =>
+    `<tr><td>${t.name}</td><td class="text-end">${t.row_count}</td></tr>`
+  ).join('');
+
+  document.getElementById('v2-columns').innerHTML =
+    data.v2_columns.map(c => `<span class="badge bg-secondary me-1 mb-1">${c}</span>`).join('');
+}
+
+// ---------------------------------------------------------------------------
+// Enums (for dropdowns)
+// ---------------------------------------------------------------------------
+async function loadEnums() {
+  const data = await api('/api/enums');
+
+  // Filter dropdowns
+  fillSelect('filter-media-type', data.media_types, 'All Media Types');
+  fillSelect('filter-deal-type', data.deal_types, 'All Deal Types');
+
+  // Manual entry dropdowns
+  fillSelect('manual-deal-type', data.deal_types, null, 'PD');
+  fillSelect('manual-media-type', data.media_types, '--');
+  fillSelect('manual-seller-type', data.seller_types, '--');
+  fillSelect('manual-price-model', data.price_models, '--');
+}
+
+function fillSelect(id, values, emptyLabel, defaultVal) {
+  const sel = document.getElementById(id);
+  if (!sel) return;
+  // Keep existing options if emptyLabel is provided
+  let html = '';
+  if (emptyLabel) html = `<option value="">${emptyLabel}</option>`;
+  values.forEach(v => {
+    const selected = v === defaultVal ? ' selected' : '';
+    html += `<option value="${v}"${selected}>${v}</option>`;
+  });
+  sel.innerHTML = html;
+}
+
+// ---------------------------------------------------------------------------
+// Deals
+// ---------------------------------------------------------------------------
+async function loadDeals() {
+  const data = await api('/api/deals?limit=500');
+  allDeals = data.deals;
+  renderDeals(allDeals);
+  populateSellerFilter(allDeals);
+  document.getElementById('nav-deal-count').textContent = data.count + ' deals';
+}
+
+function applyFilters() {
+  const params = new URLSearchParams();
+  const status = document.getElementById('filter-status').value;
+  const media = document.getElementById('filter-media-type').value;
+  const dtype = document.getElementById('filter-deal-type').value;
+  if (status) params.set('status', status);
+  if (media) params.set('media_type', media);
+  if (dtype) params.set('deal_type', dtype);
+
+  api('/api/deals?' + params.toString() + '&limit=500').then(data => {
+    // Apply seller filter client-side
+    const seller = document.getElementById('filter-seller').value;
+    let deals = data.deals;
+    if (seller) {
+      deals = deals.filter(d => (d.seller_org || d.seller_domain || '') === seller);
+    }
+    allDeals = deals;
+    renderDeals(allDeals);
+  });
+}
+
+function clearFilters() {
+  document.getElementById('filter-status').value = '';
+  document.getElementById('filter-media-type').value = '';
+  document.getElementById('filter-deal-type').value = '';
+  document.getElementById('filter-seller').value = '';
+  document.getElementById('search-box').value = '';
+  loadDeals();
+}
+
+async function searchDeals() {
+  const q = document.getElementById('search-box').value.trim();
+  if (!q) { loadDeals(); return; }
+  const data = await api('/api/search?q=' + encodeURIComponent(q));
+  allDeals = data.results;
+  renderDeals(allDeals);
+}
+
+function populateSellerFilter(deals) {
+  const sellers = new Set();
+  deals.forEach(d => {
+    const s = d.seller_org || d.seller_domain;
+    if (s) sellers.add(s);
+  });
+  const sel = document.getElementById('filter-seller');
+  let html = '<option value="">All Sellers</option>';
+  [...sellers].sort().forEach(s => {
+    html += `<option value="${esc(s)}">${esc(s)}</option>`;
+  });
+  sel.innerHTML = html;
+}
+
+function renderDeals(deals) {
+  // Sort
+  const sorted = [...deals].sort((a, b) => {
+    let av = a[sortCol] ?? '';
+    let bv = b[sortCol] ?? '';
+    if (typeof av === 'number' && typeof bv === 'number') {
+      return sortAsc ? av - bv : bv - av;
+    }
+    av = String(av).toLowerCase();
+    bv = String(bv).toLowerCase();
+    if (av < bv) return sortAsc ? -1 : 1;
+    if (av > bv) return sortAsc ? 1 : -1;
+    return 0;
+  });
+
+  const tbody = document.getElementById('deal-tbody');
+  tbody.innerHTML = sorted.map(d => {
+    const name = d.display_name || d.product_name || '(unnamed)';
+    const seller = d.seller_org || d.seller_domain || 'N/A';
+    const status = d.status || '?';
+    const price = d.price != null ? '$' + Number(d.price).toFixed(2) : '--';
+    return `<tr class="deal-row" onclick="showDealDetail('${d.id}')">
+      <td>${esc(name)}</td>
+      <td>${esc(seller)}</td>
+      <td><span class="badge bg-info text-dark">${d.deal_type || '?'}</span></td>
+      <td>${d.media_type || 'N/A'}</td>
+      <td><span class="badge badge-${status}">${status}</span></td>
+      <td>${price}</td>
+      <td>${d.flight_start || '--'}</td>
+      <td>${d.flight_end || '--'}</td>
+    </tr>`;
+  }).join('');
+
+  document.getElementById('deal-count-info').textContent =
+    `Showing ${sorted.length} deal(s)`;
+}
+
+// ---------------------------------------------------------------------------
+// Deal Detail Modal
+// ---------------------------------------------------------------------------
+async function showDealDetail(dealId) {
+  const data = await api('/api/deals/' + dealId);
+  const d = data.deal;
+  const meta = data.portfolio_metadata;
+  const acts = data.activations || [];
+  const perf = data.performance_cache;
+
+  const name = d.display_name || d.product_name || '(unnamed)';
+  document.getElementById('dealModalTitle').textContent = name;
+
+  let html = '<div class="row">';
+
+  // Core fields
+  html += '<div class="col-md-6">';
+  html += '<h6>Core Fields</h6>';
+  html += detailRow('ID', d.id);
+  html += detailRow('Display Name', name);
+  html += detailRow('Status', `<span class="badge badge-${d.status}">${d.status}</span>`);
+  html += detailRow('Deal Type', d.deal_type);
+  html += detailRow('Media Type', d.media_type || 'N/A');
+  html += detailRow('Seller Deal ID', d.seller_deal_id || 'N/A');
+  html += detailRow('Description', d.description || 'N/A');
+  html += '</div>';
+
+  // Seller + Pricing
+  html += '<div class="col-md-6">';
+  html += '<h6>Seller</h6>';
+  html += detailRow('Organization', d.seller_org || 'N/A');
+  html += detailRow('Domain', d.seller_domain || 'N/A');
+  html += detailRow('Type', d.seller_type || 'N/A');
+  html += detailRow('URL', d.seller_url || 'N/A');
+
+  html += '<h6 class="mt-2">Pricing</h6>';
+  html += detailRow('Price (CPM)', d.price != null ? '$' + Number(d.price).toFixed(2) : 'N/A');
+  html += detailRow('Fixed CPM', d.fixed_price_cpm != null ? '$' + Number(d.fixed_price_cpm).toFixed(2) : 'N/A');
+  html += detailRow('Bid Floor', d.bid_floor_cpm != null ? '$' + Number(d.bid_floor_cpm).toFixed(2) : 'N/A');
+  html += detailRow('Price Model', d.price_model || 'N/A');
+  html += detailRow('Currency', d.currency || 'USD');
+  html += '</div>';
+
+  html += '</div>'; // /row
+
+  // Volume + Dates
+  html += '<div class="row mt-2">';
+  html += '<div class="col-md-6">';
+  html += '<h6>Volume & Dates</h6>';
+  html += detailRow('Impressions', d.impressions != null ? Number(d.impressions).toLocaleString() : 'N/A');
+  html += detailRow('Flight Start', d.flight_start || 'N/A');
+  html += detailRow('Flight End', d.flight_end || 'N/A');
+  html += detailRow('Created', d.created_at || 'N/A');
+  html += '</div>';
+
+  // Portfolio Metadata
+  html += '<div class="col-md-6">';
+  html += '<h6>Portfolio Metadata</h6>';
+  if (meta) {
+    html += detailRow('Import Source', meta.import_source || 'N/A');
+    html += detailRow('Import Date', meta.import_date || 'N/A');
+    html += detailRow('Advertiser', meta.advertiser_id || 'N/A');
+    html += detailRow('Agency', meta.agency_id || 'N/A');
+    html += detailRow('Tags', meta.tags || 'N/A');
+  } else {
+    html += '<div class="text-muted small">No metadata</div>';
+  }
+  html += '</div>';
+  html += '</div>'; // /row
+
+  // Activations
+  html += '<h6 class="mt-2">Deal Activations</h6>';
+  if (acts.length) {
+    html += '<table class="table table-sm table-bordered"><thead><tr>' +
+      '<th>Platform</th><th>Platform Deal ID</th><th>Status</th><th>Last Sync</th>' +
+      '</tr></thead><tbody>';
+    acts.forEach(a => {
+      html += `<tr><td>${esc(a.platform)}</td><td>${esc(a.platform_deal_id || 'N/A')}</td>` +
+        `<td>${esc(a.activation_status || 'N/A')}</td><td>${esc(a.last_sync_at || 'N/A')}</td></tr>`;
+    });
+    html += '</tbody></table>';
+  } else {
+    html += '<div class="text-muted small">No activations</div>';
+  }
+
+  // Performance Cache
+  html += '<h6 class="mt-2">Performance Cache</h6>';
+  if (perf) {
+    html += detailRow('Impressions Delivered', perf.impressions_delivered != null ? Number(perf.impressions_delivered).toLocaleString() : 'N/A');
+    html += detailRow('Spend to Date', perf.spend_to_date != null ? '$' + Number(perf.spend_to_date).toLocaleString(undefined, {minimumFractionDigits: 2}) : 'N/A');
+    html += detailRow('Fill Rate', perf.fill_rate != null ? (perf.fill_rate * 100).toFixed(1) + '%' : 'N/A');
+    html += detailRow('Win Rate', perf.win_rate != null ? (perf.win_rate * 100).toFixed(1) + '%' : 'N/A');
+    html += detailRow('Avg eCPM', perf.avg_effective_cpm != null ? '$' + Number(perf.avg_effective_cpm).toFixed(2) : 'N/A');
+    html += detailRow('Trend', perf.performance_trend || 'N/A');
+  } else {
+    html += '<div class="text-muted small">No performance data</div>';
+  }
+
+  document.getElementById('dealModalBody').innerHTML = html;
+  new bootstrap.Modal(document.getElementById('dealModal')).show();
+}
+
+function detailRow(label, value) {
+  return `<div class="d-flex mb-1"><span class="detail-label">${label}:</span><span>${value}</span></div>`;
+}
+
+// ---------------------------------------------------------------------------
+// Summary Modal
+// ---------------------------------------------------------------------------
+async function showSummaryModal() {
+  const modal = new bootstrap.Modal(document.getElementById('summaryModal'));
+  modal.show();
+  const data = await api('/api/summary');
+
+  let html = '';
+  html += `<div class="row text-center mb-3">
+    <div class="col"><h3>${data.total_deals}</h3><small class="text-muted">Total Deals</small></div>
+    <div class="col"><h3>$${Number(data.total_value).toLocaleString(undefined,{minimumFractionDigits:2})}</h3><small class="text-muted">Portfolio Value</small></div>
+    <div class="col"><h3>${Number(data.total_impressions).toLocaleString()}</h3><small class="text-muted">Total Impressions</small></div>
+  </div>`;
+
+  html += '<div class="row">';
+  // By Status
+  html += '<div class="col-md-4"><h6>By Status</h6>';
+  for (const [k, v] of Object.entries(data.by_status || {})) {
+    html += `<div><span class="badge badge-${k} me-1">${k}</span> ${v}</div>`;
+  }
+  html += '</div>';
+
+  // By Media Type
+  html += '<div class="col-md-4"><h6>By Media Type</h6>';
+  for (const [k, v] of Object.entries(data.by_media_type || {})) {
+    html += `<div>${k}: ${v}</div>`;
+  }
+  html += '</div>';
+
+  // By Deal Type
+  html += '<div class="col-md-4"><h6>By Deal Type</h6>';
+  for (const [k, v] of Object.entries(data.by_deal_type || {})) {
+    html += `<div>${k}: ${v}</div>`;
+  }
+  html += '</div>';
+  html += '</div>';
+
+  // Top Sellers
+  html += '<h6 class="mt-3">Top Sellers</h6>';
+  (data.top_sellers || []).forEach(s => {
+    html += `<div>${esc(s.seller)}: ${s.count} deal(s)</div>`;
+  });
+
+  document.getElementById('summaryModalBody').innerHTML = html;
+}
+
+// ---------------------------------------------------------------------------
+// CSV Import
+// ---------------------------------------------------------------------------
+async function uploadCSV() {
+  const fileInput = document.getElementById('csv-file');
+  if (!fileInput.files.length) { alert('Select a CSV file first.'); return; }
+
+  const formData = new FormData();
+  formData.append('file', fileInput.files[0]);
+
+  const data = await api('/api/import', { method: 'POST', body: formData });
+
+  document.getElementById('import-results').classList.remove('d-none');
+  document.getElementById('import-success').textContent = data.successful + ' successful';
+  document.getElementById('import-errors').textContent = data.failed + ' errors';
+  document.getElementById('import-skipped').textContent = data.skipped + ' skipped';
+
+  parsedImportDeals = data.deals || [];
+
+  // Show parsed deals
+  if (parsedImportDeals.length) {
+    let html = '<table class="table table-sm table-bordered"><thead><tr>' +
+      '<th>Name</th><th>Seller</th><th>Type</th><th>Media</th><th>Price</th></tr></thead><tbody>';
+    parsedImportDeals.forEach(d => {
+      html += `<tr><td>${esc(d.display_name || '?')}</td><td>${esc(d.seller_org || '?')}</td>` +
+        `<td>${d.deal_type || '?'}</td><td>${d.media_type || 'N/A'}</td>` +
+        `<td>${d.fixed_price_cpm != null ? '$' + d.fixed_price_cpm : '--'}</td></tr>`;
+    });
+    html += '</tbody></table>';
+    document.getElementById('import-deals-table').innerHTML = html;
+  } else {
+    document.getElementById('import-deals-table').innerHTML = '';
+  }
+
+  // Show errors
+  if (data.errors && data.errors.length) {
+    let html = '<h6 class="text-danger">Errors</h6>' +
+      '<table class="table table-sm table-bordered"><thead><tr>' +
+      '<th>Row</th><th>Field</th><th>Message</th></tr></thead><tbody>';
+    data.errors.forEach(e => {
+      html += `<tr><td>${e.row_number}</td><td>${esc(e.field)}</td><td>${esc(e.message)}</td></tr>`;
+    });
+    html += '</tbody></table>';
+    document.getElementById('import-errors-table').innerHTML = html;
+  } else {
+    document.getElementById('import-errors-table').innerHTML = '';
+  }
+}
+
+async function saveImportedDeals() {
+  if (!parsedImportDeals.length) { alert('No parsed deals to save.'); return; }
+
+  const data = await api('/api/import/save', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ deals: parsedImportDeals }),
+  });
+
+  const btn = document.getElementById('save-import-btn');
+  if (data.saved > 0) {
+    btn.textContent = `Saved ${data.saved} deal(s)`;
+    btn.classList.replace('btn-success', 'btn-secondary');
+    btn.disabled = true;
+    parsedImportDeals = [];
+    loadDeals();
+    loadEvents();
+  } else {
+    alert('Error saving deals: ' + JSON.stringify(data.errors));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Manual Entry
+// ---------------------------------------------------------------------------
+async function createManualDeal() {
+  const form = document.getElementById('manual-form');
+  const fd = new FormData(form);
+  const body = {};
+
+  for (const [k, v] of fd.entries()) {
+    if (v === '' || v === '--') continue;
+    if (k === 'price' || k === 'impressions') {
+      body[k] = Number(v);
+    } else if (k === 'tags') {
+      body[k] = v.split(',').map(s => s.trim()).filter(Boolean);
+    } else {
+      body[k] = v;
+    }
+  }
+
+  const data = await api('/api/deals', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  const resultDiv = document.getElementById('manual-result');
+  if (data.success) {
+    resultDiv.innerHTML = `<div class="alert alert-success alert-sm py-1">Deal created: ${data.deal_id}</div>`;
+    form.reset();
+    loadDeals();
+    loadEvents();
+  } else {
+    resultDiv.innerHTML = `<div class="alert alert-danger alert-sm py-1">Errors: ${(data.errors || []).join('; ')}</div>`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+async function loadEvents() {
+  const data = await api('/api/events?limit=50');
+  const container = document.getElementById('event-log');
+
+  if (!data.events || !data.events.length) {
+    container.innerHTML = '<div class="text-muted small">No events yet.</div>';
+    return;
+  }
+
+  container.innerHTML = data.events.map(e => {
+    const ts = e.created_at ? new Date(e.created_at).toLocaleString() : '?';
+    let payload = '';
+    try {
+      const p = typeof e.payload === 'string' ? JSON.parse(e.payload) : e.payload;
+      payload = p.display_name || p.import_source || '';
+    } catch(_) {}
+    return `<div class="event-entry">
+      <span class="badge bg-secondary me-1">${esc(e.event_type)}</span>
+      <span class="text-muted">${ts}</span>
+      ${payload ? '<span class="ms-2">' + esc(payload) + '</span>' : ''}
+      ${e.deal_id ? '<span class="ms-2 text-muted small">' + e.deal_id.substring(0,8) + '...</span>' : ''}
+    </div>`;
+  }).join('');
+}
+
+// ---------------------------------------------------------------------------
+// Agent Info
+// ---------------------------------------------------------------------------
+async function loadAgentInfo() {
+  const data = await api('/api/agent-info');
+  let html = '';
+  html += `<h6>${esc(data.role)}</h6>`;
+  html += `<p class="small">${esc(data.goal)}</p>`;
+  html += `<p class="small text-muted">${esc(data.backstory_summary)}</p>`;
+
+  html += '<h6 class="mt-2">L1 Routing Heuristics</h6>';
+  html += '<div class="mb-1"><strong>DealJockey:</strong></div>';
+  (data.l1_routing?.deal_jockey_keywords || []).forEach(k => {
+    html += `<span class="badge bg-primary me-1 mb-1">${esc(k)}</span>`;
+  });
+  html += '<div class="mt-1 mb-1"><strong>Campaign Flow:</strong></div>';
+  (data.l1_routing?.campaign_flow_keywords || []).forEach(k => {
+    html += `<span class="badge bg-secondary me-1 mb-1">${esc(k)}</span>`;
+  });
+  html += `<div class="mt-1 small text-muted"><em>Ambiguous:</em> ${esc(data.l1_routing?.ambiguous_response || '')}</div>`;
+
+  html += '<h6 class="mt-2">Phase 1 Tools</h6>';
+  (data.phase1_tools || []).forEach(t => {
+    html += `<span class="badge bg-success me-1 mb-1">${esc(t)}</span>`;
+  });
+
+  html += '<h6 class="mt-2">Phase 1 Events</h6>';
+  (data.phase1_event_types || []).forEach(t => {
+    html += `<span class="badge bg-warning text-dark me-1 mb-1">${esc(t)}</span>`;
+  });
+
+  document.getElementById('agent-info').innerHTML = html;
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+function esc(s) {
+  if (s == null) return '';
+  const d = document.createElement('div');
+  d.textContent = String(s);
+  return d.innerHTML;
+}
+</script>
+</body>
+</html>

--- a/src/ad_buyer/events/models.py
+++ b/src/ad_buyer/events/models.py
@@ -47,6 +47,12 @@ class EventType(str, Enum):
     SESSION_CREATED = "session.created"
     SESSION_CLOSED = "session.closed"
 
+    # DealJockey - Phase 1
+    DEAL_IMPORTED = "deal.imported"
+    DEAL_TEMPLATE_CREATED = "deal.template_created"
+    PORTFOLIO_INSPECTED = "portfolio.inspected"
+    DEAL_MANUAL_ACTION_REQUIRED = "deal.manual_action_required"
+
 
 class Event(BaseModel):
     """An event emitted by the buyer system."""

--- a/src/ad_buyer/storage/deal_store.py
+++ b/src/ad_buyer/storage/deal_store.py
@@ -73,6 +73,30 @@ class DealStore:
     # Deals
     # ------------------------------------------------------------------
 
+    # All v2 intrinsic column names on the deals table, used to build
+    # dynamic INSERT statements when v2 kwargs are provided.
+    _V2_DEAL_COLUMNS = (
+        # Counterparty fields
+        "display_name", "description", "buyer_org", "buyer_id",
+        "seller_org", "seller_id", "seller_domain", "seller_type",
+        # Pricing detail fields
+        "price_model", "bid_floor_cpm", "fixed_price_cpm",
+        "cpp", "guaranteed_grps", "currency", "fee_transparency",
+        # Inventory targeting fields
+        "media_type", "formats", "content_categories",
+        "publisher_domains", "geo_targets", "dayparts",
+        "programs", "networks", "audience_segments", "estimated_volume",
+        # Lifecycle extensions
+        "deprecated_at", "deprecated_reason", "parent_deal_id",
+        # Supply chain fields
+        "schain_complete", "schain_nodes", "sellers_json_url",
+        "is_direct", "hop_count", "inventory_fingerprint",
+        # Linear TV fields
+        "makegood_provisions", "cancellation_window",
+        "audience_guarantee", "preemption_rights",
+        "agency_of_record_status",
+    )
+
     def save_deal(
         self,
         *,
@@ -90,15 +114,66 @@ class DealStore:
         flight_end: Optional[str] = None,
         buyer_context: Optional[str] = None,
         metadata: Optional[str] = None,
+        # v2 counterparty fields
+        display_name: Optional[str] = None,
+        description: Optional[str] = None,
+        buyer_org: Optional[str] = None,
+        buyer_id: Optional[str] = None,
+        seller_org: Optional[str] = None,
+        seller_id: Optional[str] = None,
+        seller_domain: Optional[str] = None,
+        seller_type: Optional[str] = None,
+        # v2 pricing detail fields
+        price_model: Optional[str] = None,
+        bid_floor_cpm: Optional[float] = None,
+        fixed_price_cpm: Optional[float] = None,
+        cpp: Optional[float] = None,
+        guaranteed_grps: Optional[float] = None,
+        currency: Optional[str] = None,
+        fee_transparency: Optional[float] = None,
+        # v2 inventory targeting fields
+        media_type: Optional[str] = None,
+        formats: Optional[str] = None,
+        content_categories: Optional[str] = None,
+        publisher_domains: Optional[str] = None,
+        geo_targets: Optional[str] = None,
+        dayparts: Optional[str] = None,
+        programs: Optional[str] = None,
+        networks: Optional[str] = None,
+        audience_segments: Optional[str] = None,
+        estimated_volume: Optional[int] = None,
+        # v2 lifecycle extensions
+        deprecated_at: Optional[str] = None,
+        deprecated_reason: Optional[str] = None,
+        parent_deal_id: Optional[str] = None,
+        # v2 supply chain fields
+        schain_complete: Optional[int] = None,
+        schain_nodes: Optional[str] = None,
+        sellers_json_url: Optional[str] = None,
+        is_direct: Optional[int] = None,
+        hop_count: Optional[int] = None,
+        inventory_fingerprint: Optional[str] = None,
+        # v2 linear TV fields
+        makegood_provisions: Optional[str] = None,
+        cancellation_window: Optional[str] = None,
+        audience_guarantee: Optional[str] = None,
+        preemption_rights: Optional[str] = None,
+        agency_of_record_status: Optional[str] = None,
     ) -> str:
         """Insert a new deal.
+
+        Accepts all v1 fields plus optional v2 intrinsic fields for the
+        deal library (counterparty, pricing detail, inventory targeting,
+        lifecycle, supply chain, and linear TV fields).  Backward
+        compatible: callers using only v1 fields continue to work
+        unchanged.
 
         Args:
             deal_id: Optional UUID. Generated if not provided.
             seller_url: Seller endpoint URL.
             product_id: Product being dealt on.
             product_name: Human-readable product name.
-            deal_type: PG, PD, or PA.
+            deal_type: PG, PD, PA, OPEN_AUCTION, UPFRONT, or SCATTER.
             status: Initial status (default ``draft``).
             seller_deal_id: Seller-assigned deal ID (may be None initially).
             price: Current/final CPM.
@@ -108,6 +183,45 @@ class DealStore:
             flight_end: ISO date string.
             buyer_context: JSON-serialized BuyerContext.
             metadata: JSON string for extensible fields.
+            display_name: Human-readable deal name (v2).
+            description: Deal description (v2).
+            buyer_org: Buyer organization name (v2).
+            buyer_id: Buyer seat ID (v2).
+            seller_org: Seller organization name (v2).
+            seller_id: Seller account ID (v2).
+            seller_domain: Seller domain, e.g. ``espn.com`` (v2).
+            seller_type: PUBLISHER, SSP, DSP, or INTERMEDIARY (v2).
+            price_model: CPM, CPP, FLAT, or HYBRID (v2).
+            bid_floor_cpm: Minimum CPM for auction deals (v2).
+            fixed_price_cpm: Fixed CPM for PG/PD deals (v2).
+            cpp: Cost Per Point for linear TV (v2).
+            guaranteed_grps: Guaranteed GRPs for linear TV (v2).
+            currency: ISO 4217 currency code (v2).
+            fee_transparency: Estimated intermediary fees (v2).
+            media_type: DIGITAL, CTV, LINEAR_TV, AUDIO, or DOOH (v2).
+            formats: JSON array of format strings (v2).
+            content_categories: JSON array of IAB category IDs (v2).
+            publisher_domains: JSON array of publisher domains (v2).
+            geo_targets: JSON array of geo targets (v2).
+            dayparts: JSON array of daypart strings (v2).
+            programs: JSON array of program names (v2).
+            networks: JSON array of network names (v2).
+            audience_segments: JSON array of audience segment IDs (v2).
+            estimated_volume: Estimated daily/weekly impressions (v2).
+            deprecated_at: ISO timestamp when deprecated (v2).
+            deprecated_reason: Why the deal was deprecated (v2).
+            parent_deal_id: ID of deal this was cloned/migrated from (v2).
+            schain_complete: 1 if full supply chain is known (v2).
+            schain_nodes: JSON array of schain nodes (v2).
+            sellers_json_url: URL to seller's sellers.json (v2).
+            is_direct: 1 if direct relationship (v2).
+            hop_count: Number of intermediaries (v2).
+            inventory_fingerprint: Canonical inventory identifier (v2).
+            makegood_provisions: Makegood terms for linear TV (v2).
+            cancellation_window: Cancellation terms for linear TV (v2).
+            audience_guarantee: Audience guarantee for linear TV (v2).
+            preemption_rights: Preemption terms for linear TV (v2).
+            agency_of_record_status: Agency of record for linear TV (v2).
 
         Returns:
             The deal ID (generated or provided).
@@ -116,32 +230,66 @@ class DealStore:
             deal_id = str(uuid.uuid4())
         now = _now_iso()
 
+        # Build column list and values dynamically to include v2 fields
+        # when provided.  Start with the v1 columns that are always present.
+        columns = [
+            "id", "seller_url", "seller_deal_id", "product_id",
+            "product_name", "deal_type", "status", "price",
+            "original_price", "impressions", "flight_start", "flight_end",
+            "buyer_context", "metadata", "created_at", "updated_at",
+        ]
+        values: list[Any] = [
+            deal_id, seller_url, seller_deal_id, product_id,
+            product_name, deal_type, status, price,
+            original_price, impressions, flight_start, flight_end,
+            buyer_context, metadata or "{}", now, now,
+        ]
+
+        # Collect v2 kwargs into a dict for dynamic column building.
+        v2_locals = {
+            "display_name": display_name, "description": description,
+            "buyer_org": buyer_org, "buyer_id": buyer_id,
+            "seller_org": seller_org, "seller_id": seller_id,
+            "seller_domain": seller_domain, "seller_type": seller_type,
+            "price_model": price_model, "bid_floor_cpm": bid_floor_cpm,
+            "fixed_price_cpm": fixed_price_cpm, "cpp": cpp,
+            "guaranteed_grps": guaranteed_grps, "currency": currency,
+            "fee_transparency": fee_transparency,
+            "media_type": media_type, "formats": formats,
+            "content_categories": content_categories,
+            "publisher_domains": publisher_domains,
+            "geo_targets": geo_targets, "dayparts": dayparts,
+            "programs": programs, "networks": networks,
+            "audience_segments": audience_segments,
+            "estimated_volume": estimated_volume,
+            "deprecated_at": deprecated_at,
+            "deprecated_reason": deprecated_reason,
+            "parent_deal_id": parent_deal_id,
+            "schain_complete": schain_complete,
+            "schain_nodes": schain_nodes,
+            "sellers_json_url": sellers_json_url,
+            "is_direct": is_direct, "hop_count": hop_count,
+            "inventory_fingerprint": inventory_fingerprint,
+            "makegood_provisions": makegood_provisions,
+            "cancellation_window": cancellation_window,
+            "audience_guarantee": audience_guarantee,
+            "preemption_rights": preemption_rights,
+            "agency_of_record_status": agency_of_record_status,
+        }
+
+        for col in self._V2_DEAL_COLUMNS:
+            val = v2_locals.get(col)
+            if val is not None:
+                columns.append(col)
+                values.append(val)
+
+        placeholders = ", ".join("?" for _ in columns)
+        col_names = ", ".join(columns)
+
         with self._lock:
             self._conn.execute(
-                """INSERT INTO deals
-                   (id, seller_url, seller_deal_id, product_id, product_name,
-                    deal_type, status, price, original_price, impressions,
-                    flight_start, flight_end, buyer_context, metadata,
-                    created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    deal_id,
-                    seller_url,
-                    seller_deal_id,
-                    product_id,
-                    product_name,
-                    deal_type,
-                    status,
-                    price,
-                    original_price,
-                    impressions,
-                    flight_start,
-                    flight_end,
-                    buyer_context,
-                    metadata or "{}",
-                    now,
-                    now,
-                ),
+                f"INSERT INTO deals ({col_names}) VALUES ({placeholders})",
+                values,
             )
             self._conn.commit()
 
@@ -179,14 +327,26 @@ class DealStore:
         status: Optional[str] = None,
         seller_url: Optional[str] = None,
         created_after: Optional[str] = None,
+        media_type: Optional[str] = None,
+        seller_domain: Optional[str] = None,
+        deal_type: Optional[str] = None,
+        advertiser_id: Optional[str] = None,
         limit: int = 50,
     ) -> list[dict[str, Any]]:
         """List deals with optional filters.
+
+        Supports v1 filters (status, seller_url, created_after) and v2
+        filters (media_type, seller_domain, deal_type, advertiser_id).
+        The advertiser_id filter performs a JOIN to portfolio_metadata.
 
         Args:
             status: Filter by deal status.
             seller_url: Filter by seller URL.
             created_after: ISO timestamp lower bound.
+            media_type: Filter by media type (v2).
+            seller_domain: Filter by seller domain (v2).
+            deal_type: Filter by deal type (v2).
+            advertiser_id: Filter by advertiser ID via portfolio_metadata (v2).
             limit: Maximum rows to return.
 
         Returns:
@@ -194,22 +354,46 @@ class DealStore:
         """
         clauses: list[str] = []
         params: list[Any] = []
+        needs_join = False
 
         if status is not None:
-            clauses.append("status = ?")
+            clauses.append("d.status = ?")
             params.append(status)
         if seller_url is not None:
-            clauses.append("seller_url = ?")
+            clauses.append("d.seller_url = ?")
             params.append(seller_url)
         if created_after is not None:
-            clauses.append("created_at > ?")
+            clauses.append("d.created_at > ?")
             params.append(created_after)
+        if media_type is not None:
+            clauses.append("d.media_type = ?")
+            params.append(media_type)
+        if seller_domain is not None:
+            clauses.append("d.seller_domain = ?")
+            params.append(seller_domain)
+        if deal_type is not None:
+            clauses.append("d.deal_type = ?")
+            params.append(deal_type)
+        if advertiser_id is not None:
+            clauses.append("pm.advertiser_id = ?")
+            params.append(advertiser_id)
+            needs_join = True
 
         where = ""
         if clauses:
             where = "WHERE " + " AND ".join(clauses)
 
-        query = f"SELECT * FROM deals {where} ORDER BY created_at DESC LIMIT ?"
+        if needs_join:
+            query = (
+                f"SELECT d.* FROM deals d "
+                f"JOIN portfolio_metadata pm ON pm.deal_id = d.id "
+                f"{where} ORDER BY d.created_at DESC LIMIT ?"
+            )
+        else:
+            query = (
+                f"SELECT d.* FROM deals d "
+                f"{where} ORDER BY d.created_at DESC LIMIT ?"
+            )
         params.append(limit)
 
         with self._lock:
@@ -748,6 +932,337 @@ class DealStore:
             )
             rows = cursor.fetchall()
         return [dict(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Portfolio Metadata (v2)
+    # ------------------------------------------------------------------
+
+    def save_portfolio_metadata(
+        self,
+        *,
+        deal_id: str,
+        import_source: Optional[str] = None,
+        import_date: Optional[str] = None,
+        tags: Optional[str] = None,
+        advertiser_id: Optional[str] = None,
+        agency_id: Optional[str] = None,
+    ) -> int:
+        """Insert a portfolio metadata record for a deal.
+
+        Args:
+            deal_id: FK to deals.
+            import_source: How the deal was imported (CSV, MANUAL, TTD_API, etc.).
+            import_date: ISO date when the deal was imported.
+            tags: JSON array of user-defined tags.
+            advertiser_id: Advertiser this deal belongs to.
+            agency_id: Agency managing this deal.
+
+        Returns:
+            The auto-generated row ID.
+        """
+        with self._lock:
+            cursor = self._conn.execute(
+                """INSERT INTO portfolio_metadata
+                   (deal_id, import_source, import_date, tags,
+                    advertiser_id, agency_id)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (deal_id, import_source, import_date, tags,
+                 advertiser_id, agency_id),
+            )
+            self._conn.commit()
+            return cursor.lastrowid
+
+    def get_portfolio_metadata(self, deal_id: str) -> Optional[dict[str, Any]]:
+        """Get portfolio metadata for a deal.
+
+        Args:
+            deal_id: The deal to query.
+
+        Returns:
+            Metadata as a dict, or None if not found.
+        """
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM portfolio_metadata WHERE deal_id = ?",
+                (deal_id,),
+            )
+            row = cursor.fetchone()
+        return dict(row) if row else None
+
+    def update_portfolio_metadata(self, deal_id: str, **kwargs: Any) -> bool:
+        """Update specific fields on a deal's portfolio metadata.
+
+        Args:
+            deal_id: The deal whose metadata to update.
+            **kwargs: Column-value pairs to update. Only known columns
+                (import_source, import_date, tags, advertiser_id,
+                agency_id) are accepted.
+
+        Returns:
+            True if a row was updated, False if no metadata exists for
+            the deal or no valid kwargs were provided.
+        """
+        allowed = {"import_source", "import_date", "tags",
+                    "advertiser_id", "agency_id"}
+        updates = {k: v for k, v in kwargs.items() if k in allowed}
+        if not updates:
+            return False
+
+        set_clause = ", ".join(f"{col} = ?" for col in updates)
+        values = list(updates.values())
+        values.append(deal_id)
+
+        with self._lock:
+            cursor = self._conn.execute(
+                f"UPDATE portfolio_metadata SET {set_clause} WHERE deal_id = ?",
+                values,
+            )
+            self._conn.commit()
+            return cursor.rowcount > 0
+
+    def delete_portfolio_metadata(self, deal_id: str) -> bool:
+        """Delete portfolio metadata for a deal.
+
+        Args:
+            deal_id: The deal whose metadata to delete.
+
+        Returns:
+            True if a row was deleted, False if no metadata existed.
+        """
+        with self._lock:
+            cursor = self._conn.execute(
+                "DELETE FROM portfolio_metadata WHERE deal_id = ?",
+                (deal_id,),
+            )
+            self._conn.commit()
+            return cursor.rowcount > 0
+
+    # ------------------------------------------------------------------
+    # Deal Activations (v2)
+    # ------------------------------------------------------------------
+
+    def save_deal_activation(
+        self,
+        *,
+        deal_id: str,
+        platform: str,
+        platform_deal_id: Optional[str] = None,
+        activation_status: Optional[str] = None,
+        last_sync_at: Optional[str] = None,
+    ) -> int:
+        """Insert a deal activation record.
+
+        Args:
+            deal_id: FK to deals.
+            platform: Platform name (TTD, DV360, XANDR, AMAZON_DSP, DIRECT).
+            platform_deal_id: Deal ID on the platform.
+            activation_status: ACTIVE, PAUSED, PENDING, or ERROR.
+            last_sync_at: ISO timestamp of last sync.
+
+        Returns:
+            The auto-generated row ID.
+        """
+        with self._lock:
+            cursor = self._conn.execute(
+                """INSERT INTO deal_activations
+                   (deal_id, platform, platform_deal_id,
+                    activation_status, last_sync_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (deal_id, platform, platform_deal_id,
+                 activation_status, last_sync_at),
+            )
+            self._conn.commit()
+            return cursor.lastrowid
+
+    def get_deal_activations(self, deal_id: str) -> list[dict[str, Any]]:
+        """Get all activations for a deal.
+
+        Args:
+            deal_id: The deal to query.
+
+        Returns:
+            List of activation dicts.
+        """
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM deal_activations WHERE deal_id = ?",
+                (deal_id,),
+            )
+            rows = cursor.fetchall()
+        return [dict(r) for r in rows]
+
+    def update_deal_activation(self, activation_id: int, **kwargs: Any) -> bool:
+        """Update specific fields on a deal activation.
+
+        Args:
+            activation_id: The activation row ID to update.
+            **kwargs: Column-value pairs to update. Only known columns
+                (platform, platform_deal_id, activation_status,
+                last_sync_at) are accepted.
+
+        Returns:
+            True if a row was updated, False if the activation was not
+            found or no valid kwargs were provided.
+        """
+        allowed = {"platform", "platform_deal_id", "activation_status",
+                    "last_sync_at"}
+        updates = {k: v for k, v in kwargs.items() if k in allowed}
+        if not updates:
+            return False
+
+        set_clause = ", ".join(f"{col} = ?" for col in updates)
+        values = list(updates.values())
+        values.append(activation_id)
+
+        with self._lock:
+            cursor = self._conn.execute(
+                f"UPDATE deal_activations SET {set_clause} WHERE id = ?",
+                values,
+            )
+            self._conn.commit()
+            return cursor.rowcount > 0
+
+    def delete_deal_activation(self, activation_id: int) -> bool:
+        """Delete a deal activation by ID.
+
+        Args:
+            activation_id: The activation row ID to delete.
+
+        Returns:
+            True if a row was deleted, False if not found.
+        """
+        with self._lock:
+            cursor = self._conn.execute(
+                "DELETE FROM deal_activations WHERE id = ?",
+                (activation_id,),
+            )
+            self._conn.commit()
+            return cursor.rowcount > 0
+
+    # ------------------------------------------------------------------
+    # Performance Cache (v2)
+    # ------------------------------------------------------------------
+
+    def save_performance_cache(
+        self,
+        *,
+        deal_id: str,
+        impressions_delivered: Optional[int] = None,
+        spend_to_date: Optional[float] = None,
+        fill_rate: Optional[float] = None,
+        win_rate: Optional[float] = None,
+        avg_effective_cpm: Optional[float] = None,
+        last_delivery_at: Optional[str] = None,
+        performance_trend: Optional[str] = None,
+        cached_at: Optional[str] = None,
+    ) -> int:
+        """Insert a performance cache entry for a deal.
+
+        Args:
+            deal_id: FK to deals.
+            impressions_delivered: Total impressions delivered.
+            spend_to_date: Total spend.
+            fill_rate: Fill rate (0.0-1.0).
+            win_rate: Win rate (0.0-1.0).
+            avg_effective_cpm: Average effective CPM.
+            last_delivery_at: ISO timestamp of last delivery.
+            performance_trend: IMPROVING, STABLE, DECLINING, or NO_DATA.
+            cached_at: ISO timestamp when this cache entry was created.
+
+        Returns:
+            The auto-generated row ID.
+        """
+        with self._lock:
+            cursor = self._conn.execute(
+                """INSERT INTO performance_cache
+                   (deal_id, impressions_delivered, spend_to_date,
+                    fill_rate, win_rate, avg_effective_cpm,
+                    last_delivery_at, performance_trend, cached_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (deal_id, impressions_delivered, spend_to_date,
+                 fill_rate, win_rate, avg_effective_cpm,
+                 last_delivery_at, performance_trend, cached_at),
+            )
+            self._conn.commit()
+            return cursor.lastrowid
+
+    def get_performance_cache(self, deal_id: str) -> Optional[dict[str, Any]]:
+        """Get the latest performance cache entry for a deal.
+
+        Args:
+            deal_id: The deal to query.
+
+        Returns:
+            Performance data as a dict, or None if not found.
+        """
+        with self._lock:
+            cursor = self._conn.execute(
+                """SELECT * FROM performance_cache
+                   WHERE deal_id = ?
+                   ORDER BY id DESC LIMIT 1""",
+                (deal_id,),
+            )
+            row = cursor.fetchone()
+        return dict(row) if row else None
+
+    def update_performance_cache(self, deal_id: str, **kwargs: Any) -> bool:
+        """Update the latest performance cache entry for a deal.
+
+        Updates the most recently inserted cache row for the given
+        deal_id.  Functions as an upsert-style update by deal_id.
+
+        Args:
+            deal_id: The deal whose cache to update.
+            **kwargs: Column-value pairs to update. Only known columns
+                (impressions_delivered, spend_to_date, fill_rate,
+                win_rate, avg_effective_cpm, last_delivery_at,
+                performance_trend, cached_at) are accepted.
+
+        Returns:
+            True if a row was updated, False if no cache exists for
+            the deal or no valid kwargs were provided.
+        """
+        allowed = {"impressions_delivered", "spend_to_date", "fill_rate",
+                    "win_rate", "avg_effective_cpm", "last_delivery_at",
+                    "performance_trend", "cached_at"}
+        updates = {k: v for k, v in kwargs.items() if k in allowed}
+        if not updates:
+            return False
+
+        set_clause = ", ".join(f"{col} = ?" for col in updates)
+        values = list(updates.values())
+        values.append(deal_id)
+
+        with self._lock:
+            # Update the most recent cache entry for this deal
+            cursor = self._conn.execute(
+                f"""UPDATE performance_cache SET {set_clause}
+                    WHERE id = (
+                        SELECT id FROM performance_cache
+                        WHERE deal_id = ?
+                        ORDER BY id DESC LIMIT 1
+                    )""",
+                values,
+            )
+            self._conn.commit()
+            return cursor.rowcount > 0
+
+    def delete_performance_cache(self, deal_id: str) -> bool:
+        """Delete all performance cache entries for a deal.
+
+        Args:
+            deal_id: The deal whose cache to delete.
+
+        Returns:
+            True if any rows were deleted, False if none existed.
+        """
+        with self._lock:
+            cursor = self._conn.execute(
+                "DELETE FROM performance_cache WHERE deal_id = ?",
+                (deal_id,),
+            )
+            self._conn.commit()
+            return cursor.rowcount > 0
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/ad_buyer/storage/schema.py
+++ b/src/ad_buyer/storage/schema.py
@@ -3,13 +3,16 @@
 
 """Database schema definitions and migration runner for deal state persistence.
 
-Defines 6 relational tables for the deal lifecycle:
-- deals: Central deal tracking
+Defines relational tables for the deal lifecycle:
+- deals: Central deal tracking (extended in v2 with deal library fields)
 - negotiation_rounds: Per-round audit trail
 - booking_records: Booked line items
 - jobs: API-initiated booking jobs (replaces in-memory dict)
 - status_transitions: Append-only audit log
 - events: Event bus event persistence
+- portfolio_metadata: Extrinsic deal metadata (v2, D-4 hybrid approach)
+- deal_activations: Cross-platform deal activations (v2)
+- performance_cache: Cached deal performance metrics (v2)
 
 Uses a schema_version table for forward-compatible migrations.
 """
@@ -21,7 +24,7 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 # Current schema version
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 # -- Schema version tracking ------------------------------------------------
 
@@ -51,16 +54,73 @@ CREATE TABLE IF NOT EXISTS deals (
     buyer_context   TEXT,
     metadata        TEXT DEFAULT '{}',
     created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-    updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+
+    -- v2: Counterparty fields (D-4 hybrid intrinsic)
+    display_name            TEXT,
+    description             TEXT,
+    buyer_org               TEXT,
+    buyer_id                TEXT,
+    seller_org              TEXT,
+    seller_id               TEXT,
+    seller_domain           TEXT,
+    seller_type             TEXT,
+
+    -- v2: Pricing detail fields
+    price_model             TEXT,
+    bid_floor_cpm           REAL,
+    fixed_price_cpm         REAL,
+    cpp                     REAL,
+    guaranteed_grps         REAL,
+    currency                TEXT DEFAULT 'USD',
+    fee_transparency        REAL,
+
+    -- v2: Inventory targeting fields
+    media_type              TEXT,
+    formats                 TEXT,
+    content_categories      TEXT,
+    publisher_domains       TEXT,
+    geo_targets             TEXT,
+    dayparts                TEXT,
+    programs                TEXT,
+    networks                TEXT,
+    audience_segments       TEXT,
+    estimated_volume        INTEGER,
+
+    -- v2: Lifecycle extensions
+    deprecated_at           TEXT,
+    deprecated_reason       TEXT,
+    parent_deal_id          TEXT,
+
+    -- v2: Supply chain fields
+    schain_complete         INTEGER,
+    schain_nodes            TEXT,
+    sellers_json_url        TEXT,
+    is_direct               INTEGER,
+    hop_count               INTEGER,
+    inventory_fingerprint   TEXT,
+
+    -- v2: Linear TV fields (per Q-6 / L-1)
+    makegood_provisions     TEXT,
+    cancellation_window     TEXT,
+    audience_guarantee      TEXT,
+    preemption_rights       TEXT,
+    agency_of_record_status TEXT
 );
 """
 
 DEALS_INDEXES = [
+    # v1 indexes
     "CREATE INDEX IF NOT EXISTS idx_deals_status ON deals(status);",
     "CREATE INDEX IF NOT EXISTS idx_deals_seller_url ON deals(seller_url);",
     "CREATE INDEX IF NOT EXISTS idx_deals_seller_deal_id ON deals(seller_deal_id);",
     "CREATE INDEX IF NOT EXISTS idx_deals_created_at ON deals(created_at);",
     "CREATE INDEX IF NOT EXISTS idx_deals_status_created ON deals(status, created_at);",
+    # v2 indexes
+    "CREATE INDEX IF NOT EXISTS idx_deals_media_type ON deals(media_type);",
+    "CREATE INDEX IF NOT EXISTS idx_deals_deal_type ON deals(deal_type);",
+    "CREATE INDEX IF NOT EXISTS idx_deals_seller_domain ON deals(seller_domain);",
+    "CREATE INDEX IF NOT EXISTS idx_deals_inventory_fingerprint ON deals(inventory_fingerprint);",
 ]
 
 NEGOTIATION_ROUNDS_TABLE = """
@@ -166,6 +226,60 @@ STATUS_TRANSITIONS_INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_transitions_created ON status_transitions(created_at);",
 ]
 
+# -- v2: Extrinsic tables (D-4 hybrid approach) ----------------------------
+
+PORTFOLIO_METADATA_TABLE = """
+CREATE TABLE IF NOT EXISTS portfolio_metadata (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    deal_id         TEXT NOT NULL REFERENCES deals(id) ON DELETE CASCADE,
+    import_source   TEXT,
+    import_date     TEXT,
+    tags            TEXT,
+    advertiser_id   TEXT,
+    agency_id       TEXT
+);
+"""
+
+PORTFOLIO_METADATA_INDEXES = [
+    "CREATE INDEX IF NOT EXISTS idx_portfolio_metadata_deal_id ON portfolio_metadata(deal_id);",
+    "CREATE INDEX IF NOT EXISTS idx_portfolio_metadata_advertiser_id ON portfolio_metadata(advertiser_id);",
+]
+
+DEAL_ACTIVATIONS_TABLE = """
+CREATE TABLE IF NOT EXISTS deal_activations (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    deal_id             TEXT NOT NULL REFERENCES deals(id) ON DELETE CASCADE,
+    platform            TEXT,
+    platform_deal_id    TEXT,
+    activation_status   TEXT,
+    last_sync_at        TEXT
+);
+"""
+
+DEAL_ACTIVATIONS_INDEXES = [
+    "CREATE INDEX IF NOT EXISTS idx_deal_activations_deal_id ON deal_activations(deal_id);",
+    "CREATE INDEX IF NOT EXISTS idx_deal_activations_platform_deal ON deal_activations(platform, deal_id);",
+]
+
+PERFORMANCE_CACHE_TABLE = """
+CREATE TABLE IF NOT EXISTS performance_cache (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    deal_id             TEXT NOT NULL REFERENCES deals(id) ON DELETE CASCADE,
+    impressions_delivered INTEGER,
+    spend_to_date       REAL,
+    fill_rate           REAL,
+    win_rate            REAL,
+    avg_effective_cpm   REAL,
+    last_delivery_at    TEXT,
+    performance_trend   TEXT,
+    cached_at           TEXT
+);
+"""
+
+PERFORMANCE_CACHE_INDEXES = [
+    "CREATE INDEX IF NOT EXISTS idx_performance_cache_deal_id ON performance_cache(deal_id);",
+]
+
 
 def create_tables(conn: sqlite3.Connection) -> None:
     """Create all tables and indexes if they don't already exist.
@@ -186,6 +300,10 @@ def create_tables(conn: sqlite3.Connection) -> None:
         JOBS_TABLE,
         EVENTS_TABLE,
         STATUS_TRANSITIONS_TABLE,
+        # v2 extrinsic tables
+        PORTFOLIO_METADATA_TABLE,
+        DEAL_ACTIVATIONS_TABLE,
+        PERFORMANCE_CACHE_TABLE,
     ]:
         cursor.execute(ddl)
 
@@ -197,6 +315,10 @@ def create_tables(conn: sqlite3.Connection) -> None:
         JOBS_INDEXES,
         EVENTS_INDEXES,
         STATUS_TRANSITIONS_INDEXES,
+        # v2 extrinsic indexes
+        PORTFOLIO_METADATA_INDEXES,
+        DEAL_ACTIVATIONS_INDEXES,
+        PERFORMANCE_CACHE_INDEXES,
     ]:
         for idx in index_list:
             cursor.execute(idx)
@@ -237,6 +359,109 @@ def set_schema_version(conn: sqlite3.Connection, version: int) -> None:
     conn.commit()
 
 
+def migrate_v1_to_v2(conn: sqlite3.Connection) -> None:
+    """Migrate schema from v1 to v2 (deal library hybrid approach, D-4).
+
+    Adds intrinsic deal library fields to the existing ``deals`` table via
+    ALTER TABLE ADD COLUMN, and creates three new extrinsic tables:
+    ``portfolio_metadata``, ``deal_activations``, ``performance_cache``.
+
+    This migration is idempotent: re-running it on a v2 database is safe
+    because both ALTER TABLE ADD COLUMN (with IF NOT EXISTS-style error
+    handling) and CREATE TABLE IF NOT EXISTS are no-ops for existing objects.
+
+    Args:
+        conn: Active SQLite connection.
+    """
+    cursor = conn.cursor()
+
+    # -- Intrinsic columns on deals table ----------------------------------
+    # SQLite does not support ALTER TABLE ADD COLUMN IF NOT EXISTS, so we
+    # check existing columns first and only add missing ones.
+    cursor.execute("PRAGMA table_info(deals)")
+    existing_cols = {row[1] for row in cursor.fetchall()}
+
+    # (column_name, column_def) pairs for all v2 intrinsic columns
+    v2_columns = [
+        # Counterparty fields
+        ("display_name", "TEXT"),
+        ("description", "TEXT"),
+        ("buyer_org", "TEXT"),
+        ("buyer_id", "TEXT"),
+        ("seller_org", "TEXT"),
+        ("seller_id", "TEXT"),
+        ("seller_domain", "TEXT"),
+        ("seller_type", "TEXT"),
+        # Pricing detail fields
+        ("price_model", "TEXT"),
+        ("bid_floor_cpm", "REAL"),
+        ("fixed_price_cpm", "REAL"),
+        ("cpp", "REAL"),
+        ("guaranteed_grps", "REAL"),
+        ("currency", "TEXT DEFAULT 'USD'"),
+        ("fee_transparency", "REAL"),
+        # Inventory targeting fields
+        ("media_type", "TEXT"),
+        ("formats", "TEXT"),
+        ("content_categories", "TEXT"),
+        ("publisher_domains", "TEXT"),
+        ("geo_targets", "TEXT"),
+        ("dayparts", "TEXT"),
+        ("programs", "TEXT"),
+        ("networks", "TEXT"),
+        ("audience_segments", "TEXT"),
+        ("estimated_volume", "INTEGER"),
+        # Lifecycle extensions
+        ("deprecated_at", "TEXT"),
+        ("deprecated_reason", "TEXT"),
+        ("parent_deal_id", "TEXT"),
+        # Supply chain fields
+        ("schain_complete", "INTEGER"),
+        ("schain_nodes", "TEXT"),
+        ("sellers_json_url", "TEXT"),
+        ("is_direct", "INTEGER"),
+        ("hop_count", "INTEGER"),
+        ("inventory_fingerprint", "TEXT"),
+        # Linear TV fields (per Q-6 / L-1)
+        ("makegood_provisions", "TEXT"),
+        ("cancellation_window", "TEXT"),
+        ("audience_guarantee", "TEXT"),
+        ("preemption_rights", "TEXT"),
+        ("agency_of_record_status", "TEXT"),
+    ]
+
+    for col_name, col_def in v2_columns:
+        if col_name not in existing_cols:
+            cursor.execute(f"ALTER TABLE deals ADD COLUMN {col_name} {col_def}")
+
+    # -- v2 indexes on deals table -----------------------------------------
+    v2_deal_indexes = [
+        "CREATE INDEX IF NOT EXISTS idx_deals_media_type ON deals(media_type);",
+        "CREATE INDEX IF NOT EXISTS idx_deals_deal_type ON deals(deal_type);",
+        "CREATE INDEX IF NOT EXISTS idx_deals_seller_domain ON deals(seller_domain);",
+        "CREATE INDEX IF NOT EXISTS idx_deals_inventory_fingerprint ON deals(inventory_fingerprint);",
+    ]
+    for idx in v2_deal_indexes:
+        cursor.execute(idx)
+
+    # -- Extrinsic tables --------------------------------------------------
+    cursor.execute(PORTFOLIO_METADATA_TABLE)
+    cursor.execute(DEAL_ACTIVATIONS_TABLE)
+    cursor.execute(PERFORMANCE_CACHE_TABLE)
+
+    # -- Extrinsic indexes -------------------------------------------------
+    for index_list in [
+        PORTFOLIO_METADATA_INDEXES,
+        DEAL_ACTIVATIONS_INDEXES,
+        PERFORMANCE_CACHE_INDEXES,
+    ]:
+        for idx in index_list:
+            cursor.execute(idx)
+
+    conn.commit()
+    logger.info("Migration v1 -> v2 complete: deal library hybrid schema applied")
+
+
 def run_migrations(conn: sqlite3.Connection) -> None:
     """Run pending schema migrations.
 
@@ -252,10 +477,9 @@ def run_migrations(conn: sqlite3.Connection) -> None:
         return
 
     # Migration registry: version -> migration function
-    # Add entries here as the schema evolves:
-    #   2: migrate_v1_to_v2,
-    #   3: migrate_v2_to_v3,
-    migrations: dict[int, callable] = {}
+    migrations: dict[int, callable] = {
+        2: migrate_v1_to_v2,
+    }
 
     for version in range(current + 1, SCHEMA_VERSION + 1):
         migration_fn = migrations.get(version)

--- a/src/ad_buyer/tools/__init__.py
+++ b/src/ad_buyer/tools/__init__.py
@@ -1,17 +1,20 @@
 # Author: Green Mountain Systems AI Inc.
 # Donated to IAB Tech Lab
 
-"""CrewAI tools for OpenDirect operations."""
+"""CrewAI tools for OpenDirect operations and DealJockey portfolio management."""
 
 from .audience import (
     AudienceDiscoveryTool,
     AudienceMatchingTool,
     CoverageEstimationTool,
 )
+from .deal_jockey import ManualDealEntryTool
 
 __all__ = [
     # Audience tools
     "AudienceDiscoveryTool",
     "AudienceMatchingTool",
     "CoverageEstimationTool",
+    # DealJockey tools
+    "ManualDealEntryTool",
 ]

--- a/src/ad_buyer/tools/__init__.py
+++ b/src/ad_buyer/tools/__init__.py
@@ -8,7 +8,13 @@ from .audience import (
     AudienceMatchingTool,
     CoverageEstimationTool,
 )
-from .deal_jockey import ManualDealEntryTool
+from .deal_jockey import (
+    InspectDealTool,
+    ListPortfolioTool,
+    ManualDealEntryTool,
+    PortfolioSummaryTool,
+    SearchPortfolioTool,
+)
 
 __all__ = [
     # Audience tools
@@ -17,4 +23,8 @@ __all__ = [
     "CoverageEstimationTool",
     # DealJockey tools
     "ManualDealEntryTool",
+    "ListPortfolioTool",
+    "SearchPortfolioTool",
+    "PortfolioSummaryTool",
+    "InspectDealTool",
 ]

--- a/src/ad_buyer/tools/deal_import.py
+++ b/src/ad_buyer/tools/deal_import.py
@@ -1,0 +1,636 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""CSV deal import parser for DealJockey.
+
+Reads CSV files containing deal data and maps them to the v2 deal library
+schema.  This is a pure function -- it does NOT call DealStore.save_deal()
+or emit events.  The caller (DealJockey agent or a higher-level import
+tool) is responsible for:
+
+1. Calling ``parse_csv_deals()`` to get parsed deal dicts.
+2. Saving each deal via ``DealStore.save_deal()`` or equivalent.
+3. Emitting ``EventType.DEAL_IMPORTED`` for each successfully imported deal.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ImportError:
+    """A validation error for a single CSV row.
+
+    Attributes:
+        row_number: 1-indexed row number within the data rows (excludes header).
+        field: Schema field name that failed validation.
+        value: The raw value that was rejected.
+        message: Human-readable description of the problem.
+    """
+
+    row_number: int
+    field: str
+    value: str
+    message: str
+
+
+@dataclass
+class ImportResult:
+    """Result of a CSV deal import operation.
+
+    Attributes:
+        deals: Successfully parsed deals as dicts ready for DealStore.
+        errors: Per-row validation errors.
+        total_rows: Number of data rows in the file (excludes header).
+        successful: Number of rows that parsed successfully.
+        failed: Number of rows that failed validation.
+        skipped: Number of rows skipped (e.g. duplicate deal_ids).
+    """
+
+    deals: list[dict[str, Any]] = field(default_factory=list)
+    errors: list[ImportError] = field(default_factory=list)
+    total_rows: int = 0
+    successful: int = 0
+    failed: int = 0
+    skipped: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Column mapping
+# ---------------------------------------------------------------------------
+
+# Maps common CSV header names (lowercase, stripped) to schema field names.
+COLUMN_MAPPINGS: dict[str, str] = {
+    # deal_id variations
+    "deal_id": "seller_deal_id",
+    "deal id": "seller_deal_id",
+    "dealid": "seller_deal_id",
+    "deal_code": "seller_deal_id",
+    "seller_deal_id": "seller_deal_id",
+    # name / display name variations
+    "name": "display_name",
+    "deal_name": "display_name",
+    "deal name": "display_name",
+    "display_name": "display_name",
+    "dealname": "display_name",
+    # seller / publisher variations
+    "publisher": "seller_org",
+    "seller": "seller_org",
+    "seller_org": "seller_org",
+    "publisher_name": "seller_org",
+    "seller_name": "seller_org",
+    # seller domain
+    "publisher_domain": "seller_domain",
+    "seller_domain": "seller_domain",
+    "domain": "seller_domain",
+    # pricing -- fixed CPM
+    "cpm": "fixed_price_cpm",
+    "price": "fixed_price_cpm",
+    "fixed_price_cpm": "fixed_price_cpm",
+    "fixed_cpm": "fixed_price_cpm",
+    "rate": "fixed_price_cpm",
+    # pricing -- bid floor
+    "floor": "bid_floor_cpm",
+    "bid_floor": "bid_floor_cpm",
+    "bid_floor_cpm": "bid_floor_cpm",
+    "floor_cpm": "bid_floor_cpm",
+    # deal type
+    "deal_type": "deal_type",
+    "type": "deal_type",
+    "dealtype": "deal_type",
+    # media type / channel
+    "media_type": "media_type",
+    "channel": "media_type",
+    "mediatype": "media_type",
+    "media type": "media_type",
+    # dates
+    "start_date": "flight_start",
+    "end_date": "flight_end",
+    "flight_start": "flight_start",
+    "flight_end": "flight_end",
+    "start date": "flight_start",
+    "end date": "flight_end",
+    # impressions
+    "impressions": "impressions",
+    "volume": "impressions",
+    "estimated_volume": "estimated_volume",
+    # buyer / advertiser
+    "advertiser": "buyer_org",
+    "buyer": "buyer_org",
+    "buyer_org": "buyer_org",
+    "advertiser_name": "buyer_org",
+    # description
+    "description": "description",
+    # currency
+    "currency": "currency",
+    # geo
+    "geo": "geo_targets",
+    "geography": "geo_targets",
+    "geo_targets": "geo_targets",
+    # formats
+    "formats": "formats",
+    "format": "formats",
+    # content categories
+    "content_categories": "content_categories",
+    "category": "content_categories",
+    "categories": "content_categories",
+    # audience
+    "audience_segments": "audience_segments",
+    "audience": "audience_segments",
+}
+
+# ---------------------------------------------------------------------------
+# Normalization tables
+# ---------------------------------------------------------------------------
+
+VALID_DEAL_TYPES = {"PG", "PD", "PA", "OPEN_AUCTION", "UPFRONT", "SCATTER"}
+
+_DEAL_TYPE_ALIASES: dict[str, str] = {
+    "pg": "PG",
+    "programmatic guaranteed": "PG",
+    "pd": "PD",
+    "preferred deal": "PD",
+    "preferred": "PD",
+    "pa": "PA",
+    "private auction": "PA",
+    "open_auction": "OPEN_AUCTION",
+    "open auction": "OPEN_AUCTION",
+    "openauction": "OPEN_AUCTION",
+    "upfront": "UPFRONT",
+    "scatter": "SCATTER",
+}
+
+VALID_MEDIA_TYPES = {"DIGITAL", "CTV", "LINEAR_TV", "AUDIO", "DOOH"}
+
+_MEDIA_TYPE_ALIASES: dict[str, str] = {
+    "digital": "DIGITAL",
+    "display": "DIGITAL",
+    "ctv": "CTV",
+    "connected tv": "CTV",
+    "connected_tv": "CTV",
+    "linear_tv": "LINEAR_TV",
+    "linear tv": "LINEAR_TV",
+    "lineartv": "LINEAR_TV",
+    "audio": "AUDIO",
+    "dooh": "DOOH",
+}
+
+# Fields that should be parsed as floats
+_FLOAT_FIELDS = {"fixed_price_cpm", "bid_floor_cpm", "cpp", "guaranteed_grps", "fee_transparency"}
+
+# Fields that should be parsed as ints
+_INT_FIELDS = {"impressions", "estimated_volume"}
+
+# Date fields
+_DATE_FIELDS = {"flight_start", "flight_end"}
+
+# ---------------------------------------------------------------------------
+# Normalization helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_header(header: str) -> str:
+    """Lowercase and strip a header for lookup in COLUMN_MAPPINGS."""
+    return header.strip().lower()
+
+
+def _parse_price(value: str) -> float | None:
+    """Parse a price string, handling $, commas, whitespace.
+
+    Examples:
+        "$12.50" -> 12.50
+        "1,234.56" -> 1234.56
+        "$1,234.56" -> 1234.56
+        "" -> None
+
+    Returns:
+        Parsed float or None if the value is empty or unparseable.
+    """
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    # Remove dollar sign and commas
+    cleaned = cleaned.replace("$", "").replace(",", "").strip()
+    if not cleaned:
+        return None
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+def _parse_int(value: str) -> int | None:
+    """Parse an integer string, handling commas.
+
+    Returns:
+        Parsed int or None if the value is empty or unparseable.
+    """
+    cleaned = value.strip().replace(",", "")
+    if not cleaned:
+        return None
+    try:
+        return int(float(cleaned))
+    except ValueError:
+        return None
+
+
+def _normalize_date(value: str) -> str | None:
+    """Normalize date strings to ISO 8601 (YYYY-MM-DD).
+
+    Supported input formats:
+        - YYYY-MM-DD (passthrough)
+        - MM/DD/YYYY
+        - M/D/YYYY
+        - MM/DD/YY
+        - M/D/YY
+
+    Returns:
+        ISO date string or None if empty/unparseable.
+    """
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+
+    # Already ISO format
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", cleaned):
+        return cleaned
+
+    # Try MM/DD/YYYY or M/D/YYYY
+    for fmt in ("%m/%d/%Y", "%m/%d/%y"):
+        try:
+            dt = datetime.strptime(cleaned, fmt)
+            return dt.strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+
+    return None
+
+
+def _normalize_deal_type(value: str) -> str | None:
+    """Normalize deal type to one of the valid values.
+
+    Returns:
+        Normalized deal type string, or None if empty.
+
+    Raises:
+        ValueError: If value is non-empty but not a recognized deal type.
+    """
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+
+    # Direct match (case-insensitive)
+    upper = cleaned.upper()
+    if upper in VALID_DEAL_TYPES:
+        return upper
+
+    # Alias lookup
+    lower = cleaned.lower()
+    if lower in _DEAL_TYPE_ALIASES:
+        return _DEAL_TYPE_ALIASES[lower]
+
+    raise ValueError(f"Unrecognized deal type: {cleaned}")
+
+
+def _normalize_media_type(value: str) -> str | None:
+    """Normalize media type to one of the valid values.
+
+    Returns:
+        Normalized media type string, or None if empty.
+
+    Raises:
+        ValueError: If value is non-empty but not a recognized media type.
+    """
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+
+    # Direct match (case-insensitive)
+    upper = cleaned.upper()
+    if upper in VALID_MEDIA_TYPES:
+        return upper
+
+    # Alias lookup
+    lower = cleaned.lower()
+    if lower in _MEDIA_TYPE_ALIASES:
+        return _MEDIA_TYPE_ALIASES[lower]
+
+    raise ValueError(f"Unrecognized media type: {cleaned}")
+
+
+# ---------------------------------------------------------------------------
+# Column resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_columns(
+    headers: list[str],
+    column_mapping: dict[str, str] | None,
+) -> dict[int, str]:
+    """Build a mapping from column index to schema field name.
+
+    Custom mappings are applied first (case-insensitive match on the
+    original header).  Remaining unmapped columns are auto-detected via
+    ``COLUMN_MAPPINGS``.
+
+    Args:
+        headers: Raw CSV header row.
+        column_mapping: Optional user-provided overrides
+            (original_header -> schema_field).
+
+    Returns:
+        Dict mapping column index -> schema field name.  Columns that
+        cannot be mapped are omitted.
+    """
+    index_map: dict[int, str] = {}
+    mapped_indices: set[int] = set()
+
+    # Pass 1: apply custom mapping (case-insensitive header match)
+    if column_mapping:
+        lower_custom = {k.strip().lower(): v for k, v in column_mapping.items()}
+        for idx, hdr in enumerate(headers):
+            key = hdr.strip().lower()
+            if key in lower_custom:
+                index_map[idx] = lower_custom[key]
+                mapped_indices.add(idx)
+
+    # Pass 2: auto-detect remaining columns
+    for idx, hdr in enumerate(headers):
+        if idx in mapped_indices:
+            continue
+        key = _normalize_header(hdr)
+        if key in COLUMN_MAPPINGS:
+            index_map[idx] = COLUMN_MAPPINGS[key]
+
+    return index_map
+
+
+# ---------------------------------------------------------------------------
+# Row parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_row(
+    row: list[str],
+    col_map: dict[int, str],
+    row_number: int,
+    *,
+    default_seller_url: str,
+    default_product_id: str,
+) -> tuple[dict[str, Any] | None, list[ImportError]]:
+    """Parse a single CSV data row into a deal dict.
+
+    Returns:
+        (deal_dict, errors) -- deal_dict is None when validation fails.
+    """
+    errors: list[ImportError] = []
+
+    # Build raw field values from the CSV row
+    raw: dict[str, str] = {}
+    for idx, field_name in col_map.items():
+        if idx < len(row):
+            raw[field_name] = row[idx].strip()
+
+    # --- Normalize and build the deal dict ---
+    deal: dict[str, Any] = {}
+
+    # Identity fields
+    deal["seller_deal_id"] = raw.get("seller_deal_id", "").strip() or None
+    deal["display_name"] = raw.get("display_name", "").strip() or None
+
+    # Require at least one of seller_deal_id or display_name
+    if not deal["seller_deal_id"] and not deal["display_name"]:
+        errors.append(
+            ImportError(
+                row_number=row_number,
+                field="seller_deal_id/display_name",
+                value="",
+                message="At least one of deal_id or name is required to identify the deal.",
+            )
+        )
+        return None, errors
+
+    # Seller info (required)
+    deal["seller_org"] = raw.get("seller_org", "").strip() or None
+    deal["seller_domain"] = raw.get("seller_domain", "").strip() or None
+
+    if not deal["seller_org"] and not deal["seller_domain"]:
+        errors.append(
+            ImportError(
+                row_number=row_number,
+                field="seller_org/seller_domain",
+                value="",
+                message="Seller information is required (seller/publisher name or domain).",
+            )
+        )
+        return None, errors
+
+    # Defaults
+    deal["seller_url"] = default_seller_url
+    deal["product_id"] = default_product_id
+    deal["status"] = "imported"
+
+    # Deal type normalization
+    raw_deal_type = raw.get("deal_type", "").strip()
+    if raw_deal_type:
+        try:
+            deal["deal_type"] = _normalize_deal_type(raw_deal_type)
+        except ValueError:
+            errors.append(
+                ImportError(
+                    row_number=row_number,
+                    field="deal_type",
+                    value=raw_deal_type,
+                    message=(
+                        f"Invalid deal type '{raw_deal_type}'. "
+                        f"Must be one of: {', '.join(sorted(VALID_DEAL_TYPES))}"
+                    ),
+                )
+            )
+            return None, errors
+    else:
+        deal["deal_type"] = "PD"  # default
+
+    # Media type normalization
+    raw_media_type = raw.get("media_type", "").strip()
+    if raw_media_type:
+        try:
+            deal["media_type"] = _normalize_media_type(raw_media_type)
+        except ValueError:
+            errors.append(
+                ImportError(
+                    row_number=row_number,
+                    field="media_type",
+                    value=raw_media_type,
+                    message=(
+                        f"Invalid media type '{raw_media_type}'. "
+                        f"Must be one of: {', '.join(sorted(VALID_MEDIA_TYPES))}"
+                    ),
+                )
+            )
+            return None, errors
+    else:
+        deal["media_type"] = None
+
+    # Float fields (prices, etc.)
+    for field_name in _FLOAT_FIELDS:
+        raw_val = raw.get(field_name, "").strip()
+        if raw_val:
+            parsed = _parse_price(raw_val)
+            deal[field_name] = parsed
+        else:
+            deal[field_name] = None
+
+    # Int fields
+    for field_name in _INT_FIELDS:
+        raw_val = raw.get(field_name, "").strip()
+        if raw_val:
+            parsed = _parse_int(raw_val)
+            deal[field_name] = parsed
+        else:
+            deal[field_name] = None
+
+    # Date fields
+    for field_name in _DATE_FIELDS:
+        raw_val = raw.get(field_name, "").strip()
+        if raw_val:
+            parsed = _normalize_date(raw_val)
+            deal[field_name] = parsed
+        else:
+            deal[field_name] = None
+
+    # Currency (default USD)
+    raw_currency = raw.get("currency", "").strip()
+    deal["currency"] = raw_currency.upper() if raw_currency else "USD"
+
+    # String pass-through fields
+    for field_name in (
+        "description",
+        "buyer_org",
+        "buyer_id",
+        "seller_id",
+        "seller_type",
+        "geo_targets",
+        "formats",
+        "content_categories",
+        "audience_segments",
+        "programs",
+        "networks",
+        "dayparts",
+        "publisher_domains",
+    ):
+        raw_val = raw.get(field_name, "").strip()
+        deal[field_name] = raw_val if raw_val else None
+
+    return deal, errors
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def parse_csv_deals(
+    file_path: str | Path,
+    *,
+    column_mapping: dict[str, str] | None = None,
+    default_seller_url: str = "",
+    default_product_id: str = "imported",
+    skip_header: bool = True,
+) -> ImportResult:
+    """Parse a CSV file of deals and return structured results.
+
+    This is a pure function -- it reads the CSV and returns parsed deal
+    dicts without touching any database or emitting events.  The caller
+    should:
+
+    1. Iterate ``result.deals`` and call ``DealStore.save_deal()`` for each.
+    2. Emit ``EventType.DEAL_IMPORTED`` for each successfully saved deal.
+
+    Args:
+        file_path: Path to the CSV file.
+        column_mapping: Optional dict mapping CSV column names to schema
+            field names, overriding auto-detection.
+        default_seller_url: Default ``seller_url`` for all imported deals
+            (since CSV rarely contains full URLs).
+        default_product_id: Default ``product_id`` for all imported deals.
+        skip_header: Whether the first row is a header (default True).
+
+    Returns:
+        An ``ImportResult`` with parsed deals, errors, and counts.
+    """
+    file_path = Path(file_path)
+    result = ImportResult()
+
+    with open(file_path, newline="", encoding="utf-8-sig") as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+
+    if not rows:
+        return result
+
+    # First row is headers
+    if skip_header:
+        headers = rows[0]
+        data_rows = rows[1:]
+    else:
+        # If no header, we can't auto-map; require column_mapping
+        headers = [str(i) for i in range(len(rows[0]))]
+        data_rows = rows
+
+    col_map = _resolve_columns(headers, column_mapping)
+
+    if not col_map:
+        logger.warning("No columns could be mapped to schema fields")
+        return result
+
+    result.total_rows = len(data_rows)
+
+    # Track seen deal IDs for deduplication within the file
+    seen_deal_ids: set[str] = set()
+
+    for row_idx, row in enumerate(data_rows, start=1):
+        # Skip completely empty rows
+        if not any(cell.strip() for cell in row):
+            result.total_rows -= 1
+            continue
+
+        deal, errors = _parse_row(
+            row,
+            col_map,
+            row_number=row_idx,
+            default_seller_url=default_seller_url,
+            default_product_id=default_product_id,
+        )
+
+        if errors:
+            result.errors.extend(errors)
+            result.failed += 1
+            continue
+
+        # Deduplication by seller_deal_id
+        deal_id = deal.get("seller_deal_id")
+        if deal_id and deal_id in seen_deal_ids:
+            result.skipped += 1
+            continue
+
+        if deal_id:
+            seen_deal_ids.add(deal_id)
+
+        result.deals.append(deal)
+        result.successful += 1
+
+    return result

--- a/src/ad_buyer/tools/deal_jockey/__init__.py
+++ b/src/ad_buyer/tools/deal_jockey/__init__.py
@@ -4,7 +4,17 @@
 """DealJockey tools for deal portfolio management."""
 
 from .deal_entry import ManualDealEntryTool
+from .portfolio_inspection import (
+    InspectDealTool,
+    ListPortfolioTool,
+    PortfolioSummaryTool,
+    SearchPortfolioTool,
+)
 
 __all__ = [
     "ManualDealEntryTool",
+    "ListPortfolioTool",
+    "SearchPortfolioTool",
+    "PortfolioSummaryTool",
+    "InspectDealTool",
 ]

--- a/src/ad_buyer/tools/deal_jockey/__init__.py
+++ b/src/ad_buyer/tools/deal_jockey/__init__.py
@@ -1,0 +1,10 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""DealJockey tools for deal portfolio management."""
+
+from .deal_entry import ManualDealEntryTool
+
+__all__ = [
+    "ManualDealEntryTool",
+]

--- a/src/ad_buyer/tools/deal_jockey/deal_entry.py
+++ b/src/ad_buyer/tools/deal_jockey/deal_entry.py
@@ -1,0 +1,450 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Manual deal entry tool for DealJockey.
+
+Validates and prepares structured deal input for saving to the deal library.
+This is a pure validation/preparation tool -- it does NOT interact with
+DealStore directly. The caller (DealJockey agent or a higher-level flow)
+handles persistence and event emission.
+
+Usage:
+    entry = ManualDealEntry(
+        display_name="ESPN Sports PMP",
+        seller_url="https://espn.seller.example.com",
+        deal_type="PD",
+        media_type="DIGITAL",
+    )
+    result = create_manual_deal(entry)
+    if result.success:
+        deal_id = store.save_deal(**result.deal_data)
+        # emit EventType.DEAL_IMPORTED with import_source="MANUAL"
+"""
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# -- Valid enum values --------------------------------------------------------
+
+VALID_DEAL_TYPES = {"PG", "PD", "PA", "OPEN_AUCTION", "UPFRONT", "SCATTER"}
+VALID_MEDIA_TYPES = {"DIGITAL", "CTV", "LINEAR_TV", "AUDIO", "DOOH"}
+VALID_SELLER_TYPES = {"PUBLISHER", "SSP", "DSP", "INTERMEDIARY"}
+VALID_PRICE_MODELS = {"CPM", "CPP", "FLAT", "HYBRID"}
+VALID_STATUSES = {"draft", "active", "paused"}
+
+
+# -- Input model --------------------------------------------------------------
+
+
+class ManualDealEntry(BaseModel):
+    """Input for manually creating a single deal.
+
+    Required fields: display_name and seller_url.
+    All other fields have defaults or are optional.
+    """
+
+    # Required
+    display_name: str = Field(
+        ...,
+        description="Human-readable name for the deal",
+    )
+    seller_url: str = Field(
+        ...,
+        description="Seller endpoint URL",
+    )
+
+    # Required with defaults
+    product_id: str = Field(
+        default="manual-entry",
+        description="Product identifier (defaults to 'manual-entry' for manual deals)",
+    )
+    deal_type: str = Field(
+        default="PD",
+        description="Deal type: PG, PD, PA, OPEN_AUCTION, UPFRONT, or SCATTER",
+    )
+    status: str = Field(
+        default="draft",
+        description="Initial deal status: draft, active, or paused",
+    )
+
+    # Optional counterparty
+    seller_deal_id: Optional[str] = Field(
+        default=None,
+        description="Seller-assigned deal ID",
+    )
+    seller_org: Optional[str] = Field(
+        default=None,
+        description="Seller organization name",
+    )
+    seller_domain: Optional[str] = Field(
+        default=None,
+        description="Seller domain (e.g., nbcuniversal.com)",
+    )
+    seller_type: Optional[str] = Field(
+        default=None,
+        description="Seller type: PUBLISHER, SSP, DSP, or INTERMEDIARY",
+    )
+    buyer_org: Optional[str] = Field(
+        default=None,
+        description="Buyer organization name",
+    )
+    buyer_id: Optional[str] = Field(
+        default=None,
+        description="Buyer identifier",
+    )
+
+    # Optional pricing
+    price: Optional[float] = Field(
+        default=None,
+        description="Deal price (CPM or flat rate depending on price_model)",
+    )
+    fixed_price_cpm: Optional[float] = Field(
+        default=None,
+        description="Fixed CPM price",
+    )
+    bid_floor_cpm: Optional[float] = Field(
+        default=None,
+        description="Bid floor CPM for auction-based deals",
+    )
+    price_model: Optional[str] = Field(
+        default=None,
+        description="Pricing model: CPM, CPP, FLAT, or HYBRID",
+    )
+    currency: str = Field(
+        default="USD",
+        description="Currency code (default: USD)",
+    )
+
+    # Optional inventory
+    media_type: Optional[str] = Field(
+        default=None,
+        description="Media type: DIGITAL, CTV, LINEAR_TV, AUDIO, or DOOH",
+    )
+    impressions: Optional[int] = Field(
+        default=None,
+        description="Contracted impression volume",
+    )
+
+    # Optional dates
+    flight_start: Optional[str] = Field(
+        default=None,
+        description="Flight start date (ISO 8601, e.g. 2026-04-01)",
+    )
+    flight_end: Optional[str] = Field(
+        default=None,
+        description="Flight end date (ISO 8601, e.g. 2026-06-30)",
+    )
+
+    # Optional metadata
+    description: Optional[str] = Field(
+        default=None,
+        description="Free-text deal description",
+    )
+    advertiser_id: Optional[str] = Field(
+        default=None,
+        description="Advertiser identifier for portfolio tracking",
+    )
+    tags: Optional[list[str]] = Field(
+        default=None,
+        description="Tags for categorization (e.g., ['premium', 'sports'])",
+    )
+
+
+# -- Output dataclass ----------------------------------------------------------
+
+
+@dataclass
+class DealEntryResult:
+    """Result of a manual deal entry validation.
+
+    Attributes:
+        success: Whether validation passed.
+        deal_data: Validated deal dict ready for DealStore.save_deal(), or None on failure.
+        metadata: Portfolio metadata dict (tags, advertiser_id, import_source), or None on failure.
+        errors: List of validation error messages (empty on success).
+    """
+
+    success: bool
+    deal_data: Optional[dict[str, Any]] = None
+    metadata: Optional[dict[str, Any]] = None
+    errors: list[str] = field(default_factory=list)
+
+
+# -- Validation & preparation -------------------------------------------------
+
+
+def _validate_entry(entry: ManualDealEntry) -> list[str]:
+    """Validate a ManualDealEntry and return a list of error messages.
+
+    Returns an empty list if the entry is valid.
+    """
+    errors: list[str] = []
+
+    # display_name must not be empty or whitespace-only
+    if not entry.display_name or not entry.display_name.strip():
+        errors.append("display_name must not be empty")
+
+    # deal_type must be in valid set
+    if entry.deal_type not in VALID_DEAL_TYPES:
+        errors.append(
+            f"Invalid deal_type '{entry.deal_type}'. "
+            f"Must be one of: {', '.join(sorted(VALID_DEAL_TYPES))}"
+        )
+
+    # status must be in valid set
+    if entry.status not in VALID_STATUSES:
+        errors.append(
+            f"Invalid status '{entry.status}'. "
+            f"Must be one of: {', '.join(sorted(VALID_STATUSES))}"
+        )
+
+    # media_type validation (only if provided)
+    if entry.media_type is not None and entry.media_type not in VALID_MEDIA_TYPES:
+        errors.append(
+            f"Invalid media_type '{entry.media_type}'. "
+            f"Must be one of: {', '.join(sorted(VALID_MEDIA_TYPES))}"
+        )
+
+    # seller_type validation (only if provided)
+    if entry.seller_type is not None and entry.seller_type not in VALID_SELLER_TYPES:
+        errors.append(
+            f"Invalid seller_type '{entry.seller_type}'. "
+            f"Must be one of: {', '.join(sorted(VALID_SELLER_TYPES))}"
+        )
+
+    # price_model validation (only if provided)
+    if entry.price_model is not None and entry.price_model not in VALID_PRICE_MODELS:
+        errors.append(
+            f"Invalid price_model '{entry.price_model}'. "
+            f"Must be one of: {', '.join(sorted(VALID_PRICE_MODELS))}"
+        )
+
+    # Flight date ordering: end must not be before start
+    if entry.flight_start is not None and entry.flight_end is not None:
+        if entry.flight_end < entry.flight_start:
+            errors.append(
+                f"flight_end ({entry.flight_end}) must not be before "
+                f"flight_start ({entry.flight_start})"
+            )
+
+    return errors
+
+
+def _build_deal_data(entry: ManualDealEntry) -> dict[str, Any]:
+    """Build a deal dict compatible with DealStore.save_deal() kwargs.
+
+    Maps ManualDealEntry fields to save_deal() parameters. V2 deal library
+    fields that don't have direct save_deal() parameters are packed into
+    the metadata JSON string.
+    """
+    # V2 extension fields packed into metadata JSON
+    v2_metadata: dict[str, Any] = {}
+
+    # Always include display_name in metadata for v2 column population
+    v2_metadata["display_name"] = entry.display_name
+
+    # Counterparty fields
+    if entry.seller_org is not None:
+        v2_metadata["seller_org"] = entry.seller_org
+    if entry.seller_domain is not None:
+        v2_metadata["seller_domain"] = entry.seller_domain
+    if entry.seller_type is not None:
+        v2_metadata["seller_type"] = entry.seller_type
+    if entry.buyer_org is not None:
+        v2_metadata["buyer_org"] = entry.buyer_org
+    if entry.buyer_id is not None:
+        v2_metadata["buyer_id"] = entry.buyer_id
+
+    # Pricing detail fields
+    if entry.price_model is not None:
+        v2_metadata["price_model"] = entry.price_model
+    if entry.fixed_price_cpm is not None:
+        v2_metadata["fixed_price_cpm"] = entry.fixed_price_cpm
+    if entry.bid_floor_cpm is not None:
+        v2_metadata["bid_floor_cpm"] = entry.bid_floor_cpm
+    v2_metadata["currency"] = entry.currency
+
+    # Inventory fields
+    if entry.media_type is not None:
+        v2_metadata["media_type"] = entry.media_type
+
+    # Description
+    if entry.description is not None:
+        v2_metadata["description"] = entry.description
+
+    # Build the deal dict matching DealStore.save_deal() parameters
+    deal_data: dict[str, Any] = {
+        "seller_url": entry.seller_url,
+        "product_id": entry.product_id,
+        "product_name": entry.display_name,
+        "deal_type": entry.deal_type,
+        "status": entry.status,
+        "seller_deal_id": entry.seller_deal_id,
+        "price": entry.price,
+        "impressions": entry.impressions,
+        "flight_start": entry.flight_start,
+        "flight_end": entry.flight_end,
+        "metadata": json.dumps(v2_metadata),
+    }
+
+    return deal_data
+
+
+def _build_portfolio_metadata(entry: ManualDealEntry) -> dict[str, Any]:
+    """Build portfolio metadata dict for the portfolio_metadata table.
+
+    This maps to the extrinsic portfolio_metadata columns:
+    import_source, tags, advertiser_id.
+    """
+    return {
+        "import_source": "MANUAL",
+        "tags": entry.tags,
+        "advertiser_id": entry.advertiser_id,
+    }
+
+
+def create_manual_deal(entry: ManualDealEntry) -> DealEntryResult:
+    """Validate and prepare a manual deal entry for saving.
+
+    This is a pure validation/preparation function -- it does NOT
+    call DealStore. The caller saves the deal and emits
+    EventType.DEAL_IMPORTED with import_source="MANUAL".
+
+    Args:
+        entry: Validated ManualDealEntry input model.
+
+    Returns:
+        DealEntryResult with success/failure, deal_data dict
+        ready for save_deal(), portfolio metadata, and any
+        validation errors.
+    """
+    errors = _validate_entry(entry)
+
+    if errors:
+        return DealEntryResult(
+            success=False,
+            deal_data=None,
+            metadata=None,
+            errors=errors,
+        )
+
+    deal_data = _build_deal_data(entry)
+    metadata = _build_portfolio_metadata(entry)
+
+    return DealEntryResult(
+        success=True,
+        deal_data=deal_data,
+        metadata=metadata,
+        errors=[],
+    )
+
+
+# -- CrewAI tool wrapper -------------------------------------------------------
+
+
+class ManualDealEntryToolInput(BaseModel):
+    """Input schema for the ManualDealEntryTool CrewAI wrapper."""
+
+    deal_params: str = Field(
+        ...,
+        description=(
+            "JSON string containing deal parameters. "
+            "Required fields: display_name, seller_url. "
+            "Optional: product_id, deal_type, status, seller_deal_id, "
+            "seller_org, seller_domain, seller_type, buyer_org, buyer_id, "
+            "price, fixed_price_cpm, bid_floor_cpm, price_model, currency, "
+            "media_type, impressions, flight_start, flight_end, description, "
+            "advertiser_id, tags."
+        ),
+    )
+
+
+class ManualDealEntryTool(BaseTool):
+    """Create a single deal from structured input.
+
+    Accepts deal parameters as a JSON string, validates them, and
+    returns a human-readable summary of the prepared deal or
+    validation errors. The tool does NOT persist the deal; the
+    caller is responsible for saving via DealStore and emitting
+    the DEAL_IMPORTED event.
+    """
+
+    name: str = "manual_deal_entry"
+    description: str = (
+        "Create a single deal from structured input for the deal portfolio. "
+        "Accepts a JSON string with deal parameters (display_name, seller_url required). "
+        "Returns a summary of the validated deal or validation errors."
+    )
+    args_schema: type[BaseModel] = ManualDealEntryToolInput
+
+    def _run(self, deal_params: str) -> str:
+        """Validate deal parameters and return a human-readable result.
+
+        Args:
+            deal_params: JSON string with deal parameters.
+
+        Returns:
+            Human-readable summary of the created deal or error messages.
+        """
+        # Parse JSON input
+        try:
+            params = json.loads(deal_params)
+        except (json.JSONDecodeError, TypeError) as exc:
+            return f"Error: Invalid JSON input -- {exc}"
+
+        # Build ManualDealEntry from parsed params
+        try:
+            entry = ManualDealEntry(**params)
+        except Exception as exc:
+            return f"Error: Invalid deal parameters -- {exc}"
+
+        # Validate and prepare
+        result = create_manual_deal(entry)
+
+        if not result.success:
+            error_list = "\n".join(f"  - {e}" for e in result.errors)
+            return f"Error: Deal validation failed:\n{error_list}"
+
+        # Format success response
+        return self._format_success(result)
+
+    def _format_success(self, result: DealEntryResult) -> str:
+        """Format a successful deal entry result as a human-readable string."""
+        data = result.deal_data
+        meta = result.metadata
+
+        lines = [
+            "Deal created successfully.",
+            "",
+            f"  Name: {data['product_name']}",
+            f"  Seller URL: {data['seller_url']}",
+            f"  Deal Type: {data['deal_type']}",
+            f"  Status: {data['status']}",
+        ]
+
+        if data.get("seller_deal_id"):
+            lines.append(f"  Seller Deal ID: {data['seller_deal_id']}")
+        if data.get("price") is not None:
+            lines.append(f"  Price: {data['price']}")
+        if data.get("impressions") is not None:
+            lines.append(f"  Impressions: {data['impressions']:,}")
+        if data.get("flight_start"):
+            lines.append(f"  Flight Start: {data['flight_start']}")
+        if data.get("flight_end"):
+            lines.append(f"  Flight End: {data['flight_end']}")
+
+        lines.append(f"  Import Source: {meta['import_source']}")
+
+        if meta.get("advertiser_id"):
+            lines.append(f"  Advertiser: {meta['advertiser_id']}")
+        if meta.get("tags"):
+            lines.append(f"  Tags: {', '.join(meta['tags'])}")
+
+        return "\n".join(lines)

--- a/src/ad_buyer/tools/deal_jockey/portfolio_inspection.py
+++ b/src/ad_buyer/tools/deal_jockey/portfolio_inspection.py
@@ -1,0 +1,686 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Portfolio inspection tools for DealJockey.
+
+CrewAI tools that let DealJockey list, filter, search, and aggregate
+deal portfolio views.  Unlike the CSV parser and manual-entry tools
+(which are pure functions), these tools interact directly with
+DealStore to query live portfolio data.
+
+Usage:
+    store = DealStore("sqlite:///./ad_buyer.db")
+    store.connect()
+
+    list_tool = ListPortfolioTool(deal_store=store)
+    result = list_tool._run(filters_json='{"status": "active"}')
+
+    search_tool = SearchPortfolioTool(deal_store=store)
+    result = search_tool._run(query="ESPN")
+
+    summary_tool = PortfolioSummaryTool(deal_store=store)
+    result = summary_tool._run(options_json='{}')
+
+    inspect_tool = InspectDealTool(deal_store=store)
+    result = inspect_tool._run(deal_id="deal-001")
+
+Note: The caller should emit EventType.PORTFOLIO_INSPECTED after
+using ListPortfolioTool or SearchPortfolioTool to track portfolio
+access in the event bus audit trail.
+"""
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+
+from ...storage.deal_store import DealStore
+
+logger = logging.getLogger(__name__)
+
+
+# -- Input schemas -----------------------------------------------------------
+
+
+class ListPortfolioInput(BaseModel):
+    """Input schema for ListPortfolioTool."""
+
+    filters_json: str = Field(
+        ...,
+        description=(
+            "JSON string with filter/sort/pagination parameters. "
+            "Filters: status, media_type, seller_domain, deal_type, "
+            "advertiser_id, seller_type. "
+            "Pagination: limit (default 50), offset (default 0). "
+            "Sorting: sort_by (created_at, price, display_name), "
+            "sort_order (asc, desc; default desc)."
+        ),
+    )
+
+
+class SearchPortfolioInput(BaseModel):
+    """Input schema for SearchPortfolioTool."""
+
+    query: str = Field(
+        ...,
+        description=(
+            "Free-text search string. Matches case-insensitively "
+            "against display_name, description, seller_org, and "
+            "seller_domain."
+        ),
+    )
+
+
+class PortfolioSummaryInput(BaseModel):
+    """Input schema for PortfolioSummaryTool."""
+
+    options_json: str = Field(
+        ...,
+        description=(
+            "JSON string with summary options. "
+            "Optional: top_sellers_count (default 5), "
+            "expiring_within_days (default 30)."
+        ),
+    )
+
+
+class InspectDealInput(BaseModel):
+    """Input schema for InspectDealTool."""
+
+    deal_id: str = Field(
+        ...,
+        description="The deal ID to inspect.",
+    )
+
+
+# -- Formatting helpers ------------------------------------------------------
+
+
+def _format_deal_summary(deal: dict[str, Any]) -> str:
+    """Format a single deal as a compact, human-readable summary line block."""
+    name = deal.get("display_name") or deal.get("product_name") or "(unnamed)"
+    deal_id = deal.get("id", "?")
+    status = deal.get("status", "?")
+    deal_type = deal.get("deal_type", "?")
+    media_type = deal.get("media_type") or "N/A"
+    seller = deal.get("seller_org") or deal.get("seller_domain") or "N/A"
+    price = deal.get("price")
+    impressions = deal.get("impressions")
+
+    lines = [
+        f"  [{deal_id}] {name}",
+        f"    Status: {status} | Type: {deal_type} | Media: {media_type}",
+        f"    Seller: {seller}",
+    ]
+
+    price_parts = []
+    if price is not None:
+        price_parts.append(f"Price: ${price:,.2f}")
+    if impressions is not None:
+        price_parts.append(f"Impressions: {impressions:,}")
+    if price_parts:
+        lines.append(f"    {' | '.join(price_parts)}")
+
+    flight_start = deal.get("flight_start")
+    flight_end = deal.get("flight_end")
+    if flight_start or flight_end:
+        flight = f"    Flight: {flight_start or '?'} to {flight_end or '?'}"
+        lines.append(flight)
+
+    return "\n".join(lines)
+
+
+def _format_number(n: int | float) -> str:
+    """Format a number with comma separators."""
+    if isinstance(n, float):
+        return f"{n:,.2f}"
+    return f"{n:,}"
+
+
+# -- ListPortfolioTool -------------------------------------------------------
+
+
+class ListPortfolioTool(BaseTool):
+    """List deals in the portfolio with rich filtering, sorting, and pagination.
+
+    Returns formatted deal summaries (not raw dicts) for agent readability.
+    The caller should emit EventType.PORTFOLIO_INSPECTED after use.
+    """
+
+    name: str = "list_portfolio"
+    description: str = (
+        "List deals in the deal portfolio with filtering, sorting, and "
+        "pagination. Accepts a JSON string with filter params (status, "
+        "media_type, seller_domain, deal_type, advertiser_id, seller_type), "
+        "pagination (limit, offset), and sorting (sort_by, sort_order)."
+    )
+    args_schema: type[BaseModel] = ListPortfolioInput
+    deal_store: Any = Field(exclude=True)
+
+    def _run(self, filters_json: str) -> str:
+        """List deals with the specified filters.
+
+        Args:
+            filters_json: JSON string with filter, sort, and pagination params.
+
+        Returns:
+            Human-readable formatted list of matching deals.
+        """
+        # Parse input
+        try:
+            params = json.loads(filters_json)
+        except (json.JSONDecodeError, TypeError) as exc:
+            return f"Error: Invalid JSON input -- {exc}"
+
+        # Extract pagination
+        limit = params.pop("limit", 50)
+        offset = params.pop("offset", 0)
+
+        # Extract sorting
+        sort_by = params.pop("sort_by", "created_at")
+        sort_order = params.pop("sort_order", "desc")
+
+        # Validate sort_by
+        valid_sort_fields = {"created_at", "price", "display_name"}
+        if sort_by not in valid_sort_fields:
+            sort_by = "created_at"
+        if sort_order not in ("asc", "desc"):
+            sort_order = "desc"
+
+        # Extract seller_type filter (handled in Python since DealStore
+        # list_deals does not support it natively)
+        seller_type_filter = params.pop("seller_type", None)
+
+        # Build DealStore filters (only pass supported ones)
+        store_filters: dict[str, Any] = {}
+        for key in ("status", "media_type", "seller_domain", "deal_type", "advertiser_id"):
+            if key in params:
+                store_filters[key] = params[key]
+
+        # Fetch from store -- get more than we need for post-filtering + sorting
+        fetch_limit = limit + offset + 200  # over-fetch for post-filtering
+        deals = self.deal_store.list_deals(limit=fetch_limit, **store_filters)
+
+        # Post-filter by seller_type if specified
+        if seller_type_filter:
+            deals = [d for d in deals if d.get("seller_type") == seller_type_filter]
+
+        # Sort
+        if sort_by == "price":
+            deals.sort(
+                key=lambda d: d.get("price") or 0,
+                reverse=(sort_order == "desc"),
+            )
+        elif sort_by == "display_name":
+            deals.sort(
+                key=lambda d: (d.get("display_name") or d.get("product_name") or "").lower(),
+                reverse=(sort_order == "desc"),
+            )
+        else:
+            # created_at -- DealStore already sorts by created_at DESC,
+            # but we may need ASC
+            if sort_order == "asc":
+                deals.sort(key=lambda d: d.get("created_at") or "")
+
+        # Apply pagination
+        total_count = len(deals)
+        deals = deals[offset: offset + limit]
+
+        # Format output
+        if not deals:
+            if total_count == 0:
+                return "No deals found matching the specified filters."
+            return f"No deals found at offset {offset} (total matching: {total_count})."
+
+        lines = [f"Portfolio: {len(deals)} of {total_count} deals shown"]
+        if offset > 0:
+            lines[0] += f" (offset: {offset})"
+        lines.append("")
+
+        for deal in deals:
+            lines.append(_format_deal_summary(deal))
+            lines.append("")
+
+        return "\n".join(lines)
+
+
+# -- SearchPortfolioTool -----------------------------------------------------
+
+
+class SearchPortfolioTool(BaseTool):
+    """Search the deal portfolio with free-text matching.
+
+    Performs case-insensitive LIKE matching across deal fields:
+    display_name, description, seller_org, seller_domain.
+    Returns matching deals with relevance context (which field matched).
+
+    The caller should emit EventType.PORTFOLIO_INSPECTED after use.
+    """
+
+    name: str = "search_portfolio"
+    description: str = (
+        "Free-text search across deal portfolio. Searches display_name, "
+        "description, seller_org, and seller_domain with case-insensitive "
+        "matching. Returns deals with context about which field matched."
+    )
+    args_schema: type[BaseModel] = SearchPortfolioInput
+    deal_store: Any = Field(exclude=True)
+
+    # Fields to search and their human-readable labels
+    _SEARCH_FIELDS = [
+        ("display_name", "display name"),
+        ("description", "description"),
+        ("seller_org", "seller organization"),
+        ("seller_domain", "seller domain"),
+    ]
+
+    def _run(self, query: str) -> str:
+        """Search deals by free-text query.
+
+        Args:
+            query: Search string (case-insensitive).
+
+        Returns:
+            Human-readable list of matching deals with match context.
+        """
+        if not query or not query.strip():
+            return "Error: Search query must not be empty."
+
+        query = query.strip()
+        query_lower = query.lower()
+
+        # Fetch all deals (search needs full scan)
+        deals = self.deal_store.list_deals(limit=10000)
+
+        # Match against search fields
+        matches: list[tuple[dict[str, Any], list[str]]] = []
+        for deal in deals:
+            matched_fields = []
+            for field_name, field_label in self._SEARCH_FIELDS:
+                value = deal.get(field_name)
+                if value and query_lower in str(value).lower():
+                    matched_fields.append(field_label)
+            if matched_fields:
+                matches.append((deal, matched_fields))
+
+        if not matches:
+            return f'No deals found matching "{query}".'
+
+        lines = [f'Search results for "{query}": {len(matches)} deal(s) found']
+        lines.append("")
+
+        for deal, matched_fields in matches:
+            lines.append(_format_deal_summary(deal))
+            lines.append(f"    Matched in: {', '.join(matched_fields)}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+
+# -- PortfolioSummaryTool ----------------------------------------------------
+
+
+class PortfolioSummaryTool(BaseTool):
+    """Generate aggregate statistics for the deal portfolio.
+
+    Produces a structured summary with counts by status, media type,
+    deal type, top sellers, total portfolio value, and expiring deals.
+    """
+
+    name: str = "portfolio_summary"
+    description: str = (
+        "Generate aggregate statistics for the deal portfolio: total "
+        "deals by status, media type, deal type; top sellers; total "
+        "portfolio value; and active deals expiring within N days."
+    )
+    args_schema: type[BaseModel] = PortfolioSummaryInput
+    deal_store: Any = Field(exclude=True)
+
+    def _run(self, options_json: str) -> str:
+        """Generate a portfolio summary.
+
+        Args:
+            options_json: JSON string with options.
+                top_sellers_count: Number of top sellers to show (default 5).
+                expiring_within_days: Show deals expiring within N days (default 30).
+
+        Returns:
+            Human-readable portfolio summary string.
+        """
+        # Parse options
+        try:
+            options = json.loads(options_json)
+        except (json.JSONDecodeError, TypeError) as exc:
+            return f"Error: Invalid JSON input -- {exc}"
+
+        top_sellers_count = options.get("top_sellers_count", 5)
+        expiring_within_days = options.get("expiring_within_days", 30)
+
+        # Fetch all deals
+        deals = self.deal_store.list_deals(limit=10000)
+
+        if not deals:
+            return (
+                "Portfolio Summary\n"
+                "=================\n"
+                "Total deals: 0\n"
+                "\nThe portfolio is empty."
+            )
+
+        total = len(deals)
+
+        # Count by status
+        status_counts: dict[str, int] = {}
+        for deal in deals:
+            s = deal.get("status", "unknown")
+            status_counts[s] = status_counts.get(s, 0) + 1
+
+        # Count by media type
+        media_counts: dict[str, int] = {}
+        for deal in deals:
+            mt = deal.get("media_type") or "N/A"
+            media_counts[mt] = media_counts.get(mt, 0) + 1
+
+        # Count by deal type
+        type_counts: dict[str, int] = {}
+        for deal in deals:
+            dt = deal.get("deal_type", "unknown")
+            type_counts[dt] = type_counts.get(dt, 0) + 1
+
+        # Top sellers by deal count
+        seller_counts: dict[str, int] = {}
+        for deal in deals:
+            seller = deal.get("seller_org") or deal.get("seller_domain") or "Unknown"
+            seller_counts[seller] = seller_counts.get(seller, 0) + 1
+        top_sellers = sorted(
+            seller_counts.items(), key=lambda x: x[1], reverse=True
+        )[:top_sellers_count]
+
+        # Total portfolio value: sum of (price * impressions / 1000) for CPM
+        total_value = 0.0
+        for deal in deals:
+            price = deal.get("price")
+            impressions = deal.get("impressions")
+            if price is not None and impressions is not None:
+                total_value += price * impressions / 1000.0
+
+        # Deals expiring within N days
+        now = datetime.now(timezone.utc)
+        cutoff = now + timedelta(days=expiring_within_days)
+        cutoff_str = cutoff.strftime("%Y-%m-%d")
+        now_str = now.strftime("%Y-%m-%d")
+
+        expiring_deals = []
+        for deal in deals:
+            if deal.get("status") not in ("active", "draft"):
+                continue
+            flight_end = deal.get("flight_end")
+            if flight_end and now_str <= flight_end <= cutoff_str:
+                expiring_deals.append(deal)
+
+        # Build output
+        lines = [
+            "Portfolio Summary",
+            "=================",
+            f"Total deals: {total}",
+            f"Total portfolio value: ${_format_number(total_value)}",
+            "",
+            "By Status:",
+        ]
+        for status, count in sorted(status_counts.items()):
+            lines.append(f"  {status}: {count}")
+
+        lines.append("")
+        lines.append("By Media Type:")
+        for mt, count in sorted(media_counts.items()):
+            lines.append(f"  {mt}: {count}")
+
+        lines.append("")
+        lines.append("By Deal Type:")
+        for dt, count in sorted(type_counts.items()):
+            lines.append(f"  {dt}: {count}")
+
+        lines.append("")
+        lines.append(f"Top Sellers (by deal count):")
+        for seller, count in top_sellers:
+            lines.append(f"  {seller}: {count} deal(s)")
+
+        lines.append("")
+        if expiring_deals:
+            lines.append(
+                f"Deals expiring within {expiring_within_days} days: "
+                f"{len(expiring_deals)}"
+            )
+            for deal in expiring_deals:
+                name = deal.get("display_name") or deal.get("product_name") or "?"
+                lines.append(
+                    f"  [{deal.get('id')}] {name} -- expires {deal.get('flight_end')}"
+                )
+        else:
+            lines.append(
+                f"No active/draft deals expiring within {expiring_within_days} days."
+            )
+
+        return "\n".join(lines)
+
+
+# -- InspectDealTool ---------------------------------------------------------
+
+
+class InspectDealTool(BaseTool):
+    """Deep inspection of a single deal by ID.
+
+    Returns all deal fields plus portfolio_metadata, deal_activations,
+    and performance_cache, formatted for agent readability.
+    """
+
+    name: str = "inspect_deal"
+    description: str = (
+        "Deep-inspect a single deal by ID. Returns all deal fields, "
+        "portfolio metadata, cross-platform activations, and cached "
+        "performance metrics in a formatted view."
+    )
+    args_schema: type[BaseModel] = InspectDealInput
+    deal_store: Any = Field(exclude=True)
+
+    def _run(self, deal_id: str) -> str:
+        """Inspect a deal in full detail.
+
+        Args:
+            deal_id: The deal's primary key.
+
+        Returns:
+            Human-readable deep inspection of the deal.
+        """
+        deal = self.deal_store.get_deal(deal_id)
+        if deal is None:
+            return f"Deal not found: {deal_id}"
+
+        lines = self._format_deal_section(deal)
+
+        # Portfolio metadata
+        metadata = self.deal_store.get_portfolio_metadata(deal_id)
+        lines.extend(self._format_metadata_section(metadata))
+
+        # Deal activations
+        activations = self.deal_store.get_deal_activations(deal_id)
+        lines.extend(self._format_activations_section(activations))
+
+        # Performance cache
+        perf = self.deal_store.get_performance_cache(deal_id)
+        lines.extend(self._format_performance_section(perf))
+
+        return "\n".join(lines)
+
+    def _format_deal_section(self, deal: dict[str, Any]) -> list[str]:
+        """Format the core deal fields."""
+        name = deal.get("display_name") or deal.get("product_name") or "(unnamed)"
+        lines = [
+            f"Deal Inspection: {name}",
+            "=" * (len(f"Deal Inspection: {name}")),
+            "",
+            "Core Fields:",
+            f"  ID: {deal.get('id')}",
+            f"  Display Name: {name}",
+            f"  Status: {deal.get('status')}",
+            f"  Deal Type: {deal.get('deal_type')}",
+            f"  Media Type: {deal.get('media_type') or 'N/A'}",
+        ]
+
+        # Seller info
+        lines.append("")
+        lines.append("Seller:")
+        for field, label in [
+            ("seller_url", "URL"),
+            ("seller_org", "Organization"),
+            ("seller_domain", "Domain"),
+            ("seller_type", "Type"),
+            ("seller_deal_id", "Deal ID"),
+        ]:
+            val = deal.get(field)
+            if val:
+                lines.append(f"  {label}: {val}")
+
+        # Buyer info
+        buyer_org = deal.get("buyer_org")
+        buyer_id = deal.get("buyer_id")
+        if buyer_org or buyer_id:
+            lines.append("")
+            lines.append("Buyer:")
+            if buyer_org:
+                lines.append(f"  Organization: {buyer_org}")
+            if buyer_id:
+                lines.append(f"  ID: {buyer_id}")
+
+        # Pricing
+        lines.append("")
+        lines.append("Pricing:")
+        for field, label in [
+            ("price", "Price (CPM)"),
+            ("original_price", "Original Price"),
+            ("fixed_price_cpm", "Fixed CPM"),
+            ("bid_floor_cpm", "Bid Floor CPM"),
+            ("price_model", "Price Model"),
+            ("currency", "Currency"),
+            ("cpp", "CPP"),
+            ("guaranteed_grps", "Guaranteed GRPs"),
+            ("fee_transparency", "Fee Transparency"),
+        ]:
+            val = deal.get(field)
+            if val is not None:
+                if isinstance(val, float):
+                    lines.append(f"  {label}: ${val:,.2f}")
+                else:
+                    lines.append(f"  {label}: {val}")
+
+        # Volume & dates
+        impressions = deal.get("impressions")
+        if impressions is not None:
+            lines.append(f"  Impressions: {impressions:,}")
+        estimated_vol = deal.get("estimated_volume")
+        if estimated_vol is not None:
+            lines.append(f"  Estimated Volume: {estimated_vol:,}")
+
+        flight_start = deal.get("flight_start")
+        flight_end = deal.get("flight_end")
+        if flight_start or flight_end:
+            lines.append("")
+            lines.append("Flight Dates:")
+            if flight_start:
+                lines.append(f"  Start: {flight_start}")
+            if flight_end:
+                lines.append(f"  End: {flight_end}")
+
+        # Description
+        description = deal.get("description")
+        if description:
+            lines.append("")
+            lines.append(f"Description: {description}")
+
+        # Timestamps
+        lines.append("")
+        lines.append("Timestamps:")
+        if deal.get("created_at"):
+            lines.append(f"  Created: {deal['created_at']}")
+        if deal.get("updated_at"):
+            lines.append(f"  Updated: {deal['updated_at']}")
+
+        return lines
+
+    def _format_metadata_section(
+        self, metadata: Optional[dict[str, Any]]
+    ) -> list[str]:
+        """Format the portfolio metadata section."""
+        lines = ["", "Portfolio Metadata:"]
+        if metadata is None:
+            lines.append("  No portfolio metadata recorded.")
+            return lines
+
+        for field, label in [
+            ("import_source", "Import Source"),
+            ("import_date", "Import Date"),
+            ("advertiser_id", "Advertiser ID"),
+            ("agency_id", "Agency ID"),
+            ("tags", "Tags"),
+        ]:
+            val = metadata.get(field)
+            if val is not None:
+                lines.append(f"  {label}: {val}")
+
+        return lines
+
+    def _format_activations_section(
+        self, activations: list[dict[str, Any]]
+    ) -> list[str]:
+        """Format the deal activations section."""
+        lines = ["", "Deal Activations:"]
+        if not activations:
+            lines.append("  No activations recorded.")
+            return lines
+
+        lines.append(f"  {len(activations)} activation(s):")
+        for act in activations:
+            platform = act.get("platform", "?")
+            pid = act.get("platform_deal_id") or "N/A"
+            status = act.get("activation_status") or "N/A"
+            sync = act.get("last_sync_at") or "never"
+            lines.append(
+                f"  - {platform}: ID={pid}, Status={status}, Last Sync={sync}"
+            )
+
+        return lines
+
+    def _format_performance_section(
+        self, perf: Optional[dict[str, Any]]
+    ) -> list[str]:
+        """Format the performance cache section."""
+        lines = ["", "Performance Cache:"]
+        if perf is None:
+            lines.append("  No performance data cached.")
+            return lines
+
+        for field, label, fmt in [
+            ("impressions_delivered", "Impressions Delivered", "int"),
+            ("spend_to_date", "Spend to Date", "dollar"),
+            ("fill_rate", "Fill Rate", "pct"),
+            ("win_rate", "Win Rate", "pct"),
+            ("avg_effective_cpm", "Avg Effective CPM", "dollar"),
+            ("last_delivery_at", "Last Delivery", "str"),
+            ("performance_trend", "Trend", "str"),
+            ("cached_at", "Cached At", "str"),
+        ]:
+            val = perf.get(field)
+            if val is not None:
+                if fmt == "int":
+                    lines.append(f"  {label}: {int(val):,}")
+                elif fmt == "dollar":
+                    lines.append(f"  {label}: ${float(val):,.2f}")
+                elif fmt == "pct":
+                    lines.append(f"  {label}: {float(val) * 100:.1f}%")
+                else:
+                    lines.append(f"  {label}: {val}")
+
+        return lines

--- a/tests/unit/test_csv_import.py
+++ b/tests/unit/test_csv_import.py
@@ -1,0 +1,789 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Unit tests for CSV deal import parser.
+
+Tests cover column detection, data normalization, validation,
+error handling, and import result reporting.
+"""
+
+import csv
+import io
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ad_buyer.tools.deal_import import (
+    COLUMN_MAPPINGS,
+    ImportError as DealImportError,
+    ImportResult,
+    parse_csv_deals,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_csv(rows: list[list[str]], *, tmpdir: str | None = None) -> str:
+    """Write rows to a temp CSV file and return its path."""
+    fd, path = tempfile.mkstemp(suffix=".csv", dir=tmpdir)
+    with os.fdopen(fd, "w", newline="") as f:
+        writer = csv.writer(f)
+        for row in rows:
+            writer.writerow(row)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Basic parsing
+# ---------------------------------------------------------------------------
+
+
+class TestBasicParsing:
+    """Test basic CSV parsing with standard column names."""
+
+    def test_single_valid_row(self, tmp_path):
+        """Parse a single valid deal row with standard column names."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "cpm", "deal_type", "media_type"],
+                ["DEAL-001", "Test Deal", "ESPN", "12.50", "PG", "DIGITAL"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+
+        assert result.total_rows == 1
+        assert result.successful == 1
+        assert result.failed == 0
+        assert result.skipped == 0
+        assert len(result.deals) == 1
+
+        deal = result.deals[0]
+        assert deal["seller_deal_id"] == "DEAL-001"
+        assert deal["display_name"] == "Test Deal"
+        assert deal["seller_org"] == "ESPN"
+        assert deal["fixed_price_cpm"] == 12.50
+        assert deal["deal_type"] == "PG"
+        assert deal["media_type"] == "DIGITAL"
+
+    def test_multiple_valid_rows(self, tmp_path):
+        """Parse multiple valid deal rows."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "cpm", "deal_type", "media_type"],
+                ["DEAL-001", "Deal A", "ESPN", "10.00", "PG", "DIGITAL"],
+                ["DEAL-002", "Deal B", "NBCU", "15.00", "PD", "CTV"],
+                ["DEAL-003", "Deal C", "Fox", "8.00", "PA", "DIGITAL"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+
+        assert result.total_rows == 3
+        assert result.successful == 3
+        assert result.failed == 0
+        assert len(result.deals) == 3
+
+    def test_path_object_accepted(self, tmp_path):
+        """Accept pathlib.Path as well as str."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller"],
+                ["DEAL-001", "Test", "ESPN"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(Path(path))
+        assert result.successful == 1
+
+    def test_default_values_applied(self, tmp_path):
+        """Default seller_url and product_id are applied when not in CSV."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller"],
+                ["DEAL-001", "Test", "ESPN"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(
+            path,
+            default_seller_url="https://seller.example.com",
+            default_product_id="imported-batch",
+        )
+        deal = result.deals[0]
+        assert deal["seller_url"] == "https://seller.example.com"
+        assert deal["product_id"] == "imported-batch"
+
+    def test_currency_defaults_to_usd(self, tmp_path):
+        """Currency defaults to USD when not specified."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller"],
+                ["DEAL-001", "Test", "ESPN"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["currency"] == "USD"
+
+
+# ---------------------------------------------------------------------------
+# Column name variation handling
+# ---------------------------------------------------------------------------
+
+
+class TestColumnNameVariations:
+    """Test case-insensitive and format-variant column name detection."""
+
+    def test_case_insensitive_headers(self, tmp_path):
+        """Column names are matched case-insensitively."""
+        path = _write_csv(
+            [
+                ["Deal_ID", "Name", "SELLER", "CPM", "Deal_Type", "Media_Type"],
+                ["DEAL-001", "Test", "ESPN", "10", "PG", "DIGITAL"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.successful == 1
+        deal = result.deals[0]
+        assert deal["seller_deal_id"] == "DEAL-001"
+        assert deal["display_name"] == "Test"
+
+    def test_space_underscore_variants(self, tmp_path):
+        """Handle 'Deal ID' vs 'deal_id' vs 'DealID'."""
+        path = _write_csv(
+            [
+                ["Deal ID", "Deal Name", "Publisher", "Price"],
+                ["DEAL-001", "Test", "ESPN", "10.00"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.successful == 1
+        deal = result.deals[0]
+        assert deal["seller_deal_id"] == "DEAL-001"
+        assert deal["display_name"] == "Test"
+        assert deal["seller_org"] == "ESPN"
+        assert deal["fixed_price_cpm"] == 10.00
+
+    def test_dealid_no_separator(self, tmp_path):
+        """Handle 'DealID' (no separator)."""
+        path = _write_csv(
+            [
+                ["DealID", "Name", "Seller"],
+                ["DEAL-001", "Test", "ESPN"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["seller_deal_id"] == "DEAL-001"
+
+    def test_publisher_domain_column(self, tmp_path):
+        """Map 'publisher_domain' to seller_domain."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "publisher_domain"],
+                ["DEAL-001", "Test", "ESPN", "espn.com"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["seller_domain"] == "espn.com"
+
+    def test_bid_floor_column(self, tmp_path):
+        """Map 'floor' and 'bid_floor' to bid_floor_cpm."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "floor"],
+                ["DEAL-001", "Test", "ESPN", "5.00"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["bid_floor_cpm"] == 5.00
+
+    def test_channel_maps_to_media_type(self, tmp_path):
+        """Map 'channel' column to media_type."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "channel"],
+                ["DEAL-001", "Test", "ESPN", "CTV"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["media_type"] == "CTV"
+
+
+# ---------------------------------------------------------------------------
+# Custom column mapping override
+# ---------------------------------------------------------------------------
+
+
+class TestCustomColumnMapping:
+    """Test user-provided column mapping overrides."""
+
+    def test_custom_mapping_overrides_auto(self, tmp_path):
+        """Custom mapping dict overrides auto-detected column names."""
+        path = _write_csv(
+            [
+                ["my_deal_code", "friendly_name", "vendor", "rate"],
+                ["DEAL-001", "Test", "ESPN", "10.00"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(
+            path,
+            column_mapping={
+                "my_deal_code": "seller_deal_id",
+                "friendly_name": "display_name",
+                "vendor": "seller_org",
+                "rate": "fixed_price_cpm",
+            },
+        )
+        assert result.successful == 1
+        deal = result.deals[0]
+        assert deal["seller_deal_id"] == "DEAL-001"
+        assert deal["display_name"] == "Test"
+        assert deal["seller_org"] == "ESPN"
+        assert deal["fixed_price_cpm"] == 10.00
+
+    def test_custom_mapping_partial_with_auto(self, tmp_path):
+        """Custom mapping for some cols, auto-detect for the rest."""
+        path = _write_csv(
+            [
+                ["my_id", "name", "seller"],
+                ["DEAL-001", "Test", "ESPN"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(
+            path,
+            column_mapping={"my_id": "seller_deal_id"},
+        )
+        assert result.successful == 1
+        deal = result.deals[0]
+        assert deal["seller_deal_id"] == "DEAL-001"
+        # "name" and "seller" should still be auto-detected
+        assert deal["display_name"] == "Test"
+        assert deal["seller_org"] == "ESPN"
+
+
+# ---------------------------------------------------------------------------
+# Date normalization
+# ---------------------------------------------------------------------------
+
+
+class TestDateNormalization:
+    """Test date parsing and normalization to ISO 8601."""
+
+    def test_iso_format_passthrough(self, tmp_path):
+        """YYYY-MM-DD passes through as-is."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "start_date", "end_date"],
+                ["DEAL-001", "Test", "ESPN", "2026-01-15", "2026-06-30"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        deal = result.deals[0]
+        assert deal["flight_start"] == "2026-01-15"
+        assert deal["flight_end"] == "2026-06-30"
+
+    def test_us_date_format(self, tmp_path):
+        """MM/DD/YYYY is normalized to YYYY-MM-DD."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "start_date", "end_date"],
+                ["DEAL-001", "Test", "ESPN", "01/15/2026", "06/30/2026"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        deal = result.deals[0]
+        assert deal["flight_start"] == "2026-01-15"
+        assert deal["flight_end"] == "2026-06-30"
+
+    def test_short_year_format(self, tmp_path):
+        """M/D/YY is normalized to YYYY-MM-DD."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "start_date"],
+                ["DEAL-001", "Test", "ESPN", "1/5/26"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["flight_start"] == "2026-01-05"
+
+    def test_flight_start_flight_end_columns(self, tmp_path):
+        """Direct flight_start/flight_end columns are recognized."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "flight_start", "flight_end"],
+                ["DEAL-001", "Test", "ESPN", "2026-03-01", "2026-12-31"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        deal = result.deals[0]
+        assert deal["flight_start"] == "2026-03-01"
+        assert deal["flight_end"] == "2026-12-31"
+
+
+# ---------------------------------------------------------------------------
+# Deal type normalization
+# ---------------------------------------------------------------------------
+
+
+class TestDealTypeNormalization:
+    """Test normalization of deal type values."""
+
+    @pytest.mark.parametrize(
+        "input_val,expected",
+        [
+            ("PG", "PG"),
+            ("pg", "PG"),
+            ("Pg", "PG"),
+            ("Programmatic Guaranteed", "PG"),
+            ("programmatic guaranteed", "PG"),
+            ("PD", "PD"),
+            ("Preferred Deal", "PD"),
+            ("preferred deal", "PD"),
+            ("PA", "PA"),
+            ("Private Auction", "PA"),
+            ("private auction", "PA"),
+            ("OPEN_AUCTION", "OPEN_AUCTION"),
+            ("Open Auction", "OPEN_AUCTION"),
+            ("open auction", "OPEN_AUCTION"),
+            ("UPFRONT", "UPFRONT"),
+            ("upfront", "UPFRONT"),
+            ("Upfront", "UPFRONT"),
+            ("SCATTER", "SCATTER"),
+            ("scatter", "SCATTER"),
+            ("Scatter", "SCATTER"),
+        ],
+    )
+    def test_deal_type_normalization(self, tmp_path, input_val, expected):
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "deal_type"],
+                ["DEAL-001", "Test", "ESPN", input_val],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["deal_type"] == expected
+
+
+# ---------------------------------------------------------------------------
+# Media type normalization
+# ---------------------------------------------------------------------------
+
+
+class TestMediaTypeNormalization:
+    """Test normalization of media type values."""
+
+    @pytest.mark.parametrize(
+        "input_val,expected",
+        [
+            ("DIGITAL", "DIGITAL"),
+            ("digital", "DIGITAL"),
+            ("Display", "DIGITAL"),
+            ("display", "DIGITAL"),
+            ("CTV", "CTV"),
+            ("ctv", "CTV"),
+            ("Connected TV", "CTV"),
+            ("connected tv", "CTV"),
+            ("LINEAR_TV", "LINEAR_TV"),
+            ("Linear TV", "LINEAR_TV"),
+            ("linear tv", "LINEAR_TV"),
+            ("AUDIO", "AUDIO"),
+            ("audio", "AUDIO"),
+            ("Audio", "AUDIO"),
+            ("DOOH", "DOOH"),
+            ("dooh", "DOOH"),
+        ],
+    )
+    def test_media_type_normalization(self, tmp_path, input_val, expected):
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "media_type"],
+                ["DEAL-001", "Test", "ESPN", input_val],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["media_type"] == expected
+
+
+# ---------------------------------------------------------------------------
+# Price parsing
+# ---------------------------------------------------------------------------
+
+
+class TestPriceParsing:
+    """Test price value parsing with various formats."""
+
+    def test_plain_number(self, tmp_path):
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "cpm"],
+                ["DEAL-001", "Test", "ESPN", "12.50"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["fixed_price_cpm"] == 12.50
+
+    def test_dollar_sign(self, tmp_path):
+        """Parse '$12.50' -> 12.50."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "cpm"],
+                ["DEAL-001", "Test", "ESPN", "$12.50"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["fixed_price_cpm"] == 12.50
+
+    def test_commas_in_number(self, tmp_path):
+        """Parse '1,234.56' -> 1234.56."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "cpm"],
+                ["DEAL-001", "Test", "ESPN", "1,234.56"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["fixed_price_cpm"] == 1234.56
+
+    def test_dollar_and_commas(self, tmp_path):
+        """Parse '$1,234.56' -> 1234.56."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "cpm"],
+                ["DEAL-001", "Test", "ESPN", "$1,234.56"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["fixed_price_cpm"] == 1234.56
+
+    def test_floor_price_parsing(self, tmp_path):
+        """Floor price also handles $ and commas."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "floor"],
+                ["DEAL-001", "Test", "ESPN", "$5.00"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["bid_floor_cpm"] == 5.00
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+class TestValidationErrors:
+    """Test validation of required fields and invalid values."""
+
+    def test_missing_deal_id_and_name(self, tmp_path):
+        """Row without deal_id or name fails validation."""
+        path = _write_csv(
+            [
+                ["seller", "cpm"],
+                ["ESPN", "10.00"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.failed == 1
+        assert result.successful == 0
+        assert len(result.errors) == 1
+        assert result.errors[0].field == "seller_deal_id/display_name"
+
+    def test_missing_seller_info(self, tmp_path):
+        """Row with deal_id but no seller info fails validation."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "cpm"],
+                ["DEAL-001", "Test", "10.00"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.failed == 1
+        assert len(result.errors) == 1
+        assert "seller" in result.errors[0].field.lower()
+
+    def test_invalid_deal_type(self, tmp_path):
+        """Invalid deal_type value produces validation error."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "deal_type"],
+                ["DEAL-001", "Test", "ESPN", "INVALID_TYPE"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.failed == 1
+        assert len(result.errors) == 1
+        assert result.errors[0].field == "deal_type"
+        assert "INVALID_TYPE" in result.errors[0].value
+
+    def test_invalid_media_type(self, tmp_path):
+        """Invalid media_type value produces validation error."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "media_type"],
+                ["DEAL-001", "Test", "ESPN", "HOLOGRAM"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.failed == 1
+        assert result.errors[0].field == "media_type"
+
+
+# ---------------------------------------------------------------------------
+# Mixed valid/invalid rows
+# ---------------------------------------------------------------------------
+
+
+class TestMixedRows:
+    """Test files with both valid and invalid rows."""
+
+    def test_mixed_valid_and_invalid(self, tmp_path):
+        """Some rows succeed, some fail; both reported correctly."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "deal_type", "media_type"],
+                ["DEAL-001", "Good Deal", "ESPN", "PG", "DIGITAL"],
+                ["DEAL-002", "Bad Type", "ESPN", "INVALID", "DIGITAL"],
+                ["DEAL-003", "Good Deal 2", "Fox", "PD", "CTV"],
+                ["DEAL-004", "Bad Media", "NBCU", "PG", "HOLOGRAM"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+
+        assert result.total_rows == 4
+        assert result.successful == 2
+        assert result.failed == 2
+        assert len(result.deals) == 2
+        assert len(result.errors) == 2
+
+    def test_error_row_numbers_are_correct(self, tmp_path):
+        """Error objects reference the correct CSV row number (1-indexed, after header)."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "deal_type"],
+                ["DEAL-001", "Good", "ESPN", "PG"],
+                ["DEAL-002", "Bad", "ESPN", "INVALID"],
+                ["DEAL-003", "Good", "Fox", "PD"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert len(result.errors) == 1
+        # Row 2 in the data (1-indexed), which is CSV line 3 (header + 2 data rows)
+        assert result.errors[0].row_number == 2
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Test empty files, header-only files, and other edge cases."""
+
+    def test_empty_csv(self, tmp_path):
+        """Empty file returns zero counts and no errors."""
+        path = _write_csv([], tmpdir=str(tmp_path))
+        result = parse_csv_deals(path)
+        assert result.total_rows == 0
+        assert result.successful == 0
+        assert result.failed == 0
+        assert result.deals == []
+        assert result.errors == []
+
+    def test_header_only_csv(self, tmp_path):
+        """CSV with only headers returns zero counts."""
+        path = _write_csv(
+            [["deal_id", "name", "seller"]],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.total_rows == 0
+        assert result.successful == 0
+        assert result.deals == []
+
+    def test_whitespace_in_values_stripped(self, tmp_path):
+        """Leading/trailing whitespace in values is stripped."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller"],
+                ["  DEAL-001  ", "  Test Deal  ", "  ESPN  "],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        deal = result.deals[0]
+        assert deal["seller_deal_id"] == "DEAL-001"
+        assert deal["display_name"] == "Test Deal"
+        assert deal["seller_org"] == "ESPN"
+
+    def test_empty_optional_fields(self, tmp_path):
+        """Empty optional field values result in None."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "cpm", "media_type"],
+                ["DEAL-001", "Test", "ESPN", "", ""],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.successful == 1
+        deal = result.deals[0]
+        assert deal.get("fixed_price_cpm") is None
+        assert deal.get("media_type") is None
+
+    def test_duplicate_deal_ids_skipped(self, tmp_path):
+        """Duplicate seller_deal_id values within the file are skipped."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller"],
+                ["DEAL-001", "First", "ESPN"],
+                ["DEAL-001", "Duplicate", "ESPN"],
+                ["DEAL-002", "Second", "Fox"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.successful == 2
+        assert result.skipped == 1
+        assert len(result.deals) == 2
+
+    def test_currency_column_override(self, tmp_path):
+        """Currency column value overrides the USD default."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "currency"],
+                ["DEAL-001", "Test", "ESPN", "EUR"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["currency"] == "EUR"
+
+
+# ---------------------------------------------------------------------------
+# Import result counts
+# ---------------------------------------------------------------------------
+
+
+class TestImportResultCounts:
+    """Verify ImportResult fields are populated correctly."""
+
+    def test_counts_add_up(self, tmp_path):
+        """total_rows == successful + failed + skipped."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "deal_type"],
+                ["DEAL-001", "Good", "ESPN", "PG"],
+                ["DEAL-002", "Bad", "ESPN", "INVALID"],
+                ["DEAL-001", "Dup", "ESPN", "PG"],  # duplicate
+                ["DEAL-003", "Good2", "Fox", "PD"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.total_rows == 4
+        assert result.successful + result.failed + result.skipped == result.total_rows
+
+    def test_import_error_dataclass_fields(self, tmp_path):
+        """ImportError has row_number, field, value, message."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "deal_type"],
+                ["DEAL-001", "Bad", "ESPN", "INVALID"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        err = result.errors[0]
+        assert isinstance(err.row_number, int)
+        assert isinstance(err.field, str)
+        assert isinstance(err.value, str)
+        assert isinstance(err.message, str)
+
+
+# ---------------------------------------------------------------------------
+# Additional schema field mapping
+# ---------------------------------------------------------------------------
+
+
+class TestAdditionalFields:
+    """Test mapping of less-common but supported schema fields."""
+
+    def test_impressions_column(self, tmp_path):
+        """Map 'impressions' column to impressions field."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "impressions"],
+                ["DEAL-001", "Test", "ESPN", "1000000"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["impressions"] == 1000000
+
+    def test_description_column(self, tmp_path):
+        """Map 'description' column."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "description"],
+                ["DEAL-001", "Test", "ESPN", "Premium sports inventory"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["description"] == "Premium sports inventory"
+
+    def test_buyer_org_column(self, tmp_path):
+        """Map 'advertiser' / 'buyer' to buyer_org."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "advertiser"],
+                ["DEAL-001", "Test", "ESPN", "QuickMeal Inc"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["buyer_org"] == "QuickMeal Inc"
+
+    def test_geo_targets_column(self, tmp_path):
+        """Map 'geo' / 'geography' to geo_targets."""
+        path = _write_csv(
+            [
+                ["deal_id", "name", "seller", "geo"],
+                ["DEAL-001", "Test", "ESPN", "US,CA"],
+            ],
+            tmpdir=str(tmp_path),
+        )
+        result = parse_csv_deals(path)
+        assert result.deals[0]["geo_targets"] == "US,CA"

--- a/tests/unit/test_deal_entry.py
+++ b/tests/unit/test_deal_entry.py
@@ -1,0 +1,695 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Unit tests for manual deal entry tool.
+
+Tests the ManualDealEntry Pydantic model, create_manual_deal() validation
+function, and the CrewAI ManualDealEntryTool wrapper.
+"""
+
+import json
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# ManualDealEntry model tests
+# ---------------------------------------------------------------------------
+
+
+class TestManualDealEntryModel:
+    """Tests for the ManualDealEntry Pydantic input model."""
+
+    def test_minimal_required_fields(self):
+        """Model should accept only the two required fields."""
+        from ad_buyer.tools.deal_jockey.deal_entry import ManualDealEntry
+
+        entry = ManualDealEntry(
+            display_name="ESPN Sports PMP",
+            seller_url="https://espn.seller.example.com",
+        )
+        assert entry.display_name == "ESPN Sports PMP"
+        assert entry.seller_url == "https://espn.seller.example.com"
+
+    def test_default_values(self):
+        """Default values should be applied when not provided."""
+        from ad_buyer.tools.deal_jockey.deal_entry import ManualDealEntry
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+        )
+        assert entry.product_id == "manual-entry"
+        assert entry.deal_type == "PD"
+        assert entry.status == "draft"
+        assert entry.currency == "USD"
+
+    def test_all_fields_populated(self):
+        """Model should accept all fields when fully populated."""
+        from ad_buyer.tools.deal_jockey.deal_entry import ManualDealEntry
+
+        entry = ManualDealEntry(
+            display_name="Premium Video PG",
+            seller_url="https://nbcu.seller.example.com",
+            product_id="prod-nbcu-video",
+            deal_type="PG",
+            status="active",
+            seller_deal_id="SELLER-ABC-123",
+            seller_org="NBCUniversal",
+            seller_domain="nbcuniversal.com",
+            seller_type="PUBLISHER",
+            buyer_org="MediaCo Agency",
+            buyer_id="buyer-mediaco-001",
+            price=15.50,
+            fixed_price_cpm=15.50,
+            bid_floor_cpm=12.00,
+            price_model="CPM",
+            currency="EUR",
+            media_type="CTV",
+            impressions=5_000_000,
+            flight_start="2026-04-01",
+            flight_end="2026-06-30",
+            description="Premium CTV video inventory for Q2 campaign",
+            advertiser_id="adv-quickmeal-001",
+            tags=["premium", "ctv", "sports"],
+        )
+        assert entry.display_name == "Premium Video PG"
+        assert entry.deal_type == "PG"
+        assert entry.seller_type == "PUBLISHER"
+        assert entry.price_model == "CPM"
+        assert entry.media_type == "CTV"
+        assert entry.impressions == 5_000_000
+        assert entry.tags == ["premium", "ctv", "sports"]
+        assert entry.currency == "EUR"
+
+    def test_optional_fields_default_none(self):
+        """Optional fields should default to None."""
+        from ad_buyer.tools.deal_jockey.deal_entry import ManualDealEntry
+
+        entry = ManualDealEntry(
+            display_name="Test",
+            seller_url="https://seller.example.com",
+        )
+        assert entry.seller_deal_id is None
+        assert entry.seller_org is None
+        assert entry.seller_domain is None
+        assert entry.seller_type is None
+        assert entry.buyer_org is None
+        assert entry.buyer_id is None
+        assert entry.price is None
+        assert entry.fixed_price_cpm is None
+        assert entry.bid_floor_cpm is None
+        assert entry.price_model is None
+        assert entry.media_type is None
+        assert entry.impressions is None
+        assert entry.flight_start is None
+        assert entry.flight_end is None
+        assert entry.description is None
+        assert entry.advertiser_id is None
+        assert entry.tags is None
+
+
+# ---------------------------------------------------------------------------
+# create_manual_deal() validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateManualDeal:
+    """Tests for the create_manual_deal() validation function."""
+
+    def test_valid_minimal_deal(self):
+        """Valid deal with minimal fields should succeed."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="ESPN Sports PMP",
+            seller_url="https://espn.seller.example.com",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is True
+        assert result.errors == []
+        assert result.deal_data is not None
+        assert result.metadata is not None
+
+    def test_valid_full_deal(self):
+        """Valid deal with all fields should succeed."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Premium Video PG",
+            seller_url="https://nbcu.seller.example.com",
+            product_id="prod-nbcu-video",
+            deal_type="PG",
+            status="active",
+            seller_deal_id="SELLER-ABC-123",
+            seller_org="NBCUniversal",
+            seller_domain="nbcuniversal.com",
+            seller_type="PUBLISHER",
+            buyer_org="MediaCo Agency",
+            buyer_id="buyer-mediaco-001",
+            price=15.50,
+            fixed_price_cpm=15.50,
+            bid_floor_cpm=12.00,
+            price_model="CPM",
+            currency="EUR",
+            media_type="CTV",
+            impressions=5_000_000,
+            flight_start="2026-04-01",
+            flight_end="2026-06-30",
+            description="Premium CTV video inventory",
+            advertiser_id="adv-quickmeal-001",
+            tags=["premium", "ctv"],
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is True
+        assert result.errors == []
+        assert result.deal_data is not None
+
+    def test_invalid_deal_type(self):
+        """Invalid deal_type should produce validation error."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+            deal_type="INVALID",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is False
+        assert result.deal_data is None
+        assert any("deal_type" in e for e in result.errors)
+
+    def test_invalid_media_type(self):
+        """Invalid media_type should produce validation error."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+            media_type="HOLOGRAM",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is False
+        assert result.deal_data is None
+        assert any("media_type" in e for e in result.errors)
+
+    def test_invalid_seller_type(self):
+        """Invalid seller_type should produce validation error."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+            seller_type="UNICORN",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is False
+        assert result.deal_data is None
+        assert any("seller_type" in e for e in result.errors)
+
+    def test_invalid_price_model(self):
+        """Invalid price_model should produce validation error."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+            price_model="BARTER",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is False
+        assert result.deal_data is None
+        assert any("price_model" in e for e in result.errors)
+
+    def test_invalid_status(self):
+        """Invalid status should produce validation error."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+            status="expired",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is False
+        assert result.deal_data is None
+        assert any("status" in e for e in result.errors)
+
+    def test_empty_display_name(self):
+        """Empty display_name should produce validation error."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="",
+            seller_url="https://seller.example.com",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is False
+        assert result.deal_data is None
+        assert any("display_name" in e for e in result.errors)
+
+    def test_whitespace_only_display_name(self):
+        """Whitespace-only display_name should produce validation error."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="   ",
+            seller_url="https://seller.example.com",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is False
+        assert result.deal_data is None
+        assert any("display_name" in e for e in result.errors)
+
+    def test_flight_end_before_start(self):
+        """flight_end before flight_start should produce validation error."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+            flight_start="2026-06-01",
+            flight_end="2026-03-01",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is False
+        assert result.deal_data is None
+        assert any("flight" in e.lower() for e in result.errors)
+
+    def test_flight_start_only_is_valid(self):
+        """Providing only flight_start (no flight_end) should be valid."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+            flight_start="2026-04-01",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is True
+
+    def test_flight_end_only_is_valid(self):
+        """Providing only flight_end (no flight_start) should be valid."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+            flight_end="2026-12-31",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is True
+
+    def test_multiple_validation_errors(self):
+        """Multiple invalid fields should produce multiple errors."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="",
+            seller_url="https://seller.example.com",
+            deal_type="INVALID",
+            media_type="HOLOGRAM",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is False
+        assert len(result.errors) >= 3
+
+
+# ---------------------------------------------------------------------------
+# Output structure tests - deal_data matches DealStore.save_deal()
+# ---------------------------------------------------------------------------
+
+
+class TestDealDataStructure:
+    """Tests that deal_data output matches DealStore.save_deal() kwargs."""
+
+    def test_deal_data_has_required_save_deal_fields(self):
+        """deal_data must contain all fields needed by DealStore.save_deal()."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is True
+        data = result.deal_data
+
+        # Required fields for save_deal()
+        assert "seller_url" in data
+        assert "product_id" in data
+        assert "product_name" in data
+        assert "deal_type" in data
+        assert "status" in data
+
+    def test_deal_data_maps_display_name_to_product_name(self):
+        """display_name should map to product_name for save_deal()."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="ESPN Sports PMP",
+            seller_url="https://espn.seller.example.com",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.deal_data["product_name"] == "ESPN Sports PMP"
+
+    def test_deal_data_includes_optional_fields_when_provided(self):
+        """Optional fields should be included in deal_data when provided."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Full Deal",
+            seller_url="https://seller.example.com",
+            seller_deal_id="SELLER-123",
+            price=15.50,
+            impressions=1_000_000,
+            flight_start="2026-04-01",
+            flight_end="2026-06-30",
+        )
+        result = create_manual_deal(entry)
+
+        data = result.deal_data
+        assert data["seller_deal_id"] == "SELLER-123"
+        assert data["price"] == 15.50
+        assert data["impressions"] == 1_000_000
+        assert data["flight_start"] == "2026-04-01"
+        assert data["flight_end"] == "2026-06-30"
+
+    def test_deal_data_includes_v2_fields_in_metadata(self):
+        """V2 deal library fields should be included in deal_data metadata JSON."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="V2 Deal",
+            seller_url="https://seller.example.com",
+            seller_org="NBCUniversal",
+            seller_domain="nbcuniversal.com",
+            seller_type="PUBLISHER",
+            buyer_org="MediaCo",
+            buyer_id="buyer-001",
+            price_model="CPM",
+            fixed_price_cpm=15.50,
+            bid_floor_cpm=12.00,
+            currency="EUR",
+            media_type="CTV",
+            description="Premium CTV",
+        )
+        result = create_manual_deal(entry)
+
+        data = result.deal_data
+        # V2 fields should be present as top-level metadata JSON keys
+        metadata = json.loads(data["metadata"])
+        assert metadata["display_name"] == "V2 Deal"
+        assert metadata["seller_org"] == "NBCUniversal"
+        assert metadata["seller_domain"] == "nbcuniversal.com"
+        assert metadata["seller_type"] == "PUBLISHER"
+        assert metadata["buyer_org"] == "MediaCo"
+        assert metadata["buyer_id"] == "buyer-001"
+        assert metadata["price_model"] == "CPM"
+        assert metadata["fixed_price_cpm"] == 15.50
+        assert metadata["bid_floor_cpm"] == 12.00
+        assert metadata["currency"] == "EUR"
+        assert metadata["media_type"] == "CTV"
+        assert metadata["description"] == "Premium CTV"
+
+
+# ---------------------------------------------------------------------------
+# Metadata extraction tests
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataExtraction:
+    """Tests that portfolio metadata is correctly extracted."""
+
+    def test_metadata_import_source_is_manual(self):
+        """metadata.import_source should always be 'MANUAL'."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.metadata["import_source"] == "MANUAL"
+
+    def test_metadata_includes_tags(self):
+        """metadata should include tags when provided."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+            tags=["premium", "sports"],
+        )
+        result = create_manual_deal(entry)
+
+        assert result.metadata["tags"] == ["premium", "sports"]
+
+    def test_metadata_includes_advertiser_id(self):
+        """metadata should include advertiser_id when provided."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+            advertiser_id="adv-001",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.metadata["advertiser_id"] == "adv-001"
+
+    def test_metadata_tags_none_when_not_provided(self):
+        """metadata.tags should be None when not provided."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.metadata["tags"] is None
+
+    def test_metadata_advertiser_id_none_when_not_provided(self):
+        """metadata.advertiser_id should be None when not provided."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.metadata["advertiser_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# CrewAI tool wrapper tests
+# ---------------------------------------------------------------------------
+
+
+class TestManualDealEntryTool:
+    """Tests for the CrewAI ManualDealEntryTool wrapper."""
+
+    def test_tool_has_correct_name(self):
+        """Tool should have the expected name."""
+        from ad_buyer.tools.deal_jockey.deal_entry import ManualDealEntryTool
+
+        tool = ManualDealEntryTool()
+        assert tool.name == "manual_deal_entry"
+
+    def test_tool_has_description(self):
+        """Tool should have a non-empty description."""
+        from ad_buyer.tools.deal_jockey.deal_entry import ManualDealEntryTool
+
+        tool = ManualDealEntryTool()
+        assert len(tool.description) > 0
+
+    def test_tool_accepts_json_string(self):
+        """Tool should accept a JSON string of deal parameters."""
+        from ad_buyer.tools.deal_jockey.deal_entry import ManualDealEntryTool
+
+        tool = ManualDealEntryTool()
+        result = tool._run(
+            deal_params=json.dumps({
+                "display_name": "ESPN Sports PMP",
+                "seller_url": "https://espn.seller.example.com",
+            })
+        )
+
+        # Should return a string with success indication
+        assert "ESPN Sports PMP" in result
+        assert "success" in result.lower() or "created" in result.lower()
+
+    def test_tool_returns_errors_for_invalid_input(self):
+        """Tool should return validation errors for invalid input."""
+        from ad_buyer.tools.deal_jockey.deal_entry import ManualDealEntryTool
+
+        tool = ManualDealEntryTool()
+        result = tool._run(
+            deal_params=json.dumps({
+                "display_name": "",
+                "seller_url": "https://seller.example.com",
+                "deal_type": "INVALID",
+            })
+        )
+
+        assert "error" in result.lower() or "invalid" in result.lower()
+
+    def test_tool_returns_errors_for_malformed_json(self):
+        """Tool should handle malformed JSON gracefully."""
+        from ad_buyer.tools.deal_jockey.deal_entry import ManualDealEntryTool
+
+        tool = ManualDealEntryTool()
+        result = tool._run(deal_params="not valid json {{{")
+
+        assert "error" in result.lower()
+
+    def test_tool_returns_errors_for_missing_required_fields(self):
+        """Tool should return errors when required fields are missing."""
+        from ad_buyer.tools.deal_jockey.deal_entry import ManualDealEntryTool
+
+        tool = ManualDealEntryTool()
+        result = tool._run(
+            deal_params=json.dumps({
+                "deal_type": "PD",
+            })
+        )
+
+        assert "error" in result.lower()
+
+    def test_tool_has_args_schema(self):
+        """Tool should have a Pydantic args_schema for CrewAI."""
+        from ad_buyer.tools.deal_jockey.deal_entry import ManualDealEntryTool
+
+        tool = ManualDealEntryTool()
+        assert hasattr(tool, "args_schema")
+        assert tool.args_schema is not None
+
+
+# ---------------------------------------------------------------------------
+# DealEntryResult dataclass tests
+# ---------------------------------------------------------------------------
+
+
+class TestDealEntryResult:
+    """Tests for the DealEntryResult output dataclass."""
+
+    def test_success_result_structure(self):
+        """Successful result should have all expected fields populated."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="Test Deal",
+            seller_url="https://seller.example.com",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is True
+        assert isinstance(result.deal_data, dict)
+        assert isinstance(result.metadata, dict)
+        assert isinstance(result.errors, list)
+        assert len(result.errors) == 0
+
+    def test_failure_result_structure(self):
+        """Failed result should have None for data fields and populated errors."""
+        from ad_buyer.tools.deal_jockey.deal_entry import (
+            ManualDealEntry,
+            create_manual_deal,
+        )
+
+        entry = ManualDealEntry(
+            display_name="",
+            seller_url="https://seller.example.com",
+        )
+        result = create_manual_deal(entry)
+
+        assert result.success is False
+        assert result.deal_data is None
+        assert result.metadata is None
+        assert len(result.errors) > 0

--- a/tests/unit/test_deal_jockey_agent.py
+++ b/tests/unit/test_deal_jockey_agent.py
@@ -1,0 +1,81 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Tests for DealJockey L2 agent creation."""
+
+import os
+import pytest
+from unittest.mock import MagicMock
+
+from crewai.tools import BaseTool
+from pydantic import Field
+
+# Set a dummy API key for tests (agents validate on creation)
+os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-for-unit-tests")
+
+from ad_buyer.agents.level2.deal_jockey_agent import create_deal_jockey_agent
+from ad_buyer.agents.level2 import create_deal_jockey_agent as imported_from_package
+
+
+class _MockTool(BaseTool):
+    """A minimal mock tool for testing."""
+
+    name: str = "mock_tool"
+    description: str = "A mock tool for testing"
+
+    def _run(self, **kwargs):
+        return "mock result"
+
+
+class TestDealJockeyAgent:
+    """Tests for the DealJockey L2 agent."""
+
+    def test_deal_jockey_agent_creation(self):
+        """Test DealJockey agent can be created with default args."""
+        agent = create_deal_jockey_agent(verbose=False)
+
+        assert agent is not None
+        assert agent.role == "Deal Jockey - Portfolio Manager"
+
+    def test_deal_jockey_agent_goal_keywords(self):
+        """Test DealJockey agent goal contains portfolio management keywords."""
+        agent = create_deal_jockey_agent(verbose=False)
+        goal_lower = agent.goal.lower()
+
+        assert "portfolio" in goal_lower or "deal" in goal_lower
+        assert "import" in goal_lower or "catalog" in goal_lower or "manage" in goal_lower
+
+    def test_deal_jockey_agent_backstory_keywords(self):
+        """Test DealJockey agent backstory contains expected expertise areas."""
+        agent = create_deal_jockey_agent(verbose=False)
+        backstory_lower = agent.backstory.lower()
+
+        assert "portfolio" in backstory_lower
+        assert "csv" in backstory_lower or "import" in backstory_lower
+        assert "migration" in backstory_lower or "migrate" in backstory_lower
+
+    def test_deal_jockey_agent_can_delegate(self):
+        """Test DealJockey agent can delegate (L2 agents delegate to L3)."""
+        agent = create_deal_jockey_agent(verbose=False)
+        assert agent.allow_delegation is True
+
+    def test_deal_jockey_agent_has_memory(self):
+        """Test DealJockey agent has memory enabled."""
+        agent = create_deal_jockey_agent(verbose=False)
+        # CrewAI converts memory=True into a Memory object
+        assert agent.memory is not None
+
+    def test_deal_jockey_agent_with_no_tools(self):
+        """Test DealJockey agent starts with no tools by default."""
+        agent = create_deal_jockey_agent(verbose=False)
+        assert len(agent.tools) == 0
+
+    def test_deal_jockey_agent_with_custom_tools(self):
+        """Test DealJockey agent can be created with custom tools."""
+        mock_tools = [_MockTool(), _MockTool(name="mock_tool_2")]
+        agent = create_deal_jockey_agent(tools=mock_tools, verbose=False)
+        assert len(agent.tools) == 2
+
+    def test_deal_jockey_importable_from_level2_package(self):
+        """Test DealJockey agent factory is importable from level2 package."""
+        assert imported_from_package is create_deal_jockey_agent

--- a/tests/unit/test_deal_jockey_events.py
+++ b/tests/unit/test_deal_jockey_events.py
@@ -1,0 +1,466 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Tests for DealJockey Phase 1 event types.
+
+Verifies that the four Phase 1 DealJockey event types are properly
+defined, can be used to create Event instances, can be emitted on
+the event bus, and can be persisted via DealStore.save_event().
+"""
+
+import asyncio
+import json
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# EventType enum tests - Phase 1 DealJockey events
+# ---------------------------------------------------------------------------
+
+
+class TestDealJockeyEventTypes:
+    """Tests for DealJockey Phase 1 EventType enum values."""
+
+    def test_deal_imported_exists(self):
+        """DEAL_IMPORTED event type must exist with correct value."""
+        from ad_buyer.events.models import EventType
+
+        assert hasattr(EventType, "DEAL_IMPORTED")
+        assert EventType.DEAL_IMPORTED == "deal.imported"
+        assert EventType.DEAL_IMPORTED.value == "deal.imported"
+
+    def test_deal_template_created_exists(self):
+        """DEAL_TEMPLATE_CREATED event type must exist with correct value."""
+        from ad_buyer.events.models import EventType
+
+        assert hasattr(EventType, "DEAL_TEMPLATE_CREATED")
+        assert EventType.DEAL_TEMPLATE_CREATED == "deal.template_created"
+        assert EventType.DEAL_TEMPLATE_CREATED.value == "deal.template_created"
+
+    def test_portfolio_inspected_exists(self):
+        """PORTFOLIO_INSPECTED event type must exist with correct value."""
+        from ad_buyer.events.models import EventType
+
+        assert hasattr(EventType, "PORTFOLIO_INSPECTED")
+        assert EventType.PORTFOLIO_INSPECTED == "portfolio.inspected"
+        assert EventType.PORTFOLIO_INSPECTED.value == "portfolio.inspected"
+
+    def test_deal_manual_action_required_exists(self):
+        """DEAL_MANUAL_ACTION_REQUIRED event type must exist with correct value."""
+        from ad_buyer.events.models import EventType
+
+        assert hasattr(EventType, "DEAL_MANUAL_ACTION_REQUIRED")
+        assert EventType.DEAL_MANUAL_ACTION_REQUIRED == "deal.manual_action_required"
+        assert (
+            EventType.DEAL_MANUAL_ACTION_REQUIRED.value
+            == "deal.manual_action_required"
+        )
+
+    def test_all_phase1_types_in_enum(self):
+        """All four Phase 1 DealJockey event types must be in EventType."""
+        from ad_buyer.events.models import EventType
+
+        expected_phase1 = [
+            "deal.imported",
+            "deal.template_created",
+            "portfolio.inspected",
+            "deal.manual_action_required",
+        ]
+        actual_values = [e.value for e in EventType]
+        for val in expected_phase1:
+            assert val in actual_values, f"Missing Phase 1 event type: {val}"
+
+    def test_phase1_types_are_string_enum(self):
+        """Phase 1 DealJockey types should be str Enum for JSON serialization."""
+        from ad_buyer.events.models import EventType
+
+        assert isinstance(EventType.DEAL_IMPORTED, str)
+        assert isinstance(EventType.DEAL_TEMPLATE_CREATED, str)
+        assert isinstance(EventType.PORTFOLIO_INSPECTED, str)
+        assert isinstance(EventType.DEAL_MANUAL_ACTION_REQUIRED, str)
+
+
+# ---------------------------------------------------------------------------
+# Event model tests with Phase 1 types
+# ---------------------------------------------------------------------------
+
+
+class TestDealJockeyEventModel:
+    """Tests for creating Event instances with DealJockey Phase 1 types."""
+
+    def test_event_with_deal_imported(self):
+        """Event should be creatable with DEAL_IMPORTED type."""
+        from ad_buyer.events.models import Event, EventType
+
+        event = Event(
+            event_type=EventType.DEAL_IMPORTED,
+            deal_id="deal-import-1",
+            payload={"import_source": "csv", "file_name": "deals.csv"},
+        )
+        assert event.event_type == EventType.DEAL_IMPORTED
+        assert event.deal_id == "deal-import-1"
+        assert event.payload["import_source"] == "csv"
+
+    def test_event_with_deal_template_created(self):
+        """Event should be creatable with DEAL_TEMPLATE_CREATED type."""
+        from ad_buyer.events.models import Event, EventType
+
+        event = Event(
+            event_type=EventType.DEAL_TEMPLATE_CREATED,
+            payload={"template_id": "tmpl-1", "template_name": "Standard PMP"},
+        )
+        assert event.event_type == EventType.DEAL_TEMPLATE_CREATED
+        assert event.payload["template_id"] == "tmpl-1"
+
+    def test_event_with_portfolio_inspected(self):
+        """Event should be creatable with PORTFOLIO_INSPECTED type."""
+        from ad_buyer.events.models import Event, EventType
+
+        event = Event(
+            event_type=EventType.PORTFOLIO_INSPECTED,
+            payload={"query_params": {"status": "active"}, "result_count": 42},
+        )
+        assert event.event_type == EventType.PORTFOLIO_INSPECTED
+        assert event.payload["result_count"] == 42
+
+    def test_event_with_deal_manual_action_required(self):
+        """Event should be creatable with DEAL_MANUAL_ACTION_REQUIRED type."""
+        from ad_buyer.events.models import Event, EventType
+
+        event = Event(
+            event_type=EventType.DEAL_MANUAL_ACTION_REQUIRED,
+            deal_id="deal-99",
+            payload={
+                "action_description": "Seller requires manual deal setup",
+                "reason": "No API available",
+            },
+        )
+        assert event.event_type == EventType.DEAL_MANUAL_ACTION_REQUIRED
+        assert event.deal_id == "deal-99"
+        assert "action_description" in event.payload
+
+    def test_phase1_event_serialization(self):
+        """Phase 1 events should serialize to dict correctly."""
+        from ad_buyer.events.models import Event, EventType
+
+        event = Event(
+            event_type=EventType.DEAL_IMPORTED,
+            payload={"source": "csv"},
+        )
+        data = event.model_dump(mode="json")
+        assert data["event_type"] == "deal.imported"
+        assert isinstance(data["timestamp"], str)
+        assert data["payload"]["source"] == "csv"
+
+
+# ---------------------------------------------------------------------------
+# EventBus tests with Phase 1 types
+# ---------------------------------------------------------------------------
+
+
+class TestDealJockeyEventBus:
+    """Tests for emitting DealJockey Phase 1 events on the bus."""
+
+    @pytest.fixture
+    def bus(self):
+        from ad_buyer.events.bus import InMemoryEventBus
+
+        return InMemoryEventBus()
+
+    def test_publish_deal_imported(self, bus):
+        """DEAL_IMPORTED events should be publishable on the bus."""
+        from ad_buyer.events.models import Event, EventType
+
+        event = Event(
+            event_type=EventType.DEAL_IMPORTED,
+            payload={"import_source": "csv"},
+        )
+        asyncio.get_event_loop().run_until_complete(bus.publish(event))
+        assert len(bus._events) == 1
+        assert bus._events[0].event_type == EventType.DEAL_IMPORTED
+
+    def test_publish_deal_template_created(self, bus):
+        """DEAL_TEMPLATE_CREATED events should be publishable on the bus."""
+        from ad_buyer.events.models import Event, EventType
+
+        event = Event(
+            event_type=EventType.DEAL_TEMPLATE_CREATED,
+            payload={"template_id": "tmpl-1"},
+        )
+        asyncio.get_event_loop().run_until_complete(bus.publish(event))
+        assert len(bus._events) == 1
+        assert bus._events[0].event_type == EventType.DEAL_TEMPLATE_CREATED
+
+    def test_publish_portfolio_inspected(self, bus):
+        """PORTFOLIO_INSPECTED events should be publishable on the bus."""
+        from ad_buyer.events.models import Event, EventType
+
+        event = Event(
+            event_type=EventType.PORTFOLIO_INSPECTED,
+            payload={"result_count": 10},
+        )
+        asyncio.get_event_loop().run_until_complete(bus.publish(event))
+        assert len(bus._events) == 1
+        assert bus._events[0].event_type == EventType.PORTFOLIO_INSPECTED
+
+    def test_publish_deal_manual_action_required(self, bus):
+        """DEAL_MANUAL_ACTION_REQUIRED events should be publishable."""
+        from ad_buyer.events.models import Event, EventType
+
+        event = Event(
+            event_type=EventType.DEAL_MANUAL_ACTION_REQUIRED,
+            deal_id="deal-99",
+            payload={"action_description": "Manual setup needed"},
+        )
+        asyncio.get_event_loop().run_until_complete(bus.publish(event))
+        assert len(bus._events) == 1
+        assert bus._events[0].event_type == EventType.DEAL_MANUAL_ACTION_REQUIRED
+
+    def test_subscribe_to_deal_imported(self, bus):
+        """Subscriber should receive DEAL_IMPORTED events."""
+        from ad_buyer.events.models import Event, EventType
+
+        received = []
+        asyncio.get_event_loop().run_until_complete(
+            bus.subscribe("deal.imported", lambda e: received.append(e))
+        )
+
+        event = Event(event_type=EventType.DEAL_IMPORTED)
+        asyncio.get_event_loop().run_until_complete(bus.publish(event))
+
+        assert len(received) == 1
+        assert received[0].event_type == EventType.DEAL_IMPORTED
+
+    def test_subscribe_to_deal_manual_action_required(self, bus):
+        """Subscriber should receive DEAL_MANUAL_ACTION_REQUIRED events."""
+        from ad_buyer.events.models import Event, EventType
+
+        received = []
+        asyncio.get_event_loop().run_until_complete(
+            bus.subscribe(
+                "deal.manual_action_required", lambda e: received.append(e)
+            )
+        )
+
+        event = Event(event_type=EventType.DEAL_MANUAL_ACTION_REQUIRED)
+        asyncio.get_event_loop().run_until_complete(bus.publish(event))
+
+        assert len(received) == 1
+        assert received[0].event_type == EventType.DEAL_MANUAL_ACTION_REQUIRED
+
+    def test_list_events_by_phase1_type(self, bus):
+        """Should filter events by Phase 1 event types."""
+        from ad_buyer.events.models import Event, EventType
+
+        asyncio.get_event_loop().run_until_complete(
+            bus.publish(Event(event_type=EventType.DEAL_IMPORTED))
+        )
+        asyncio.get_event_loop().run_until_complete(
+            bus.publish(Event(event_type=EventType.DEAL_BOOKED))
+        )
+        asyncio.get_event_loop().run_until_complete(
+            bus.publish(Event(event_type=EventType.PORTFOLIO_INSPECTED))
+        )
+
+        events = asyncio.get_event_loop().run_until_complete(
+            bus.list_events(event_type="deal.imported")
+        )
+        assert len(events) == 1
+        assert events[0].event_type == EventType.DEAL_IMPORTED
+
+    def test_wildcard_receives_phase1_events(self, bus):
+        """Wildcard subscriber should receive Phase 1 events."""
+        from ad_buyer.events.models import Event, EventType
+
+        received = []
+        asyncio.get_event_loop().run_until_complete(
+            bus.subscribe("*", lambda e: received.append(e))
+        )
+
+        asyncio.get_event_loop().run_until_complete(
+            bus.publish(Event(event_type=EventType.DEAL_IMPORTED))
+        )
+        asyncio.get_event_loop().run_until_complete(
+            bus.publish(Event(event_type=EventType.DEAL_TEMPLATE_CREATED))
+        )
+
+        assert len(received) == 2
+
+
+# ---------------------------------------------------------------------------
+# DealStore persistence tests with Phase 1 types
+# ---------------------------------------------------------------------------
+
+
+class TestDealJockeyEventPersistence:
+    """Tests for persisting Phase 1 DealJockey events via DealStore."""
+
+    @pytest.fixture
+    def store(self):
+        """Create an in-memory DealStore."""
+        from ad_buyer.storage.deal_store import DealStore
+
+        s = DealStore("sqlite:///:memory:")
+        s.connect()
+        yield s
+        s.disconnect()
+
+    def test_persist_deal_imported(self, store):
+        """DEAL_IMPORTED event should be persistable via DealStore."""
+        event_id = store.save_event(
+            event_type="deal.imported",
+            deal_id="deal-import-1",
+            payload=json.dumps({"import_source": "csv", "file_name": "deals.csv"}),
+        )
+        assert event_id
+
+        event = store.get_event(event_id)
+        assert event is not None
+        assert event["event_type"] == "deal.imported"
+        assert event["deal_id"] == "deal-import-1"
+
+    def test_persist_deal_template_created(self, store):
+        """DEAL_TEMPLATE_CREATED event should be persistable via DealStore."""
+        event_id = store.save_event(
+            event_type="deal.template_created",
+            payload=json.dumps({"template_id": "tmpl-1"}),
+        )
+        assert event_id
+
+        event = store.get_event(event_id)
+        assert event is not None
+        assert event["event_type"] == "deal.template_created"
+
+    def test_persist_portfolio_inspected(self, store):
+        """PORTFOLIO_INSPECTED event should be persistable via DealStore."""
+        event_id = store.save_event(
+            event_type="portfolio.inspected",
+            payload=json.dumps({"query_params": {}, "result_count": 42}),
+        )
+        assert event_id
+
+        event = store.get_event(event_id)
+        assert event is not None
+        assert event["event_type"] == "portfolio.inspected"
+
+    def test_persist_deal_manual_action_required(self, store):
+        """DEAL_MANUAL_ACTION_REQUIRED event should be persistable."""
+        event_id = store.save_event(
+            event_type="deal.manual_action_required",
+            deal_id="deal-99",
+            payload=json.dumps({"action_description": "Manual setup needed"}),
+        )
+        assert event_id
+
+        event = store.get_event(event_id)
+        assert event is not None
+        assert event["event_type"] == "deal.manual_action_required"
+        assert event["deal_id"] == "deal-99"
+
+    def test_list_phase1_events_by_type(self, store):
+        """Should filter persisted events by Phase 1 type."""
+        store.save_event(event_type="deal.imported")
+        store.save_event(event_type="deal.template_created")
+        store.save_event(event_type="portfolio.inspected")
+        store.save_event(event_type="deal.manual_action_required")
+        store.save_event(event_type="deal.booked")  # existing type
+
+        events = store.list_events(event_type="deal.imported")
+        assert len(events) == 1
+        assert events[0]["event_type"] == "deal.imported"
+
+        events = store.list_events(event_type="portfolio.inspected")
+        assert len(events) == 1
+        assert events[0]["event_type"] == "portfolio.inspected"
+
+
+# ---------------------------------------------------------------------------
+# emit_event helper tests with Phase 1 types
+# ---------------------------------------------------------------------------
+
+
+class TestDealJockeyEmitEvent:
+    """Tests for emitting Phase 1 events via the emit_event helper."""
+
+    def test_emit_deal_imported(self):
+        """emit_event should handle DEAL_IMPORTED type."""
+        from ad_buyer.events.helpers import emit_event
+        from ad_buyer.events.models import EventType
+
+        import ad_buyer.events.bus as bus_mod
+
+        bus_mod._event_bus_instance = None
+
+        event = asyncio.get_event_loop().run_until_complete(
+            emit_event(
+                event_type=EventType.DEAL_IMPORTED,
+                deal_id="deal-import-1",
+                payload={"import_source": "csv"},
+            )
+        )
+        assert event is not None
+        assert event.event_type == EventType.DEAL_IMPORTED
+        assert event.deal_id == "deal-import-1"
+
+        bus_mod._event_bus_instance = None
+
+    def test_emit_portfolio_inspected(self):
+        """emit_event should handle PORTFOLIO_INSPECTED type."""
+        from ad_buyer.events.helpers import emit_event
+        from ad_buyer.events.models import EventType
+
+        import ad_buyer.events.bus as bus_mod
+
+        bus_mod._event_bus_instance = None
+
+        event = asyncio.get_event_loop().run_until_complete(
+            emit_event(
+                event_type=EventType.PORTFOLIO_INSPECTED,
+                payload={"result_count": 15},
+            )
+        )
+        assert event is not None
+        assert event.event_type == EventType.PORTFOLIO_INSPECTED
+
+        bus_mod._event_bus_instance = None
+
+    def test_emit_deal_manual_action_required(self):
+        """emit_event should handle DEAL_MANUAL_ACTION_REQUIRED type."""
+        from ad_buyer.events.helpers import emit_event
+        from ad_buyer.events.models import EventType
+
+        import ad_buyer.events.bus as bus_mod
+
+        bus_mod._event_bus_instance = None
+
+        event = asyncio.get_event_loop().run_until_complete(
+            emit_event(
+                event_type=EventType.DEAL_MANUAL_ACTION_REQUIRED,
+                deal_id="deal-99",
+                payload={"action_description": "Manual setup needed"},
+            )
+        )
+        assert event is not None
+        assert event.event_type == EventType.DEAL_MANUAL_ACTION_REQUIRED
+
+        bus_mod._event_bus_instance = None
+
+    def test_emit_sync_deal_imported(self):
+        """emit_event_sync should handle DEAL_IMPORTED type."""
+        from ad_buyer.events.helpers import emit_event_sync
+        from ad_buyer.events.models import EventType
+
+        import ad_buyer.events.bus as bus_mod
+
+        bus_mod._event_bus_instance = None
+
+        event = emit_event_sync(
+            event_type=EventType.DEAL_IMPORTED,
+            deal_id="deal-sync-1",
+            payload={"import_source": "manual"},
+        )
+        assert event is not None
+        assert event.event_type == EventType.DEAL_IMPORTED
+
+        bus_mod._event_bus_instance = None

--- a/tests/unit/test_deal_library_crud.py
+++ b/tests/unit/test_deal_library_crud.py
@@ -1,0 +1,874 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Tests for DealStore deal library CRUD operations (v2).
+
+Tests cover:
+- portfolio_metadata CRUD (save, get, update, delete)
+- deal_activations CRUD (save, get, update, delete)
+- performance_cache CRUD (save, get, update, delete)
+- save_deal() with v2 intrinsic fields
+- list_deals() with v2 filters (media_type, seller_domain, deal_type, advertiser_id)
+- Foreign key constraints
+- Backward compatibility
+"""
+
+import json
+import sqlite3
+
+import pytest
+
+from ad_buyer.storage import DealStore
+
+
+# -----------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------
+
+@pytest.fixture
+def deal_store():
+    """Create a DealStore backed by in-memory SQLite."""
+    store = DealStore("sqlite:///:memory:")
+    store.connect()
+    yield store
+    store.disconnect()
+
+
+@pytest.fixture
+def deal_with_metadata(deal_store):
+    """Create a deal and attach portfolio metadata for convenience."""
+    deal_id = deal_store.save_deal(
+        seller_url="http://seller.example.com",
+        product_id="prod_1",
+        product_name="Banner Ad",
+    )
+    meta_id = deal_store.save_portfolio_metadata(
+        deal_id=deal_id,
+        import_source="CSV",
+        import_date="2026-03-18",
+        tags=json.dumps(["premium", "sports"]),
+        advertiser_id="adv-001",
+        agency_id="agency-001",
+    )
+    return deal_id, meta_id
+
+
+# -----------------------------------------------------------------------
+# Portfolio Metadata CRUD Tests
+# -----------------------------------------------------------------------
+
+class TestPortfolioMetadataCRUD:
+    """Tests for portfolio_metadata save, get, update, delete."""
+
+    def test_save_portfolio_metadata_returns_row_id(self, deal_store):
+        """save_portfolio_metadata returns the row ID."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        row_id = deal_store.save_portfolio_metadata(
+            deal_id=deal_id,
+            import_source="CSV",
+        )
+        assert isinstance(row_id, int)
+        assert row_id > 0
+
+    def test_save_portfolio_metadata_all_fields(self, deal_store):
+        """save_portfolio_metadata stores all fields correctly."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        row_id = deal_store.save_portfolio_metadata(
+            deal_id=deal_id,
+            import_source="TTD_API",
+            import_date="2026-03-18",
+            tags=json.dumps(["video", "premium"]),
+            advertiser_id="adv-123",
+            agency_id="agency-456",
+        )
+        meta = deal_store.get_portfolio_metadata(deal_id)
+        assert meta is not None
+        assert meta["id"] == row_id
+        assert meta["deal_id"] == deal_id
+        assert meta["import_source"] == "TTD_API"
+        assert meta["import_date"] == "2026-03-18"
+        assert json.loads(meta["tags"]) == ["video", "premium"]
+        assert meta["advertiser_id"] == "adv-123"
+        assert meta["agency_id"] == "agency-456"
+
+    def test_save_portfolio_metadata_minimal_fields(self, deal_store):
+        """save_portfolio_metadata works with only deal_id."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        row_id = deal_store.save_portfolio_metadata(deal_id=deal_id)
+        assert row_id > 0
+        meta = deal_store.get_portfolio_metadata(deal_id)
+        assert meta is not None
+        assert meta["import_source"] is None
+        assert meta["tags"] is None
+
+    def test_get_portfolio_metadata_returns_dict(self, deal_with_metadata):
+        """get_portfolio_metadata returns a dict for existing deal."""
+        deal_id, _ = deal_with_metadata
+        # get_portfolio_metadata is tested via deal_with_metadata fixture
+        # just verify it returns a dict
+        from ad_buyer.storage import DealStore
+        # Already tested via fixture, but explicitly:
+        meta = deal_with_metadata  # deal_id, meta_id tuple
+        assert meta is not None
+
+    def test_get_portfolio_metadata_not_found(self, deal_store):
+        """get_portfolio_metadata returns None for deal with no metadata."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        assert deal_store.get_portfolio_metadata(deal_id) is None
+
+    def test_get_portfolio_metadata_nonexistent_deal(self, deal_store):
+        """get_portfolio_metadata returns None for nonexistent deal."""
+        assert deal_store.get_portfolio_metadata("nonexistent") is None
+
+    def test_update_portfolio_metadata(self, deal_store):
+        """update_portfolio_metadata updates specified fields."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        deal_store.save_portfolio_metadata(
+            deal_id=deal_id,
+            import_source="CSV",
+            advertiser_id="adv-001",
+        )
+        result = deal_store.update_portfolio_metadata(
+            deal_id,
+            import_source="MANUAL",
+            tags=json.dumps(["updated"]),
+        )
+        assert result is True
+
+        meta = deal_store.get_portfolio_metadata(deal_id)
+        assert meta["import_source"] == "MANUAL"
+        assert json.loads(meta["tags"]) == ["updated"]
+        # Unchanged field should remain
+        assert meta["advertiser_id"] == "adv-001"
+
+    def test_update_portfolio_metadata_not_found(self, deal_store):
+        """update_portfolio_metadata returns False for nonexistent deal."""
+        result = deal_store.update_portfolio_metadata(
+            "nonexistent", import_source="CSV",
+        )
+        assert result is False
+
+    def test_update_portfolio_metadata_no_kwargs(self, deal_store):
+        """update_portfolio_metadata with no kwargs returns False."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        deal_store.save_portfolio_metadata(deal_id=deal_id)
+        result = deal_store.update_portfolio_metadata(deal_id)
+        assert result is False
+
+    def test_delete_portfolio_metadata(self, deal_store):
+        """delete_portfolio_metadata removes metadata for a deal."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        deal_store.save_portfolio_metadata(
+            deal_id=deal_id, import_source="CSV",
+        )
+        result = deal_store.delete_portfolio_metadata(deal_id)
+        assert result is True
+        assert deal_store.get_portfolio_metadata(deal_id) is None
+
+    def test_delete_portfolio_metadata_not_found(self, deal_store):
+        """delete_portfolio_metadata returns False for nonexistent deal."""
+        assert deal_store.delete_portfolio_metadata("nonexistent") is False
+
+    def test_save_portfolio_metadata_foreign_key_constraint(self, deal_store):
+        """save_portfolio_metadata fails for nonexistent deal_id."""
+        with pytest.raises(sqlite3.IntegrityError):
+            deal_store.save_portfolio_metadata(
+                deal_id="nonexistent-deal",
+                import_source="CSV",
+            )
+
+
+# -----------------------------------------------------------------------
+# Deal Activations CRUD Tests
+# -----------------------------------------------------------------------
+
+class TestDealActivationsCRUD:
+    """Tests for deal_activations save, get, update, delete."""
+
+    def test_save_deal_activation_returns_row_id(self, deal_store):
+        """save_deal_activation returns the row ID."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        row_id = deal_store.save_deal_activation(
+            deal_id=deal_id,
+            platform="TTD",
+        )
+        assert isinstance(row_id, int)
+        assert row_id > 0
+
+    def test_save_deal_activation_all_fields(self, deal_store):
+        """save_deal_activation stores all fields correctly."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        row_id = deal_store.save_deal_activation(
+            deal_id=deal_id,
+            platform="TTD",
+            platform_deal_id="TTD-ESPN-12345",
+            activation_status="ACTIVE",
+            last_sync_at="2026-03-18T10:00:00Z",
+        )
+        activations = deal_store.get_deal_activations(deal_id)
+        assert len(activations) == 1
+        act = activations[0]
+        assert act["id"] == row_id
+        assert act["deal_id"] == deal_id
+        assert act["platform"] == "TTD"
+        assert act["platform_deal_id"] == "TTD-ESPN-12345"
+        assert act["activation_status"] == "ACTIVE"
+        assert act["last_sync_at"] == "2026-03-18T10:00:00Z"
+
+    def test_get_deal_activations_multiple(self, deal_store):
+        """get_deal_activations returns all activations for a deal."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        deal_store.save_deal_activation(
+            deal_id=deal_id, platform="TTD",
+            platform_deal_id="TTD-001", activation_status="ACTIVE",
+        )
+        deal_store.save_deal_activation(
+            deal_id=deal_id, platform="DV360",
+            platform_deal_id="DV360-001", activation_status="PENDING",
+        )
+        deal_store.save_deal_activation(
+            deal_id=deal_id, platform="XANDR",
+            platform_deal_id="XN-001", activation_status="ACTIVE",
+        )
+        activations = deal_store.get_deal_activations(deal_id)
+        assert len(activations) == 3
+
+    def test_get_deal_activations_empty(self, deal_store):
+        """get_deal_activations returns empty list for deal with no activations."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        assert deal_store.get_deal_activations(deal_id) == []
+
+    def test_update_deal_activation(self, deal_store):
+        """update_deal_activation updates specified fields."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        act_id = deal_store.save_deal_activation(
+            deal_id=deal_id,
+            platform="TTD",
+            platform_deal_id="TTD-001",
+            activation_status="PENDING",
+        )
+        result = deal_store.update_deal_activation(
+            act_id,
+            activation_status="ACTIVE",
+            last_sync_at="2026-03-18T12:00:00Z",
+        )
+        assert result is True
+
+        activations = deal_store.get_deal_activations(deal_id)
+        assert len(activations) == 1
+        act = activations[0]
+        assert act["activation_status"] == "ACTIVE"
+        assert act["last_sync_at"] == "2026-03-18T12:00:00Z"
+        # Unchanged field
+        assert act["platform_deal_id"] == "TTD-001"
+
+    def test_update_deal_activation_not_found(self, deal_store):
+        """update_deal_activation returns False for nonexistent activation."""
+        result = deal_store.update_deal_activation(
+            99999, activation_status="ACTIVE",
+        )
+        assert result is False
+
+    def test_update_deal_activation_no_kwargs(self, deal_store):
+        """update_deal_activation with no kwargs returns False."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        act_id = deal_store.save_deal_activation(
+            deal_id=deal_id, platform="TTD",
+        )
+        result = deal_store.update_deal_activation(act_id)
+        assert result is False
+
+    def test_delete_deal_activation(self, deal_store):
+        """delete_deal_activation removes an activation by ID."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        act_id = deal_store.save_deal_activation(
+            deal_id=deal_id, platform="TTD",
+        )
+        result = deal_store.delete_deal_activation(act_id)
+        assert result is True
+        assert deal_store.get_deal_activations(deal_id) == []
+
+    def test_delete_deal_activation_not_found(self, deal_store):
+        """delete_deal_activation returns False for nonexistent ID."""
+        assert deal_store.delete_deal_activation(99999) is False
+
+    def test_save_deal_activation_foreign_key_constraint(self, deal_store):
+        """save_deal_activation fails for nonexistent deal_id."""
+        with pytest.raises(sqlite3.IntegrityError):
+            deal_store.save_deal_activation(
+                deal_id="nonexistent-deal",
+                platform="TTD",
+            )
+
+
+# -----------------------------------------------------------------------
+# Performance Cache CRUD Tests
+# -----------------------------------------------------------------------
+
+class TestPerformanceCacheCRUD:
+    """Tests for performance_cache save, get, update, delete."""
+
+    def test_save_performance_cache_returns_row_id(self, deal_store):
+        """save_performance_cache returns the row ID."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        row_id = deal_store.save_performance_cache(
+            deal_id=deal_id,
+            impressions_delivered=100000,
+        )
+        assert isinstance(row_id, int)
+        assert row_id > 0
+
+    def test_save_performance_cache_all_fields(self, deal_store):
+        """save_performance_cache stores all fields correctly."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        row_id = deal_store.save_performance_cache(
+            deal_id=deal_id,
+            impressions_delivered=1500000,
+            spend_to_date=22500.00,
+            fill_rate=0.85,
+            win_rate=0.42,
+            avg_effective_cpm=15.00,
+            last_delivery_at="2026-03-18T09:00:00Z",
+            performance_trend="IMPROVING",
+            cached_at="2026-03-18T10:00:00Z",
+        )
+
+        perf = deal_store.get_performance_cache(deal_id)
+        assert perf is not None
+        assert perf["id"] == row_id
+        assert perf["deal_id"] == deal_id
+        assert perf["impressions_delivered"] == 1500000
+        assert perf["spend_to_date"] == 22500.00
+        assert perf["fill_rate"] == 0.85
+        assert perf["win_rate"] == 0.42
+        assert perf["avg_effective_cpm"] == 15.00
+        assert perf["last_delivery_at"] == "2026-03-18T09:00:00Z"
+        assert perf["performance_trend"] == "IMPROVING"
+        assert perf["cached_at"] == "2026-03-18T10:00:00Z"
+
+    def test_save_performance_cache_minimal_fields(self, deal_store):
+        """save_performance_cache works with only deal_id."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        row_id = deal_store.save_performance_cache(deal_id=deal_id)
+        assert row_id > 0
+        perf = deal_store.get_performance_cache(deal_id)
+        assert perf is not None
+        assert perf["impressions_delivered"] is None
+        assert perf["spend_to_date"] is None
+
+    def test_get_performance_cache_returns_latest(self, deal_store):
+        """get_performance_cache returns the latest cache entry."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        deal_store.save_performance_cache(
+            deal_id=deal_id,
+            impressions_delivered=100000,
+            cached_at="2026-03-17T10:00:00Z",
+        )
+        deal_store.save_performance_cache(
+            deal_id=deal_id,
+            impressions_delivered=200000,
+            cached_at="2026-03-18T10:00:00Z",
+        )
+        perf = deal_store.get_performance_cache(deal_id)
+        assert perf is not None
+        # Should return the entry with the highest ID (most recent insert)
+        assert perf["impressions_delivered"] == 200000
+
+    def test_get_performance_cache_not_found(self, deal_store):
+        """get_performance_cache returns None for deal with no cache."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        assert deal_store.get_performance_cache(deal_id) is None
+
+    def test_get_performance_cache_nonexistent_deal(self, deal_store):
+        """get_performance_cache returns None for nonexistent deal."""
+        assert deal_store.get_performance_cache("nonexistent") is None
+
+    def test_update_performance_cache(self, deal_store):
+        """update_performance_cache updates specified fields."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        deal_store.save_performance_cache(
+            deal_id=deal_id,
+            impressions_delivered=100000,
+            fill_rate=0.70,
+        )
+        result = deal_store.update_performance_cache(
+            deal_id,
+            impressions_delivered=200000,
+            performance_trend="IMPROVING",
+        )
+        assert result is True
+
+        perf = deal_store.get_performance_cache(deal_id)
+        assert perf["impressions_delivered"] == 200000
+        assert perf["performance_trend"] == "IMPROVING"
+        # Unchanged field
+        assert perf["fill_rate"] == 0.70
+
+    def test_update_performance_cache_not_found(self, deal_store):
+        """update_performance_cache returns False for deal with no cache."""
+        result = deal_store.update_performance_cache(
+            "nonexistent", impressions_delivered=100,
+        )
+        assert result is False
+
+    def test_update_performance_cache_no_kwargs(self, deal_store):
+        """update_performance_cache with no kwargs returns False."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        deal_store.save_performance_cache(deal_id=deal_id)
+        result = deal_store.update_performance_cache(deal_id)
+        assert result is False
+
+    def test_delete_performance_cache(self, deal_store):
+        """delete_performance_cache removes cache entries for a deal."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com", product_id="prod_1",
+        )
+        deal_store.save_performance_cache(
+            deal_id=deal_id, impressions_delivered=100000,
+        )
+        result = deal_store.delete_performance_cache(deal_id)
+        assert result is True
+        assert deal_store.get_performance_cache(deal_id) is None
+
+    def test_delete_performance_cache_not_found(self, deal_store):
+        """delete_performance_cache returns False for deal with no cache."""
+        assert deal_store.delete_performance_cache("nonexistent") is False
+
+    def test_save_performance_cache_foreign_key_constraint(self, deal_store):
+        """save_performance_cache fails for nonexistent deal_id."""
+        with pytest.raises(sqlite3.IntegrityError):
+            deal_store.save_performance_cache(
+                deal_id="nonexistent-deal",
+                impressions_delivered=100,
+            )
+
+
+# -----------------------------------------------------------------------
+# save_deal() with v2 Intrinsic Fields Tests
+# -----------------------------------------------------------------------
+
+class TestSaveDealV2Fields:
+    """Tests for save_deal() extended with v2 intrinsic fields."""
+
+    def test_save_deal_v1_fields_still_work(self, deal_store):
+        """save_deal with only v1 fields works unchanged."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+            product_name="Banner Ad",
+            deal_type="PD",
+            status="draft",
+            price=12.50,
+        )
+        deal = deal_store.get_deal(deal_id)
+        assert deal["seller_url"] == "http://seller.com"
+        assert deal["product_name"] == "Banner Ad"
+        assert deal["price"] == 12.50
+        # v2 fields should be NULL
+        assert deal["display_name"] is None
+        assert deal["media_type"] is None
+
+    def test_save_deal_with_counterparty_fields(self, deal_store):
+        """save_deal accepts counterparty v2 fields."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+            display_name="ESPN Premium Video PG",
+            description="Premium video deal with ESPN",
+            buyer_org="Acme Agency",
+            buyer_id="buyer-001",
+            seller_org="ESPN",
+            seller_id="seller-espn",
+            seller_domain="espn.com",
+            seller_type="PUBLISHER",
+        )
+        deal = deal_store.get_deal(deal_id)
+        assert deal["display_name"] == "ESPN Premium Video PG"
+        assert deal["description"] == "Premium video deal with ESPN"
+        assert deal["buyer_org"] == "Acme Agency"
+        assert deal["buyer_id"] == "buyer-001"
+        assert deal["seller_org"] == "ESPN"
+        assert deal["seller_id"] == "seller-espn"
+        assert deal["seller_domain"] == "espn.com"
+        assert deal["seller_type"] == "PUBLISHER"
+
+    def test_save_deal_with_pricing_fields(self, deal_store):
+        """save_deal accepts pricing v2 fields."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+            price_model="CPM",
+            bid_floor_cpm=15.00,
+            fixed_price_cpm=18.50,
+            currency="EUR",
+            fee_transparency=0.12,
+        )
+        deal = deal_store.get_deal(deal_id)
+        assert deal["price_model"] == "CPM"
+        assert deal["bid_floor_cpm"] == 15.00
+        assert deal["fixed_price_cpm"] == 18.50
+        assert deal["currency"] == "EUR"
+        assert deal["fee_transparency"] == 0.12
+
+    def test_save_deal_with_linear_tv_fields(self, deal_store):
+        """save_deal accepts linear TV v2 fields."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_tv",
+            deal_type="UPFRONT",
+            media_type="LINEAR_TV",
+            cpp=45.00,
+            guaranteed_grps=150.0,
+            dayparts=json.dumps(["M-F 8p-11p"]),
+            programs=json.dumps(["Sunday Night Football"]),
+            networks=json.dumps(["NBC", "ESPN"]),
+            makegood_provisions="Standard makegood within 2 weeks",
+            cancellation_window="30 days written notice",
+            audience_guarantee="A18-49 Nielsen Live+3",
+            preemption_rights="Non-preemptible for upfront",
+            agency_of_record_status="BBDO Worldwide",
+        )
+        deal = deal_store.get_deal(deal_id)
+        assert deal["media_type"] == "LINEAR_TV"
+        assert deal["cpp"] == 45.00
+        assert deal["guaranteed_grps"] == 150.0
+        assert json.loads(deal["dayparts"]) == ["M-F 8p-11p"]
+        assert json.loads(deal["programs"]) == ["Sunday Night Football"]
+        assert json.loads(deal["networks"]) == ["NBC", "ESPN"]
+        assert deal["makegood_provisions"] == "Standard makegood within 2 weeks"
+        assert deal["cancellation_window"] == "30 days written notice"
+        assert deal["audience_guarantee"] == "A18-49 Nielsen Live+3"
+        assert deal["preemption_rights"] == "Non-preemptible for upfront"
+        assert deal["agency_of_record_status"] == "BBDO Worldwide"
+
+    def test_save_deal_with_inventory_fields(self, deal_store):
+        """save_deal accepts inventory targeting v2 fields."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+            media_type="DIGITAL",
+            formats=json.dumps(["banner_300x250", "video_15s"]),
+            content_categories=json.dumps(["IAB17"]),
+            publisher_domains=json.dumps(["espn.com"]),
+            geo_targets=json.dumps(["US"]),
+            audience_segments=json.dumps(["sports_enthusiasts"]),
+            estimated_volume=500000,
+        )
+        deal = deal_store.get_deal(deal_id)
+        assert deal["media_type"] == "DIGITAL"
+        assert json.loads(deal["formats"]) == ["banner_300x250", "video_15s"]
+        assert json.loads(deal["content_categories"]) == ["IAB17"]
+        assert json.loads(deal["publisher_domains"]) == ["espn.com"]
+        assert json.loads(deal["geo_targets"]) == ["US"]
+        assert json.loads(deal["audience_segments"]) == ["sports_enthusiasts"]
+        assert deal["estimated_volume"] == 500000
+
+    def test_save_deal_with_supply_chain_fields(self, deal_store):
+        """save_deal accepts supply chain v2 fields."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+            schain_complete=1,
+            schain_nodes=json.dumps([{"asi": "espn.com", "sid": "001", "hp": 1}]),
+            sellers_json_url="https://espn.com/sellers.json",
+            is_direct=1,
+            hop_count=1,
+            inventory_fingerprint="espn.com|IAB17|banner_300x250|DIGITAL",
+        )
+        deal = deal_store.get_deal(deal_id)
+        assert deal["schain_complete"] == 1
+        assert json.loads(deal["schain_nodes"]) == [{"asi": "espn.com", "sid": "001", "hp": 1}]
+        assert deal["sellers_json_url"] == "https://espn.com/sellers.json"
+        assert deal["is_direct"] == 1
+        assert deal["hop_count"] == 1
+        assert deal["inventory_fingerprint"] == "espn.com|IAB17|banner_300x250|DIGITAL"
+
+    def test_save_deal_with_lifecycle_fields(self, deal_store):
+        """save_deal accepts lifecycle extension v2 fields."""
+        parent_id = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_parent",
+        )
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+            deprecated_at="2026-03-15T00:00:00Z",
+            deprecated_reason="Replaced by direct deal",
+            parent_deal_id=parent_id,
+        )
+        deal = deal_store.get_deal(deal_id)
+        assert deal["deprecated_at"] == "2026-03-15T00:00:00Z"
+        assert deal["deprecated_reason"] == "Replaced by direct deal"
+        assert deal["parent_deal_id"] == parent_id
+
+    def test_save_deal_mixed_v1_and_v2_fields(self, deal_store):
+        """save_deal with both v1 and v2 fields works."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+            product_name="ESPN Video",
+            deal_type="PG",
+            status="draft",
+            price=15.00,
+            impressions=1000000,
+            # v2 fields
+            display_name="ESPN Premium Video PG",
+            media_type="DIGITAL",
+            seller_domain="espn.com",
+            bid_floor_cpm=12.00,
+        )
+        deal = deal_store.get_deal(deal_id)
+        # v1 fields
+        assert deal["product_name"] == "ESPN Video"
+        assert deal["price"] == 15.00
+        assert deal["impressions"] == 1000000
+        # v2 fields
+        assert deal["display_name"] == "ESPN Premium Video PG"
+        assert deal["media_type"] == "DIGITAL"
+        assert deal["seller_domain"] == "espn.com"
+        assert deal["bid_floor_cpm"] == 12.00
+
+
+# -----------------------------------------------------------------------
+# list_deals() with v2 Filters Tests
+# -----------------------------------------------------------------------
+
+class TestListDealsV2Filters:
+    """Tests for list_deals() with new v2 filter parameters."""
+
+    def test_list_deals_filter_by_media_type(self, deal_store):
+        """list_deals filters by media_type."""
+        deal_store.save_deal(
+            seller_url="http://a.com", product_id="p1",
+            media_type="DIGITAL",
+        )
+        deal_store.save_deal(
+            seller_url="http://b.com", product_id="p2",
+            media_type="CTV",
+        )
+        deal_store.save_deal(
+            seller_url="http://c.com", product_id="p3",
+            media_type="DIGITAL",
+        )
+        results = deal_store.list_deals(media_type="DIGITAL")
+        assert len(results) == 2
+        for r in results:
+            assert r["media_type"] == "DIGITAL"
+
+    def test_list_deals_filter_by_seller_domain(self, deal_store):
+        """list_deals filters by seller_domain."""
+        deal_store.save_deal(
+            seller_url="http://a.com", product_id="p1",
+            seller_domain="espn.com",
+        )
+        deal_store.save_deal(
+            seller_url="http://b.com", product_id="p2",
+            seller_domain="nyt.com",
+        )
+        results = deal_store.list_deals(seller_domain="espn.com")
+        assert len(results) == 1
+        assert results[0]["seller_domain"] == "espn.com"
+
+    def test_list_deals_filter_by_deal_type(self, deal_store):
+        """list_deals filters by deal_type."""
+        deal_store.save_deal(
+            seller_url="http://a.com", product_id="p1",
+            deal_type="PG",
+        )
+        deal_store.save_deal(
+            seller_url="http://b.com", product_id="p2",
+            deal_type="PD",
+        )
+        deal_store.save_deal(
+            seller_url="http://c.com", product_id="p3",
+            deal_type="PG",
+        )
+        results = deal_store.list_deals(deal_type="PG")
+        assert len(results) == 2
+        for r in results:
+            assert r["deal_type"] == "PG"
+
+    def test_list_deals_filter_by_advertiser_id(self, deal_store):
+        """list_deals filters by advertiser_id (via JOIN to portfolio_metadata)."""
+        d1 = deal_store.save_deal(
+            seller_url="http://a.com", product_id="p1",
+        )
+        d2 = deal_store.save_deal(
+            seller_url="http://b.com", product_id="p2",
+        )
+        d3 = deal_store.save_deal(
+            seller_url="http://c.com", product_id="p3",
+        )
+        # Set up metadata with different advertiser IDs
+        deal_store.save_portfolio_metadata(
+            deal_id=d1, advertiser_id="adv-alpha",
+        )
+        deal_store.save_portfolio_metadata(
+            deal_id=d2, advertiser_id="adv-beta",
+        )
+        deal_store.save_portfolio_metadata(
+            deal_id=d3, advertiser_id="adv-alpha",
+        )
+        results = deal_store.list_deals(advertiser_id="adv-alpha")
+        assert len(results) == 2
+        result_ids = {r["id"] for r in results}
+        assert d1 in result_ids
+        assert d3 in result_ids
+
+    def test_list_deals_combined_v2_filters(self, deal_store):
+        """list_deals combines multiple v2 filters."""
+        deal_store.save_deal(
+            seller_url="http://a.com", product_id="p1",
+            media_type="DIGITAL", seller_domain="espn.com", deal_type="PG",
+        )
+        deal_store.save_deal(
+            seller_url="http://b.com", product_id="p2",
+            media_type="DIGITAL", seller_domain="nyt.com", deal_type="PD",
+        )
+        deal_store.save_deal(
+            seller_url="http://c.com", product_id="p3",
+            media_type="CTV", seller_domain="espn.com", deal_type="PG",
+        )
+        results = deal_store.list_deals(
+            media_type="DIGITAL", seller_domain="espn.com",
+        )
+        assert len(results) == 1
+        assert results[0]["product_id"] == "p1"
+
+    def test_list_deals_v1_filters_still_work(self, deal_store):
+        """list_deals v1 filters (status, seller_url, created_after) still work."""
+        deal_store.save_deal(
+            seller_url="http://a.com", product_id="p1", status="draft",
+        )
+        deal_store.save_deal(
+            seller_url="http://b.com", product_id="p2", status="booked",
+        )
+        results = deal_store.list_deals(status="draft")
+        assert len(results) == 1
+        assert results[0]["status"] == "draft"
+
+    def test_list_deals_v1_and_v2_filters_combined(self, deal_store):
+        """list_deals combines v1 and v2 filters together."""
+        deal_store.save_deal(
+            seller_url="http://a.com", product_id="p1",
+            status="draft", media_type="DIGITAL",
+        )
+        deal_store.save_deal(
+            seller_url="http://a.com", product_id="p2",
+            status="booked", media_type="DIGITAL",
+        )
+        deal_store.save_deal(
+            seller_url="http://b.com", product_id="p3",
+            status="draft", media_type="CTV",
+        )
+        results = deal_store.list_deals(status="draft", media_type="DIGITAL")
+        assert len(results) == 1
+        assert results[0]["product_id"] == "p1"
+
+    def test_list_deals_no_filter_still_returns_all(self, deal_store):
+        """list_deals with no filters returns all deals."""
+        deal_store.save_deal(
+            seller_url="http://a.com", product_id="p1",
+            media_type="DIGITAL",
+        )
+        deal_store.save_deal(
+            seller_url="http://b.com", product_id="p2",
+            media_type="CTV",
+        )
+        results = deal_store.list_deals()
+        assert len(results) == 2
+
+
+# -----------------------------------------------------------------------
+# Cascade Delete Tests for v2 Tables
+# -----------------------------------------------------------------------
+
+class TestCascadeDeleteV2:
+    """Tests that deal deletion cascades to v2 extrinsic tables."""
+
+    def test_cascade_deletes_portfolio_metadata(self, deal_store):
+        """Deleting a deal cascades to portfolio_metadata."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://a.com", product_id="p1",
+        )
+        deal_store.save_portfolio_metadata(
+            deal_id=deal_id, import_source="CSV",
+        )
+        with deal_store._lock:
+            deal_store._conn.execute(
+                "DELETE FROM deals WHERE id = ?", (deal_id,),
+            )
+            deal_store._conn.commit()
+        assert deal_store.get_portfolio_metadata(deal_id) is None
+
+    def test_cascade_deletes_deal_activations(self, deal_store):
+        """Deleting a deal cascades to deal_activations."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://a.com", product_id="p1",
+        )
+        deal_store.save_deal_activation(
+            deal_id=deal_id, platform="TTD",
+        )
+        with deal_store._lock:
+            deal_store._conn.execute(
+                "DELETE FROM deals WHERE id = ?", (deal_id,),
+            )
+            deal_store._conn.commit()
+        assert deal_store.get_deal_activations(deal_id) == []
+
+    def test_cascade_deletes_performance_cache(self, deal_store):
+        """Deleting a deal cascades to performance_cache."""
+        deal_id = deal_store.save_deal(
+            seller_url="http://a.com", product_id="p1",
+        )
+        deal_store.save_performance_cache(
+            deal_id=deal_id, impressions_delivered=100,
+        )
+        with deal_store._lock:
+            deal_store._conn.execute(
+                "DELETE FROM deals WHERE id = ?", (deal_id,),
+            )
+            deal_store._conn.commit()
+        assert deal_store.get_performance_cache(deal_id) is None

--- a/tests/unit/test_deal_store_v2.py
+++ b/tests/unit/test_deal_store_v2.py
@@ -1,0 +1,826 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Tests for deal library schema v2 — the hybrid approach per D-4.
+
+Tests cover:
+- Schema migration from v1 to v2
+- New intrinsic columns on the deals table
+- New extrinsic tables: portfolio_metadata, deal_activations, performance_cache
+- New indexes
+- Backward compatibility with existing v1 data
+"""
+
+import json
+import sqlite3
+
+import pytest
+
+from ad_buyer.storage import DealStore, SCHEMA_VERSION
+from ad_buyer.storage.schema import (
+    create_tables,
+    get_schema_version,
+    initialize_schema,
+    migrate_v1_to_v2,
+    run_migrations,
+    set_schema_version,
+)
+
+
+# -----------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------
+
+@pytest.fixture
+def deal_store():
+    """Create a DealStore backed by in-memory SQLite."""
+    store = DealStore("sqlite:///:memory:")
+    store.connect()
+    yield store
+    store.disconnect()
+
+
+@pytest.fixture
+def raw_conn():
+    """A raw in-memory connection for schema-level tests."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    yield conn
+    conn.close()
+
+
+# -----------------------------------------------------------------------
+# Schema Version Tests
+# -----------------------------------------------------------------------
+
+class TestSchemaV2Version:
+    """Verify schema version is bumped to 2."""
+
+    def test_schema_version_is_2(self):
+        """SCHEMA_VERSION constant must be 2."""
+        assert SCHEMA_VERSION == 2
+
+    def test_initialize_schema_sets_version_2(self, raw_conn):
+        """initialize_schema records version 2."""
+        initialize_schema(raw_conn)
+        assert get_schema_version(raw_conn) == 2
+
+
+# -----------------------------------------------------------------------
+# Migration Function Tests
+# -----------------------------------------------------------------------
+
+class TestMigrationV1ToV2:
+    """Tests for the migrate_v1_to_v2 migration function."""
+
+    def _setup_v1_schema(self, conn):
+        """Create v1 schema (tables only, no v2 columns)."""
+        # Import v1 table DDL directly
+        from ad_buyer.storage.schema import (
+            DEALS_TABLE,
+            NEGOTIATION_ROUNDS_TABLE,
+            BOOKING_RECORDS_TABLE,
+            JOBS_TABLE,
+            EVENTS_TABLE,
+            STATUS_TRANSITIONS_TABLE,
+            SCHEMA_VERSION_TABLE,
+        )
+        cursor = conn.cursor()
+        cursor.execute(SCHEMA_VERSION_TABLE)
+        for ddl in [
+            DEALS_TABLE,
+            NEGOTIATION_ROUNDS_TABLE,
+            BOOKING_RECORDS_TABLE,
+            JOBS_TABLE,
+            EVENTS_TABLE,
+            STATUS_TRANSITIONS_TABLE,
+        ]:
+            cursor.execute(ddl)
+        conn.commit()
+        set_schema_version(conn, 1)
+
+    def test_migrate_v1_to_v2_adds_intrinsic_columns(self, raw_conn):
+        """Migration adds all new intrinsic columns to the deals table."""
+        self._setup_v1_schema(raw_conn)
+        migrate_v1_to_v2(raw_conn)
+
+        # Check that all new columns exist by inserting a row with them
+        intrinsic_columns = [
+            "display_name", "description", "buyer_org", "buyer_id",
+            "seller_org", "seller_id", "seller_domain", "seller_type",
+            "price_model", "bid_floor_cpm", "fixed_price_cpm",
+            "cpp", "guaranteed_grps", "currency",
+            "fee_transparency", "media_type", "formats",
+            "content_categories", "publisher_domains", "geo_targets",
+            "dayparts", "programs", "networks", "audience_segments",
+            "estimated_volume", "deprecated_at", "deprecated_reason",
+            "parent_deal_id", "schain_complete", "schain_nodes",
+            "sellers_json_url", "is_direct", "hop_count",
+            "inventory_fingerprint",
+            "makegood_provisions", "cancellation_window",
+            "audience_guarantee", "preemption_rights",
+            "agency_of_record_status",
+        ]
+
+        # Verify columns exist via PRAGMA
+        cursor = raw_conn.execute("PRAGMA table_info(deals)")
+        existing_cols = {row[1] for row in cursor.fetchall()}
+
+        for col in intrinsic_columns:
+            assert col in existing_cols, f"Column '{col}' missing from deals table"
+
+    def test_migrate_v1_to_v2_creates_portfolio_metadata_table(self, raw_conn):
+        """Migration creates the portfolio_metadata table."""
+        self._setup_v1_schema(raw_conn)
+        migrate_v1_to_v2(raw_conn)
+
+        cursor = raw_conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='portfolio_metadata'"
+        )
+        assert cursor.fetchone() is not None, "portfolio_metadata table not created"
+
+        # Check columns
+        cursor = raw_conn.execute("PRAGMA table_info(portfolio_metadata)")
+        cols = {row[1] for row in cursor.fetchall()}
+        expected = {"id", "deal_id", "import_source", "import_date", "tags",
+                    "advertiser_id", "agency_id"}
+        assert expected.issubset(cols)
+
+    def test_migrate_v1_to_v2_creates_deal_activations_table(self, raw_conn):
+        """Migration creates the deal_activations table."""
+        self._setup_v1_schema(raw_conn)
+        migrate_v1_to_v2(raw_conn)
+
+        cursor = raw_conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='deal_activations'"
+        )
+        assert cursor.fetchone() is not None, "deal_activations table not created"
+
+        cursor = raw_conn.execute("PRAGMA table_info(deal_activations)")
+        cols = {row[1] for row in cursor.fetchall()}
+        expected = {"id", "deal_id", "platform", "platform_deal_id",
+                    "activation_status", "last_sync_at"}
+        assert expected.issubset(cols)
+
+    def test_migrate_v1_to_v2_creates_performance_cache_table(self, raw_conn):
+        """Migration creates the performance_cache table."""
+        self._setup_v1_schema(raw_conn)
+        migrate_v1_to_v2(raw_conn)
+
+        cursor = raw_conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='performance_cache'"
+        )
+        assert cursor.fetchone() is not None, "performance_cache table not created"
+
+        cursor = raw_conn.execute("PRAGMA table_info(performance_cache)")
+        cols = {row[1] for row in cursor.fetchall()}
+        expected = {"id", "deal_id", "impressions_delivered", "spend_to_date",
+                    "fill_rate", "win_rate", "avg_effective_cpm",
+                    "last_delivery_at", "performance_trend", "cached_at"}
+        assert expected.issubset(cols)
+
+    def test_migrate_v1_to_v2_creates_indexes(self, raw_conn):
+        """Migration creates the expected indexes."""
+        self._setup_v1_schema(raw_conn)
+        migrate_v1_to_v2(raw_conn)
+
+        cursor = raw_conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%'"
+        )
+        indexes = {row[0] for row in cursor.fetchall()}
+
+        v2_indexes = {
+            # Deals table indexes
+            "idx_deals_media_type",
+            "idx_deals_deal_type",
+            "idx_deals_seller_domain",
+            "idx_deals_inventory_fingerprint",
+            # Extrinsic table indexes
+            "idx_portfolio_metadata_deal_id",
+            "idx_portfolio_metadata_advertiser_id",
+            "idx_deal_activations_deal_id",
+            "idx_deal_activations_platform_deal",
+            "idx_performance_cache_deal_id",
+        }
+        for idx in v2_indexes:
+            assert idx in indexes, f"Index '{idx}' not created"
+
+    def test_migrate_v1_to_v2_preserves_existing_data(self, raw_conn):
+        """Migration preserves existing v1 deal data."""
+        self._setup_v1_schema(raw_conn)
+
+        # Insert a v1 deal
+        raw_conn.execute(
+            """INSERT INTO deals
+               (id, seller_url, product_id, product_name, deal_type, status,
+                price, created_at, updated_at)
+               VALUES ('deal-1', 'http://seller.com', 'prod_1', 'Banner',
+                       'PD', 'draft', 12.50,
+                       '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')"""
+        )
+        raw_conn.commit()
+
+        migrate_v1_to_v2(raw_conn)
+
+        # Verify the existing deal is intact
+        cursor = raw_conn.execute("SELECT * FROM deals WHERE id = 'deal-1'")
+        row = cursor.fetchone()
+        assert row is not None
+        deal = dict(row)
+        assert deal["seller_url"] == "http://seller.com"
+        assert deal["product_name"] == "Banner"
+        assert deal["deal_type"] == "PD"
+        assert deal["price"] == 12.50
+
+        # New columns should be NULL (or default)
+        assert deal["display_name"] is None
+        assert deal["buyer_org"] is None
+        assert deal["currency"] == "USD"  # has a default
+
+    def test_migration_is_idempotent(self, raw_conn):
+        """Running migrate_v1_to_v2 twice does not raise."""
+        self._setup_v1_schema(raw_conn)
+        migrate_v1_to_v2(raw_conn)
+        # Should not raise on second run
+        migrate_v1_to_v2(raw_conn)
+
+    def test_migration_registered_in_migrations_dict(self, raw_conn):
+        """run_migrations calls migrate_v1_to_v2 when upgrading from v1."""
+        self._setup_v1_schema(raw_conn)
+        # run_migrations should bring v1 to v2
+        run_migrations(raw_conn)
+        assert get_schema_version(raw_conn) == 2
+
+        # Verify migration was actually applied (check for a new column)
+        cursor = raw_conn.execute("PRAGMA table_info(deals)")
+        cols = {row[1] for row in cursor.fetchall()}
+        assert "display_name" in cols
+
+    def test_currency_defaults_to_usd(self, raw_conn):
+        """New currency column defaults to 'USD'."""
+        self._setup_v1_schema(raw_conn)
+        migrate_v1_to_v2(raw_conn)
+
+        raw_conn.execute(
+            """INSERT INTO deals
+               (id, seller_url, product_id, deal_type, status,
+                created_at, updated_at)
+               VALUES ('deal-new', 'http://seller.com', 'prod_1',
+                       'PD', 'draft',
+                       '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')"""
+        )
+        raw_conn.commit()
+
+        cursor = raw_conn.execute(
+            "SELECT currency FROM deals WHERE id = 'deal-new'"
+        )
+        assert cursor.fetchone()[0] == "USD"
+
+
+# -----------------------------------------------------------------------
+# Intrinsic Fields Tests (via DealStore)
+# -----------------------------------------------------------------------
+
+class TestIntrinsicFieldsViaStore:
+    """Test that new intrinsic columns are accessible through DealStore."""
+
+    def test_deal_type_supports_extended_values(self, deal_store):
+        """deal_type supports PG, PD, PA, OPEN_AUCTION, UPFRONT, SCATTER."""
+        for dt in ("PG", "PD", "PA", "OPEN_AUCTION", "UPFRONT", "SCATTER"):
+            did = deal_store.save_deal(
+                seller_url="http://seller.com",
+                product_id="prod_1",
+                deal_type=dt,
+            )
+            deal = deal_store.get_deal(did)
+            assert deal["deal_type"] == dt
+
+    def test_new_intrinsic_columns_default_to_null(self, deal_store):
+        """New columns default to NULL for deals saved without them."""
+        did = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+        )
+        deal = deal_store.get_deal(did)
+
+        # Spot-check new columns are NULL
+        assert deal["display_name"] is None
+        assert deal["buyer_org"] is None
+        assert deal["seller_domain"] is None
+        assert deal["media_type"] is None
+        assert deal["bid_floor_cpm"] is None
+        assert deal["schain_complete"] is None
+
+    def test_currency_defaults_to_usd_via_store(self, deal_store):
+        """Currency defaults to 'USD' for deals created through DealStore."""
+        did = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+        )
+        deal = deal_store.get_deal(did)
+        assert deal["currency"] == "USD"
+
+    def test_intrinsic_fields_round_trip_via_raw_sql(self, deal_store):
+        """New intrinsic columns can be set and read via raw SQL."""
+        did = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+        )
+
+        # Update using raw SQL (DealStore doesn't have setters for new
+        # fields yet — that's a separate bead)
+        with deal_store._lock:
+            deal_store._conn.execute(
+                """UPDATE deals SET
+                    display_name = ?,
+                    description = ?,
+                    buyer_org = ?,
+                    buyer_id = ?,
+                    seller_org = ?,
+                    seller_id = ?,
+                    seller_domain = ?,
+                    seller_type = ?,
+                    price_model = ?,
+                    bid_floor_cpm = ?,
+                    fixed_price_cpm = ?,
+                    cpp = ?,
+                    guaranteed_grps = ?,
+                    currency = ?,
+                    fee_transparency = ?,
+                    media_type = ?,
+                    formats = ?,
+                    content_categories = ?,
+                    publisher_domains = ?,
+                    geo_targets = ?,
+                    dayparts = ?,
+                    programs = ?,
+                    networks = ?,
+                    audience_segments = ?,
+                    estimated_volume = ?,
+                    parent_deal_id = ?,
+                    schain_complete = ?,
+                    schain_nodes = ?,
+                    sellers_json_url = ?,
+                    is_direct = ?,
+                    hop_count = ?,
+                    inventory_fingerprint = ?,
+                    makegood_provisions = ?,
+                    cancellation_window = ?,
+                    audience_guarantee = ?,
+                    preemption_rights = ?,
+                    agency_of_record_status = ?
+                   WHERE id = ?""",
+                (
+                    "ESPN Premium Video PG",
+                    "Premium video deal with ESPN",
+                    "Acme Agency",
+                    "buyer-001",
+                    "ESPN",
+                    "seller-espn",
+                    "espn.com",
+                    "PUBLISHER",
+                    "CPM",
+                    15.00,
+                    18.50,
+                    None,  # cpp (not linear TV)
+                    None,  # guaranteed_grps
+                    "USD",
+                    0.12,
+                    "DIGITAL",
+                    json.dumps(["banner_300x250", "video_15s"]),
+                    json.dumps(["IAB17"]),
+                    json.dumps(["espn.com"]),
+                    json.dumps(["US"]),
+                    None,  # dayparts
+                    None,  # programs
+                    None,  # networks
+                    json.dumps(["sports_enthusiasts"]),
+                    500000,
+                    None,  # parent_deal_id
+                    1,  # schain_complete (boolean)
+                    json.dumps([{"asi": "espn.com", "sid": "001", "hp": 1}]),
+                    "https://espn.com/sellers.json",
+                    1,  # is_direct (boolean)
+                    1,  # hop_count
+                    "espn.com|IAB17|banner_300x250|DIGITAL",
+                    None,  # makegood_provisions
+                    None,  # cancellation_window
+                    None,  # audience_guarantee
+                    None,  # preemption_rights
+                    None,  # agency_of_record_status
+                    did,
+                ),
+            )
+            deal_store._conn.commit()
+
+        deal = deal_store.get_deal(did)
+        assert deal["display_name"] == "ESPN Premium Video PG"
+        assert deal["description"] == "Premium video deal with ESPN"
+        assert deal["buyer_org"] == "Acme Agency"
+        assert deal["buyer_id"] == "buyer-001"
+        assert deal["seller_org"] == "ESPN"
+        assert deal["seller_id"] == "seller-espn"
+        assert deal["seller_domain"] == "espn.com"
+        assert deal["seller_type"] == "PUBLISHER"
+        assert deal["price_model"] == "CPM"
+        assert deal["bid_floor_cpm"] == 15.00
+        assert deal["fixed_price_cpm"] == 18.50
+        assert deal["currency"] == "USD"
+        assert deal["fee_transparency"] == 0.12
+        assert deal["media_type"] == "DIGITAL"
+        assert json.loads(deal["formats"]) == ["banner_300x250", "video_15s"]
+        assert json.loads(deal["content_categories"]) == ["IAB17"]
+        assert json.loads(deal["publisher_domains"]) == ["espn.com"]
+        assert json.loads(deal["geo_targets"]) == ["US"]
+        assert json.loads(deal["audience_segments"]) == ["sports_enthusiasts"]
+        assert deal["estimated_volume"] == 500000
+        assert deal["schain_complete"] == 1
+        assert deal["is_direct"] == 1
+        assert deal["hop_count"] == 1
+        assert deal["inventory_fingerprint"] == "espn.com|IAB17|banner_300x250|DIGITAL"
+        assert deal["sellers_json_url"] == "https://espn.com/sellers.json"
+
+    def test_linear_tv_fields_round_trip(self, deal_store):
+        """Linear TV-specific fields store and retrieve correctly."""
+        did = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_tv",
+            deal_type="UPFRONT",
+        )
+
+        with deal_store._lock:
+            deal_store._conn.execute(
+                """UPDATE deals SET
+                    media_type = ?,
+                    cpp = ?,
+                    guaranteed_grps = ?,
+                    dayparts = ?,
+                    programs = ?,
+                    networks = ?,
+                    makegood_provisions = ?,
+                    cancellation_window = ?,
+                    audience_guarantee = ?,
+                    preemption_rights = ?,
+                    agency_of_record_status = ?
+                   WHERE id = ?""",
+                (
+                    "LINEAR_TV",
+                    45.00,
+                    150.0,
+                    json.dumps(["M-F 8p-11p"]),
+                    json.dumps(["Sunday Night Football"]),
+                    json.dumps(["NBC", "ESPN"]),
+                    "Standard makegood within 2 weeks",
+                    "30 days written notice",
+                    "A18-49 Nielsen Live+3",
+                    "Non-preemptible for upfront",
+                    "BBDO Worldwide",
+                    did,
+                ),
+            )
+            deal_store._conn.commit()
+
+        deal = deal_store.get_deal(did)
+        assert deal["media_type"] == "LINEAR_TV"
+        assert deal["cpp"] == 45.00
+        assert deal["guaranteed_grps"] == 150.0
+        assert json.loads(deal["dayparts"]) == ["M-F 8p-11p"]
+        assert json.loads(deal["programs"]) == ["Sunday Night Football"]
+        assert json.loads(deal["networks"]) == ["NBC", "ESPN"]
+        assert deal["makegood_provisions"] == "Standard makegood within 2 weeks"
+        assert deal["cancellation_window"] == "30 days written notice"
+        assert deal["audience_guarantee"] == "A18-49 Nielsen Live+3"
+        assert deal["preemption_rights"] == "Non-preemptible for upfront"
+        assert deal["agency_of_record_status"] == "BBDO Worldwide"
+
+
+# -----------------------------------------------------------------------
+# Extrinsic Table Tests
+# -----------------------------------------------------------------------
+
+class TestPortfolioMetadata:
+    """Tests for the portfolio_metadata extrinsic table."""
+
+    def test_insert_and_query_portfolio_metadata(self, deal_store):
+        """portfolio_metadata records can be inserted and queried."""
+        did = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+        )
+
+        with deal_store._lock:
+            deal_store._conn.execute(
+                """INSERT INTO portfolio_metadata
+                   (deal_id, import_source, import_date, tags,
+                    advertiser_id, agency_id)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    did,
+                    "CSV",
+                    "2026-03-18",
+                    json.dumps(["premium", "sports"]),
+                    "adv-001",
+                    "agency-001",
+                ),
+            )
+            deal_store._conn.commit()
+
+        with deal_store._lock:
+            cursor = deal_store._conn.execute(
+                "SELECT * FROM portfolio_metadata WHERE deal_id = ?",
+                (did,),
+            )
+            row = cursor.fetchone()
+
+        assert row is not None
+        meta = dict(row)
+        assert meta["deal_id"] == did
+        assert meta["import_source"] == "CSV"
+        assert meta["import_date"] == "2026-03-18"
+        assert json.loads(meta["tags"]) == ["premium", "sports"]
+        assert meta["advertiser_id"] == "adv-001"
+        assert meta["agency_id"] == "agency-001"
+
+    def test_portfolio_metadata_foreign_key(self, deal_store):
+        """portfolio_metadata deal_id must reference an existing deal."""
+        with deal_store._lock:
+            with pytest.raises(sqlite3.IntegrityError):
+                deal_store._conn.execute(
+                    """INSERT INTO portfolio_metadata
+                       (deal_id, import_source) VALUES (?, ?)""",
+                    ("nonexistent-deal", "CSV"),
+                )
+
+
+class TestDealActivations:
+    """Tests for the deal_activations extrinsic table."""
+
+    def test_insert_and_query_deal_activation(self, deal_store):
+        """deal_activations records can be inserted and queried."""
+        did = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+        )
+
+        with deal_store._lock:
+            deal_store._conn.execute(
+                """INSERT INTO deal_activations
+                   (deal_id, platform, platform_deal_id,
+                    activation_status, last_sync_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (
+                    did,
+                    "TTD",
+                    "TTD-ESP-12345",
+                    "ACTIVE",
+                    "2026-03-18T10:00:00Z",
+                ),
+            )
+            deal_store._conn.commit()
+
+        with deal_store._lock:
+            cursor = deal_store._conn.execute(
+                "SELECT * FROM deal_activations WHERE deal_id = ?",
+                (did,),
+            )
+            row = cursor.fetchone()
+
+        assert row is not None
+        activation = dict(row)
+        assert activation["platform"] == "TTD"
+        assert activation["platform_deal_id"] == "TTD-ESP-12345"
+        assert activation["activation_status"] == "ACTIVE"
+
+    def test_multiple_activations_per_deal(self, deal_store):
+        """A deal can be activated on multiple platforms."""
+        did = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+        )
+
+        platforms = [
+            ("TTD", "TTD-001", "ACTIVE"),
+            ("DV360", "DV360-001", "PENDING"),
+            ("XANDR", "XN-001", "ACTIVE"),
+        ]
+
+        with deal_store._lock:
+            for platform, pid, status in platforms:
+                deal_store._conn.execute(
+                    """INSERT INTO deal_activations
+                       (deal_id, platform, platform_deal_id, activation_status)
+                       VALUES (?, ?, ?, ?)""",
+                    (did, platform, pid, status),
+                )
+            deal_store._conn.commit()
+
+        with deal_store._lock:
+            cursor = deal_store._conn.execute(
+                "SELECT * FROM deal_activations WHERE deal_id = ?",
+                (did,),
+            )
+            rows = cursor.fetchall()
+
+        assert len(rows) == 3
+
+    def test_deal_activations_foreign_key(self, deal_store):
+        """deal_activations deal_id must reference an existing deal."""
+        with deal_store._lock:
+            with pytest.raises(sqlite3.IntegrityError):
+                deal_store._conn.execute(
+                    """INSERT INTO deal_activations
+                       (deal_id, platform, platform_deal_id, activation_status)
+                       VALUES (?, ?, ?, ?)""",
+                    ("nonexistent-deal", "TTD", "TTD-001", "ACTIVE"),
+                )
+
+
+class TestPerformanceCache:
+    """Tests for the performance_cache extrinsic table."""
+
+    def test_insert_and_query_performance_cache(self, deal_store):
+        """performance_cache records can be inserted and queried."""
+        did = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+        )
+
+        with deal_store._lock:
+            deal_store._conn.execute(
+                """INSERT INTO performance_cache
+                   (deal_id, impressions_delivered, spend_to_date,
+                    fill_rate, win_rate, avg_effective_cpm,
+                    last_delivery_at, performance_trend, cached_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    did,
+                    1500000,
+                    22500.00,
+                    0.85,
+                    0.42,
+                    15.00,
+                    "2026-03-18T09:00:00Z",
+                    "IMPROVING",
+                    "2026-03-18T10:00:00Z",
+                ),
+            )
+            deal_store._conn.commit()
+
+        with deal_store._lock:
+            cursor = deal_store._conn.execute(
+                "SELECT * FROM performance_cache WHERE deal_id = ?",
+                (did,),
+            )
+            row = cursor.fetchone()
+
+        assert row is not None
+        perf = dict(row)
+        assert perf["impressions_delivered"] == 1500000
+        assert perf["spend_to_date"] == 22500.00
+        assert perf["fill_rate"] == 0.85
+        assert perf["win_rate"] == 0.42
+        assert perf["avg_effective_cpm"] == 15.00
+        assert perf["performance_trend"] == "IMPROVING"
+
+    def test_performance_cache_foreign_key(self, deal_store):
+        """performance_cache deal_id must reference an existing deal."""
+        with deal_store._lock:
+            with pytest.raises(sqlite3.IntegrityError):
+                deal_store._conn.execute(
+                    """INSERT INTO performance_cache
+                       (deal_id, impressions_delivered, spend_to_date)
+                       VALUES (?, ?, ?)""",
+                    ("nonexistent-deal", 1000, 15.00),
+                )
+
+
+# -----------------------------------------------------------------------
+# Backward Compatibility Tests
+# -----------------------------------------------------------------------
+
+class TestBackwardCompatibility:
+    """Ensure v1 operations still work after schema v2 migration."""
+
+    def test_save_deal_v1_style_still_works(self, deal_store):
+        """save_deal with only v1 fields works on v2 schema."""
+        did = deal_store.save_deal(
+            seller_url="http://seller.com",
+            product_id="prod_1",
+            product_name="Banner Ad",
+            deal_type="PD",
+            status="draft",
+            price=12.50,
+        )
+
+        deal = deal_store.get_deal(did)
+        assert deal is not None
+        assert deal["seller_url"] == "http://seller.com"
+        assert deal["product_name"] == "Banner Ad"
+        assert deal["price"] == 12.50
+
+    def test_list_deals_still_works(self, deal_store):
+        """list_deals works on v2 schema."""
+        deal_store.save_deal(
+            seller_url="http://a.com",
+            product_id="p1",
+            status="draft",
+        )
+        deal_store.save_deal(
+            seller_url="http://b.com",
+            product_id="p2",
+            status="booked",
+        )
+
+        all_deals = deal_store.list_deals()
+        assert len(all_deals) == 2
+
+        drafts = deal_store.list_deals(status="draft")
+        assert len(drafts) == 1
+
+    def test_negotiation_rounds_still_work(self, deal_store):
+        """Negotiation rounds work on v2 schema."""
+        did = deal_store.save_deal(
+            seller_url="http://a.com",
+            product_id="p1",
+        )
+        deal_store.save_negotiation_round(
+            deal_id=did,
+            proposal_id="prop_1",
+            round_number=1,
+            buyer_price=10.0,
+            seller_price=15.0,
+            action="counter",
+        )
+
+        history = deal_store.get_negotiation_history(did)
+        assert len(history) == 1
+
+    def test_booking_records_still_work(self, deal_store):
+        """Booking records work on v2 schema."""
+        did = deal_store.save_deal(
+            seller_url="http://a.com",
+            product_id="p1",
+        )
+        deal_store.save_booking_record(
+            deal_id=did,
+            line_id="line_1",
+            channel="branding",
+            impressions=500000,
+            cost=7500.0,
+        )
+
+        records = deal_store.get_booking_records(did)
+        assert len(records) == 1
+
+    def test_jobs_still_work(self, deal_store):
+        """Job operations work on v2 schema."""
+        deal_store.save_job(
+            job_id="j1",
+            status="pending",
+            brief='{"name": "Test"}',
+        )
+        job = deal_store.get_job("j1")
+        assert job is not None
+        assert job["status"] == "pending"
+
+    def test_cascade_deletes_include_extrinsic_tables(self, deal_store):
+        """Deleting a deal cascades to extrinsic tables."""
+        did = deal_store.save_deal(
+            seller_url="http://a.com",
+            product_id="p1",
+        )
+
+        # Insert records in extrinsic tables
+        with deal_store._lock:
+            deal_store._conn.execute(
+                "INSERT INTO portfolio_metadata (deal_id, import_source) VALUES (?, ?)",
+                (did, "CSV"),
+            )
+            deal_store._conn.execute(
+                """INSERT INTO deal_activations
+                   (deal_id, platform, platform_deal_id, activation_status)
+                   VALUES (?, ?, ?, ?)""",
+                (did, "TTD", "TTD-001", "ACTIVE"),
+            )
+            deal_store._conn.execute(
+                """INSERT INTO performance_cache
+                   (deal_id, impressions_delivered, spend_to_date)
+                   VALUES (?, ?, ?)""",
+                (did, 1000, 15.00),
+            )
+            deal_store._conn.commit()
+
+        # Delete the deal
+        with deal_store._lock:
+            deal_store._conn.execute("DELETE FROM deals WHERE id = ?", (did,))
+            deal_store._conn.commit()
+
+        # All extrinsic records should be gone
+        with deal_store._lock:
+            for table in ("portfolio_metadata", "deal_activations", "performance_cache"):
+                cursor = deal_store._conn.execute(
+                    f"SELECT COUNT(*) FROM {table} WHERE deal_id = ?",
+                    (did,),
+                )
+                assert cursor.fetchone()[0] == 0, \
+                    f"Cascade delete failed for {table}"

--- a/tests/unit/test_dealjockey_dashboard.py
+++ b/tests/unit/test_dealjockey_dashboard.py
@@ -1,0 +1,428 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Tests for the DealJockey demo dashboard.
+
+Covers:
+  - Seed data populates the expected number of deals
+  - API routes return 200 with expected JSON structure
+  - CSV import endpoint parses correctly
+  - Manual entry endpoint validates correctly
+  - Event log returns Phase 1 event types
+  - Schema endpoint returns version info
+"""
+
+import csv
+import io
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ad_buyer.demo.dealjockey_dashboard import create_app
+from ad_buyer.demo.seed_data import seed_demo_data
+from ad_buyer.storage.deal_store import DealStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store():
+    """Create an in-memory DealStore for testing."""
+    s = DealStore("sqlite:///:memory:")
+    s.connect()
+    yield s
+    s.disconnect()
+
+
+@pytest.fixture
+def seeded_store(store):
+    """DealStore with seed data loaded."""
+    seed_demo_data(store)
+    return store
+
+
+@pytest.fixture
+def app(seeded_store):
+    """Flask test app with seeded data."""
+    application = create_app("sqlite:///:memory:")
+    # Replace the store with our seeded one
+    application.config["DEAL_STORE"] = seeded_store
+    application.config["TESTING"] = True
+    return application
+
+
+@pytest.fixture
+def client(app):
+    """Flask test client."""
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# Seed Data Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSeedData:
+    """Tests for the seed_data module."""
+
+    def test_seed_creates_expected_deal_count(self, store):
+        """seed_demo_data should create exactly 14 deals."""
+        ids = seed_demo_data(store)
+        assert len(ids) == 14
+
+    def test_seed_creates_unique_ids(self, store):
+        """All seeded deal IDs should be unique."""
+        ids = seed_demo_data(store)
+        assert len(set(ids)) == 14
+
+    def test_seed_creates_mixed_statuses(self, store):
+        """Seeded deals should include multiple statuses."""
+        seed_demo_data(store)
+        deals = store.list_deals(limit=100)
+        statuses = {d["status"] for d in deals}
+        assert "active" in statuses
+        assert "draft" in statuses
+        assert "paused" in statuses
+        assert "expired" in statuses
+        assert "canceled" in statuses
+
+    def test_seed_creates_mixed_media_types(self, store):
+        """Seeded deals should include multiple media types."""
+        seed_demo_data(store)
+        deals = store.list_deals(limit=100)
+        media_types = {d.get("media_type") for d in deals if d.get("media_type")}
+        assert "DIGITAL" in media_types
+        assert "CTV" in media_types
+        assert "LINEAR_TV" in media_types
+        assert "AUDIO" in media_types
+        assert "DOOH" in media_types
+
+    def test_seed_creates_portfolio_metadata(self, store):
+        """Some seeded deals should have portfolio metadata."""
+        ids = seed_demo_data(store)
+        meta_count = sum(
+            1 for did in ids
+            if store.get_portfolio_metadata(did) is not None
+        )
+        assert meta_count >= 8  # at least 8 deals have metadata
+
+    def test_seed_creates_activations(self, store):
+        """Some seeded deals should have deal activations."""
+        ids = seed_demo_data(store)
+        act_count = sum(
+            1 for did in ids
+            if len(store.get_deal_activations(did)) > 0
+        )
+        assert act_count >= 5  # at least 5 deals have activations
+
+    def test_seed_creates_performance_cache(self, store):
+        """Some seeded deals should have performance cache entries."""
+        ids = seed_demo_data(store)
+        perf_count = sum(
+            1 for did in ids
+            if store.get_performance_cache(did) is not None
+        )
+        assert perf_count >= 5  # at least 5 deals have perf data
+
+    def test_seed_emits_events(self, store):
+        """Each seeded deal should emit a deal.imported event."""
+        ids = seed_demo_data(store)
+        events = store.list_events(limit=100)
+        import_events = [
+            e for e in events if e["event_type"] == "deal.imported"
+        ]
+        assert len(import_events) >= len(ids)
+
+
+# ---------------------------------------------------------------------------
+# API Route Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAPIRoutes:
+    """Tests for the dashboard API routes."""
+
+    def test_index_returns_html(self, client):
+        """GET / should return the dashboard HTML page."""
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert b"DealJockey" in resp.data
+
+    def test_api_schema(self, client):
+        """GET /api/schema should return version and table info."""
+        resp = client.get("/api/schema")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["schema_version"] == 2
+        assert isinstance(data["tables"], list)
+        assert len(data["tables"]) > 0
+        assert isinstance(data["v2_columns"], list)
+        assert len(data["v2_columns"]) > 0
+
+    def test_api_deals_list(self, client):
+        """GET /api/deals should return a list of deals."""
+        resp = client.get("/api/deals")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "deals" in data
+        assert "count" in data
+        assert data["count"] > 0
+
+    def test_api_deals_filter_by_status(self, client):
+        """GET /api/deals?status=active should filter correctly."""
+        resp = client.get("/api/deals?status=active")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        for deal in data["deals"]:
+            assert deal["status"] == "active"
+
+    def test_api_deals_filter_by_media_type(self, client):
+        """GET /api/deals?media_type=CTV should filter correctly."""
+        resp = client.get("/api/deals?media_type=CTV")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        for deal in data["deals"]:
+            assert deal["media_type"] == "CTV"
+
+    def test_api_deal_detail(self, client):
+        """GET /api/deals/<id> should return deal with metadata."""
+        # Get a deal ID first
+        deals_resp = client.get("/api/deals?limit=1")
+        deal_id = deals_resp.get_json()["deals"][0]["id"]
+
+        resp = client.get(f"/api/deals/{deal_id}")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "deal" in data
+        assert data["deal"]["id"] == deal_id
+        assert "portfolio_metadata" in data
+        assert "activations" in data
+        assert "performance_cache" in data
+
+    def test_api_deal_detail_not_found(self, client):
+        """GET /api/deals/<nonexistent> should return 404."""
+        resp = client.get("/api/deals/nonexistent-id-000")
+        assert resp.status_code == 404
+
+    def test_api_search(self, client):
+        """GET /api/search?q=ESPN should find deals."""
+        resp = client.get("/api/search?q=ESPN")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["count"] >= 1
+        assert any("ESPN" in str(d.values()) for d in data["results"])
+
+    def test_api_search_empty_query(self, client):
+        """GET /api/search with empty query should return 400."""
+        resp = client.get("/api/search?q=")
+        assert resp.status_code == 400
+
+    def test_api_summary(self, client):
+        """GET /api/summary should return aggregate statistics."""
+        resp = client.get("/api/summary")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total_deals"] > 0
+        assert "by_status" in data
+        assert "by_media_type" in data
+        assert "by_deal_type" in data
+        assert "top_sellers" in data
+        assert "total_value" in data
+
+    def test_api_events(self, client):
+        """GET /api/events should return Phase 1 events."""
+        resp = client.get("/api/events")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "events" in data
+        # All returned events should be Phase 1 types
+        phase1_types = {
+            "deal.imported", "deal.template_created",
+            "portfolio.inspected", "deal.manual_action_required",
+        }
+        for event in data["events"]:
+            assert event["event_type"] in phase1_types
+
+    def test_api_agent_info(self, client):
+        """GET /api/agent-info should return agent configuration."""
+        resp = client.get("/api/agent-info")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["role"] == "Deal Jockey - Portfolio Manager"
+        assert "l1_routing" in data
+        assert "phase1_tools" in data
+        assert "phase1_event_types" in data
+
+    def test_api_enums(self, client):
+        """GET /api/enums should return valid enum values."""
+        resp = client.get("/api/enums")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "PG" in data["deal_types"]
+        assert "CTV" in data["media_types"]
+        assert "CPM" in data["price_models"]
+        assert "PUBLISHER" in data["seller_types"]
+
+
+# ---------------------------------------------------------------------------
+# CSV Import Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCSVImport:
+    """Tests for the CSV import endpoint."""
+
+    def _make_csv_bytes(self, rows: list[list[str]]) -> bytes:
+        """Build CSV bytes from a list of rows."""
+        output = io.StringIO()
+        writer = csv.writer(output)
+        for row in rows:
+            writer.writerow(row)
+        return output.getvalue().encode("utf-8")
+
+    def test_import_valid_csv(self, client):
+        """POST /api/import with valid CSV should parse deals."""
+        csv_data = self._make_csv_bytes([
+            ["deal_id", "name", "publisher", "deal_type", "media_type", "cpm", "start_date", "end_date"],
+            ["TEST-001", "Test Deal 1", "TestPub", "PG", "DIGITAL", "15.00", "2026-04-01", "2026-06-30"],
+            ["TEST-002", "Test Deal 2", "TestPub2", "PD", "CTV", "25.00", "2026-05-01", "2026-07-31"],
+        ])
+
+        data = {
+            "file": (io.BytesIO(csv_data), "test_deals.csv"),
+        }
+        resp = client.post("/api/import", data=data, content_type="multipart/form-data")
+        assert resp.status_code == 200
+        result = resp.get_json()
+        assert result["successful"] == 2
+        assert result["failed"] == 0
+        assert len(result["deals"]) == 2
+
+    def test_import_csv_with_errors(self, client):
+        """POST /api/import with invalid rows should report errors."""
+        csv_data = self._make_csv_bytes([
+            ["deal_id", "name", "publisher", "deal_type"],
+            # Missing seller info (no publisher value)
+            ["ERR-001", "Bad Deal", "", "PG"],
+        ])
+
+        data = {
+            "file": (io.BytesIO(csv_data), "bad_deals.csv"),
+        }
+        resp = client.post("/api/import", data=data, content_type="multipart/form-data")
+        assert resp.status_code == 200
+        result = resp.get_json()
+        assert result["failed"] >= 1
+        assert len(result["errors"]) >= 1
+
+    def test_import_no_file(self, client):
+        """POST /api/import without a file should return 400."""
+        resp = client.post("/api/import", content_type="multipart/form-data")
+        assert resp.status_code == 400
+
+    def test_import_save(self, client):
+        """POST /api/import/save should persist parsed deals."""
+        deals = [
+            {
+                "seller_deal_id": "SAVE-001",
+                "display_name": "Saved Deal",
+                "seller_org": "SavePub",
+                "deal_type": "PD",
+                "media_type": "DIGITAL",
+                "fixed_price_cpm": 10.0,
+                "status": "draft",
+            },
+        ]
+        resp = client.post(
+            "/api/import/save",
+            data=json.dumps({"deals": deals}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        result = resp.get_json()
+        assert result["saved"] == 1
+        assert len(result["deal_ids"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Manual Entry Tests
+# ---------------------------------------------------------------------------
+
+
+class TestManualEntry:
+    """Tests for the manual deal entry endpoint."""
+
+    def test_create_valid_deal(self, client):
+        """POST /api/deals with valid data should create a deal."""
+        resp = client.post(
+            "/api/deals",
+            data=json.dumps({
+                "display_name": "Manual Test Deal",
+                "seller_url": "https://test.seller.example.com",
+                "deal_type": "PD",
+                "media_type": "DIGITAL",
+                "status": "draft",
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert "deal_id" in data
+
+    def test_create_deal_missing_required(self, client):
+        """POST /api/deals missing required fields should return 400."""
+        resp = client.post(
+            "/api/deals",
+            data=json.dumps({
+                "deal_type": "PD",
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["success"] is False
+
+    def test_create_deal_invalid_deal_type(self, client):
+        """POST /api/deals with invalid deal_type should return 400."""
+        resp = client.post(
+            "/api/deals",
+            data=json.dumps({
+                "display_name": "Bad Type Deal",
+                "seller_url": "https://test.seller.example.com",
+                "deal_type": "INVALID",
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["success"] is False
+        assert any("deal_type" in e for e in data["errors"])
+
+    def test_create_deal_with_metadata(self, client):
+        """POST /api/deals with tags and advertiser should succeed."""
+        resp = client.post(
+            "/api/deals",
+            data=json.dumps({
+                "display_name": "Tagged Deal",
+                "seller_url": "https://test.seller.example.com",
+                "deal_type": "PG",
+                "media_type": "CTV",
+                "tags": ["premium", "test"],
+                "advertiser_id": "ADV-TEST-001",
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+
+        # Verify the deal exists and has metadata
+        detail_resp = client.get(f"/api/deals/{data['deal_id']}")
+        detail = detail_resp.get_json()
+        assert detail["deal"]["media_type"] == "CTV"

--- a/tests/unit/test_portfolio_inspection.py
+++ b/tests/unit/test_portfolio_inspection.py
@@ -1,0 +1,841 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Unit tests for portfolio inspection tools.
+
+Tests ListPortfolioTool, SearchPortfolioTool, PortfolioSummaryTool,
+and InspectDealTool -- the CrewAI tools DealJockey uses to view,
+filter, search, and aggregate portfolio views.
+"""
+
+import json
+
+import pytest
+
+from ad_buyer.storage.deal_store import DealStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def deal_store():
+    """Create an in-memory DealStore for testing."""
+    store = DealStore("sqlite:///:memory:")
+    store.connect()
+    yield store
+    store.disconnect()
+
+
+@pytest.fixture
+def populated_store(deal_store):
+    """DealStore with a variety of deals for testing filters and aggregation."""
+    # Deal 1: active digital PD from ESPN
+    deal_store.save_deal(
+        deal_id="deal-001",
+        seller_url="https://espn.seller.example.com",
+        product_id="prod-espn",
+        product_name="ESPN Sports PMP",
+        deal_type="PD",
+        status="active",
+        price=12.50,
+        impressions=1000000,
+        display_name="ESPN Sports PMP",
+        media_type="DIGITAL",
+        seller_domain="espn.com",
+        seller_org="ESPN",
+        seller_type="PUBLISHER",
+        description="Premium sports display inventory",
+        flight_start="2026-01-01",
+        flight_end="2026-06-30",
+    )
+    deal_store.save_portfolio_metadata(
+        deal_id="deal-001",
+        import_source="CSV",
+        advertiser_id="adv-acme",
+        tags='["sports", "premium"]',
+    )
+
+    # Deal 2: draft CTV PG from Hulu
+    deal_store.save_deal(
+        deal_id="deal-002",
+        seller_url="https://hulu.seller.example.com",
+        product_id="prod-hulu",
+        product_name="Hulu CTV PG",
+        deal_type="PG",
+        status="draft",
+        price=25.00,
+        impressions=500000,
+        display_name="Hulu CTV PG",
+        media_type="CTV",
+        seller_domain="hulu.com",
+        seller_org="Hulu",
+        seller_type="PUBLISHER",
+        description="Connected TV guaranteed deal",
+        flight_start="2026-03-01",
+        flight_end="2026-12-31",
+    )
+    deal_store.save_portfolio_metadata(
+        deal_id="deal-002",
+        import_source="MANUAL",
+        advertiser_id="adv-acme",
+        tags='["ctv", "premium"]',
+    )
+
+    # Deal 3: paused digital PA from TradeDesk
+    deal_store.save_deal(
+        deal_id="deal-003",
+        seller_url="https://ttd.seller.example.com",
+        product_id="prod-ttd",
+        product_name="TTD Open Marketplace",
+        deal_type="PA",
+        status="paused",
+        price=8.00,
+        impressions=2000000,
+        display_name="TTD Open Marketplace",
+        media_type="DIGITAL",
+        seller_domain="thetradedesk.com",
+        seller_org="The Trade Desk",
+        seller_type="DSP",
+        description="Private auction via TTD",
+    )
+    deal_store.save_portfolio_metadata(
+        deal_id="deal-003",
+        import_source="CSV",
+        advertiser_id="adv-beta",
+    )
+
+    # Deal 4: active LINEAR_TV UPFRONT from NBCU
+    deal_store.save_deal(
+        deal_id="deal-004",
+        seller_url="https://nbcu.seller.example.com",
+        product_id="prod-nbcu",
+        product_name="NBCU Upfront 2026",
+        deal_type="UPFRONT",
+        status="active",
+        price=45.00,
+        impressions=3000000,
+        display_name="NBCU Upfront 2026",
+        media_type="LINEAR_TV",
+        seller_domain="nbcuniversal.com",
+        seller_org="NBCUniversal",
+        seller_type="PUBLISHER",
+        description="Linear TV upfront commitment",
+        flight_start="2026-09-01",
+        flight_end="2027-05-31",
+    )
+    deal_store.save_portfolio_metadata(
+        deal_id="deal-004",
+        import_source="MANUAL",
+        advertiser_id="adv-acme",
+    )
+
+    # Deal 5: expired AUDIO PD from Spotify
+    deal_store.save_deal(
+        deal_id="deal-005",
+        seller_url="https://spotify.seller.example.com",
+        product_id="prod-spotify",
+        product_name="Spotify Audio PD",
+        deal_type="PD",
+        status="expired",
+        price=6.00,
+        impressions=800000,
+        display_name="Spotify Audio PD",
+        media_type="AUDIO",
+        seller_domain="spotify.com",
+        seller_org="Spotify",
+        seller_type="PUBLISHER",
+        description="Audio streaming inventory",
+        flight_start="2025-01-01",
+        flight_end="2025-12-31",
+    )
+
+    return deal_store
+
+
+@pytest.fixture
+def store_with_related_data(populated_store):
+    """Add activations and performance cache to the populated store."""
+    # Add activations for deal-001
+    populated_store.save_deal_activation(
+        deal_id="deal-001",
+        platform="TTD",
+        platform_deal_id="TTD-ESPN-001",
+        activation_status="ACTIVE",
+        last_sync_at="2026-03-15T10:00:00Z",
+    )
+    populated_store.save_deal_activation(
+        deal_id="deal-001",
+        platform="DV360",
+        platform_deal_id="DV360-ESPN-001",
+        activation_status="PENDING",
+    )
+
+    # Add performance cache for deal-001
+    populated_store.save_performance_cache(
+        deal_id="deal-001",
+        impressions_delivered=500000,
+        spend_to_date=6250.00,
+        fill_rate=0.85,
+        win_rate=0.72,
+        avg_effective_cpm=12.50,
+        last_delivery_at="2026-03-17T23:59:59Z",
+        performance_trend="STABLE",
+        cached_at="2026-03-18T00:00:00Z",
+    )
+
+    return populated_store
+
+
+# ---------------------------------------------------------------------------
+# ListPortfolioTool tests
+# ---------------------------------------------------------------------------
+
+
+class TestListPortfolioTool:
+    """Tests for the ListPortfolioTool CrewAI tool."""
+
+    def test_list_all_deals_no_filters(self, populated_store):
+        """List all deals without any filters."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=populated_store)
+        result = tool._run(filters_json="{}")
+
+        assert "deal-001" in result or "ESPN" in result
+        assert "deal-002" in result or "Hulu" in result
+        # Should contain all 5 deals
+        assert "5 deal" in result.lower() or all(
+            name in result
+            for name in ["ESPN", "Hulu", "TTD", "NBCU", "Spotify"]
+        )
+
+    def test_filter_by_status(self, populated_store):
+        """Filter deals by status."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=populated_store)
+        result = tool._run(filters_json='{"status": "active"}')
+
+        assert "ESPN" in result
+        assert "NBCU" in result
+        # Should not include draft, paused, or expired deals
+        assert "Hulu" not in result
+        assert "Spotify" not in result
+
+    def test_filter_by_media_type(self, populated_store):
+        """Filter deals by media type."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=populated_store)
+        result = tool._run(filters_json='{"media_type": "DIGITAL"}')
+
+        assert "ESPN" in result
+        assert "TTD" in result
+        # Should not include CTV, LINEAR_TV, or AUDIO deals
+        assert "Hulu" not in result
+        assert "NBCU" not in result
+
+    def test_filter_by_seller_domain(self, populated_store):
+        """Filter deals by seller domain."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=populated_store)
+        result = tool._run(filters_json='{"seller_domain": "espn.com"}')
+
+        assert "ESPN" in result
+        assert "Hulu" not in result
+
+    def test_filter_by_deal_type(self, populated_store):
+        """Filter deals by deal type."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=populated_store)
+        result = tool._run(filters_json='{"deal_type": "PG"}')
+
+        assert "Hulu" in result
+        assert "ESPN" not in result
+
+    def test_filter_by_advertiser_id(self, populated_store):
+        """Filter deals by advertiser ID from portfolio metadata."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=populated_store)
+        result = tool._run(filters_json='{"advertiser_id": "adv-beta"}')
+
+        assert "TTD" in result
+        assert "ESPN" not in result
+        assert "Hulu" not in result
+
+    def test_filter_by_seller_type(self, populated_store):
+        """Filter deals by seller type."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=populated_store)
+        result = tool._run(filters_json='{"seller_type": "DSP"}')
+
+        assert "TTD" in result or "Trade Desk" in result
+        assert "ESPN" not in result
+
+    def test_combined_filters(self, populated_store):
+        """Apply multiple filters at once."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=populated_store)
+        result = tool._run(
+            filters_json='{"status": "active", "media_type": "DIGITAL"}'
+        )
+
+        assert "ESPN" in result
+        # NBCU is active but LINEAR_TV, not DIGITAL
+        assert "NBCU" not in result
+
+    def test_pagination_limit(self, populated_store):
+        """Limit the number of results."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=populated_store)
+        result = tool._run(filters_json='{"limit": 2}')
+
+        # Should show only 2 deals and indicate more are available
+        # The exact text will depend on implementation, but the total
+        # deal count of 5 should be mentioned or indicated
+        assert "2" in result
+
+    def test_pagination_offset(self, populated_store):
+        """Skip results with offset."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=populated_store)
+        # Get all results first
+        all_result = tool._run(filters_json='{}')
+        # Get offset results
+        offset_result = tool._run(filters_json='{"offset": 2, "limit": 2}')
+
+        # Offset results should not include the first 2 results
+        assert offset_result != all_result
+
+    def test_sort_by_price_asc(self, populated_store):
+        """Sort deals by price ascending."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=populated_store)
+        result = tool._run(
+            filters_json='{"sort_by": "price", "sort_order": "asc"}'
+        )
+
+        # Spotify ($6) should appear before ESPN ($12.50)
+        spotify_pos = result.find("Spotify")
+        espn_pos = result.find("ESPN")
+        if spotify_pos >= 0 and espn_pos >= 0:
+            assert spotify_pos < espn_pos
+
+    def test_sort_by_price_desc(self, populated_store):
+        """Sort deals by price descending."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=populated_store)
+        result = tool._run(
+            filters_json='{"sort_by": "price", "sort_order": "desc"}'
+        )
+
+        # NBCU ($45) should appear before ESPN ($12.50)
+        nbcu_pos = result.find("NBCU")
+        espn_pos = result.find("ESPN")
+        if nbcu_pos >= 0 and espn_pos >= 0:
+            assert nbcu_pos < espn_pos
+
+    def test_sort_by_display_name(self, populated_store):
+        """Sort deals by display name."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=populated_store)
+        result = tool._run(
+            filters_json='{"sort_by": "display_name", "sort_order": "asc"}'
+        )
+
+        # ESPN should appear before Hulu (alphabetical)
+        espn_pos = result.find("ESPN")
+        hulu_pos = result.find("Hulu")
+        if espn_pos >= 0 and hulu_pos >= 0:
+            assert espn_pos < hulu_pos
+
+    def test_empty_database(self, deal_store):
+        """Handle an empty database gracefully."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=deal_store)
+        result = tool._run(filters_json="{}")
+
+        assert "no deal" in result.lower() or "0 deal" in result.lower() or "empty" in result.lower()
+
+    def test_invalid_json_input(self, deal_store):
+        """Handle invalid JSON gracefully."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=deal_store)
+        result = tool._run(filters_json="not valid json")
+
+        assert "error" in result.lower()
+
+    def test_returns_human_readable_output(self, populated_store):
+        """Output should be human-readable, not raw dicts."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            ListPortfolioTool,
+        )
+
+        tool = ListPortfolioTool(deal_store=populated_store)
+        result = tool._run(filters_json='{"status": "active"}')
+
+        # Should not look like a raw Python dict
+        assert "{'id'" not in result
+        # Should contain structured, readable information
+        assert "ESPN" in result
+
+
+# ---------------------------------------------------------------------------
+# SearchPortfolioTool tests
+# ---------------------------------------------------------------------------
+
+
+class TestSearchPortfolioTool:
+    """Tests for the SearchPortfolioTool CrewAI tool."""
+
+    def test_search_by_display_name(self, populated_store):
+        """Search should find deals by display name."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            SearchPortfolioTool,
+        )
+
+        tool = SearchPortfolioTool(deal_store=populated_store)
+        result = tool._run(query="ESPN")
+
+        assert "ESPN" in result
+        assert "deal-001" in result
+
+    def test_search_by_seller_org(self, populated_store):
+        """Search should find deals by seller organization."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            SearchPortfolioTool,
+        )
+
+        tool = SearchPortfolioTool(deal_store=populated_store)
+        result = tool._run(query="NBCUniversal")
+
+        assert "NBCU" in result
+        assert "deal-004" in result
+
+    def test_search_by_seller_domain(self, populated_store):
+        """Search should find deals by seller domain."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            SearchPortfolioTool,
+        )
+
+        tool = SearchPortfolioTool(deal_store=populated_store)
+        result = tool._run(query="hulu.com")
+
+        assert "Hulu" in result
+
+    def test_search_by_description(self, populated_store):
+        """Search should find deals by description text."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            SearchPortfolioTool,
+        )
+
+        tool = SearchPortfolioTool(deal_store=populated_store)
+        result = tool._run(query="streaming")
+
+        assert "Spotify" in result
+
+    def test_search_case_insensitive(self, populated_store):
+        """Search should be case-insensitive."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            SearchPortfolioTool,
+        )
+
+        tool = SearchPortfolioTool(deal_store=populated_store)
+        result = tool._run(query="espn")
+
+        assert "ESPN" in result
+
+    def test_search_no_results(self, populated_store):
+        """Search with no matches should report cleanly."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            SearchPortfolioTool,
+        )
+
+        tool = SearchPortfolioTool(deal_store=populated_store)
+        result = tool._run(query="nonexistent_xyz_deal")
+
+        assert "no" in result.lower() or "0" in result
+
+    def test_search_empty_database(self, deal_store):
+        """Search on empty database should handle gracefully."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            SearchPortfolioTool,
+        )
+
+        tool = SearchPortfolioTool(deal_store=deal_store)
+        result = tool._run(query="anything")
+
+        assert "no" in result.lower() or "0" in result
+
+    def test_search_shows_match_context(self, populated_store):
+        """Search results should indicate which field matched."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            SearchPortfolioTool,
+        )
+
+        tool = SearchPortfolioTool(deal_store=populated_store)
+        result = tool._run(query="streaming")
+
+        # Should indicate the match was in the description field
+        assert "description" in result.lower() or "matched" in result.lower()
+
+    def test_search_empty_query(self, populated_store):
+        """Empty search query should return an error or all deals."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            SearchPortfolioTool,
+        )
+
+        tool = SearchPortfolioTool(deal_store=populated_store)
+        result = tool._run(query="")
+
+        # Either an error message or returns all deals
+        assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# PortfolioSummaryTool tests
+# ---------------------------------------------------------------------------
+
+
+class TestPortfolioSummaryTool:
+    """Tests for the PortfolioSummaryTool CrewAI tool."""
+
+    def test_summary_empty_portfolio(self, deal_store):
+        """Summary on empty portfolio should report zeros gracefully."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            PortfolioSummaryTool,
+        )
+
+        tool = PortfolioSummaryTool(deal_store=deal_store)
+        result = tool._run(options_json="{}")
+
+        assert "0" in result
+
+    def test_summary_total_deal_count(self, populated_store):
+        """Summary should report total number of deals."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            PortfolioSummaryTool,
+        )
+
+        tool = PortfolioSummaryTool(deal_store=populated_store)
+        result = tool._run(options_json="{}")
+
+        assert "5" in result
+
+    def test_summary_by_status(self, populated_store):
+        """Summary should break down deals by status."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            PortfolioSummaryTool,
+        )
+
+        tool = PortfolioSummaryTool(deal_store=populated_store)
+        result = tool._run(options_json="{}")
+
+        # 2 active, 1 draft, 1 paused, 1 expired
+        assert "active" in result.lower()
+        assert "draft" in result.lower()
+        assert "paused" in result.lower()
+        assert "expired" in result.lower()
+
+    def test_summary_by_media_type(self, populated_store):
+        """Summary should break down deals by media type."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            PortfolioSummaryTool,
+        )
+
+        tool = PortfolioSummaryTool(deal_store=populated_store)
+        result = tool._run(options_json="{}")
+
+        assert "DIGITAL" in result
+        assert "CTV" in result
+        assert "LINEAR_TV" in result
+        assert "AUDIO" in result
+
+    def test_summary_by_deal_type(self, populated_store):
+        """Summary should break down deals by deal type."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            PortfolioSummaryTool,
+        )
+
+        tool = PortfolioSummaryTool(deal_store=populated_store)
+        result = tool._run(options_json="{}")
+
+        assert "PD" in result
+        assert "PG" in result
+        assert "PA" in result
+        assert "UPFRONT" in result
+
+    def test_summary_top_sellers(self, populated_store):
+        """Summary should list top sellers by deal count."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            PortfolioSummaryTool,
+        )
+
+        tool = PortfolioSummaryTool(deal_store=populated_store)
+        result = tool._run(options_json="{}")
+
+        # Should mention some sellers
+        assert "ESPN" in result or "espn.com" in result.lower()
+
+    def test_summary_portfolio_value(self, populated_store):
+        """Summary should calculate total portfolio value."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            PortfolioSummaryTool,
+        )
+
+        tool = PortfolioSummaryTool(deal_store=populated_store)
+        result = tool._run(options_json="{}")
+
+        # Total value = sum of (price * impressions / 1000) for CPM
+        # ESPN: 12.50 * 1,000,000 / 1000 = 12,500
+        # Hulu: 25.00 * 500,000 / 1000 = 12,500
+        # TTD: 8.00 * 2,000,000 / 1000 = 16,000
+        # NBCU: 45.00 * 3,000,000 / 1000 = 135,000
+        # Spotify: 6.00 * 800,000 / 1000 = 4,800
+        # Total = 180,800
+        assert "180,800" in result or "180800" in result
+
+    def test_summary_expiring_deals(self, populated_store):
+        """Summary should report deals expiring within N days if requested."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            PortfolioSummaryTool,
+        )
+
+        tool = PortfolioSummaryTool(deal_store=populated_store)
+        # Check for deals expiring within a very large window (all should be caught)
+        result = tool._run(options_json='{"expiring_within_days": 365}')
+
+        assert "expir" in result.lower()
+
+    def test_summary_invalid_json(self, deal_store):
+        """Handle invalid JSON input gracefully."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            PortfolioSummaryTool,
+        )
+
+        tool = PortfolioSummaryTool(deal_store=deal_store)
+        result = tool._run(options_json="bad json")
+
+        assert "error" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# InspectDealTool tests
+# ---------------------------------------------------------------------------
+
+
+class TestInspectDealTool:
+    """Tests for the InspectDealTool CrewAI tool."""
+
+    def test_inspect_existing_deal(self, populated_store):
+        """Inspect an existing deal by ID."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            InspectDealTool,
+        )
+
+        tool = InspectDealTool(deal_store=populated_store)
+        result = tool._run(deal_id="deal-001")
+
+        assert "ESPN" in result
+        assert "deal-001" in result
+        assert "DIGITAL" in result
+        assert "PD" in result
+        assert "active" in result.lower()
+        assert "12.5" in result
+
+    def test_inspect_deal_shows_metadata(self, populated_store):
+        """Inspect should show portfolio metadata."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            InspectDealTool,
+        )
+
+        tool = InspectDealTool(deal_store=populated_store)
+        result = tool._run(deal_id="deal-001")
+
+        assert "adv-acme" in result
+        assert "CSV" in result
+
+    def test_inspect_deal_shows_activations(self, store_with_related_data):
+        """Inspect should show deal activations."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            InspectDealTool,
+        )
+
+        tool = InspectDealTool(deal_store=store_with_related_data)
+        result = tool._run(deal_id="deal-001")
+
+        assert "TTD" in result
+        assert "DV360" in result
+        assert "ACTIVE" in result
+
+    def test_inspect_deal_shows_performance(self, store_with_related_data):
+        """Inspect should show performance cache data."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            InspectDealTool,
+        )
+
+        tool = InspectDealTool(deal_store=store_with_related_data)
+        result = tool._run(deal_id="deal-001")
+
+        assert "500,000" in result or "500000" in result
+        assert "STABLE" in result
+
+    def test_inspect_nonexistent_deal(self, deal_store):
+        """Inspect a non-existent deal should return a clear message."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            InspectDealTool,
+        )
+
+        tool = InspectDealTool(deal_store=deal_store)
+        result = tool._run(deal_id="nonexistent-deal")
+
+        assert "not found" in result.lower()
+
+    def test_inspect_deal_without_metadata(self, deal_store):
+        """Inspect a deal that has no portfolio_metadata or activations."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            InspectDealTool,
+        )
+
+        # Save a bare deal with no metadata
+        deal_store.save_deal(
+            deal_id="deal-bare",
+            seller_url="https://seller.example.com",
+            product_id="prod-bare",
+            product_name="Bare Deal",
+            display_name="Bare Deal",
+        )
+        tool = InspectDealTool(deal_store=deal_store)
+        result = tool._run(deal_id="deal-bare")
+
+        assert "Bare Deal" in result
+        assert "deal-bare" in result
+
+    def test_inspect_human_readable_format(self, populated_store):
+        """Output should be formatted for agent readability, not raw dicts."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            InspectDealTool,
+        )
+
+        tool = InspectDealTool(deal_store=populated_store)
+        result = tool._run(deal_id="deal-001")
+
+        # Should not look like a raw Python dict
+        assert "{'id'" not in result
+
+
+# ---------------------------------------------------------------------------
+# Tool registration / export tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolExports:
+    """Verify tools are importable and properly exported."""
+
+    def test_import_all_tools(self):
+        """All four tools should be importable from the module."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            InspectDealTool,
+            ListPortfolioTool,
+            PortfolioSummaryTool,
+            SearchPortfolioTool,
+        )
+
+        assert ListPortfolioTool is not None
+        assert SearchPortfolioTool is not None
+        assert PortfolioSummaryTool is not None
+        assert InspectDealTool is not None
+
+    def test_tools_exported_from_deal_jockey_init(self):
+        """Tools should be re-exported from deal_jockey.__init__."""
+        from ad_buyer.tools.deal_jockey import (
+            InspectDealTool,
+            ListPortfolioTool,
+            PortfolioSummaryTool,
+            SearchPortfolioTool,
+        )
+
+        assert ListPortfolioTool is not None
+        assert SearchPortfolioTool is not None
+        assert PortfolioSummaryTool is not None
+        assert InspectDealTool is not None
+
+    def test_tools_are_crewai_base_tools(self, deal_store):
+        """Each tool should be a CrewAI BaseTool subclass."""
+        from crewai.tools import BaseTool
+
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            InspectDealTool,
+            ListPortfolioTool,
+            PortfolioSummaryTool,
+            SearchPortfolioTool,
+        )
+
+        assert issubclass(ListPortfolioTool, BaseTool)
+        assert issubclass(SearchPortfolioTool, BaseTool)
+        assert issubclass(PortfolioSummaryTool, BaseTool)
+        assert issubclass(InspectDealTool, BaseTool)
+
+    def test_tools_have_name_and_description(self, deal_store):
+        """Each tool should have a name and description."""
+        from ad_buyer.tools.deal_jockey.portfolio_inspection import (
+            InspectDealTool,
+            ListPortfolioTool,
+            PortfolioSummaryTool,
+            SearchPortfolioTool,
+        )
+
+        for ToolClass in [
+            ListPortfolioTool,
+            SearchPortfolioTool,
+            PortfolioSummaryTool,
+            InspectDealTool,
+        ]:
+            tool = ToolClass(deal_store=deal_store)
+            assert tool.name
+            assert tool.description


### PR DESCRIPTION
## Summary
- Adds DealJockey phase grouping (Phases 1-4) to PROGRESS.md generator
- Filters out [LEGACY] beads from display
- Groups Phase 1 execution beads alongside imported buyer-te6b.* beads

## Context
46 DealJockey beads migrated from parent repo (ar-te6b.*) to buyer repo (buyer-te6b.*). The generator needed to recognize the new naming pattern and group them into DealJockey phase sections.

## Test plan
- [x] Verified PROGRESS.md regenerates correctly with all phases
- [x] LEGACY beads filtered out
- [x] Phase 1 completed work shows checkmarks

🤖 Generated with [Claude Code](https://claude.com/claude-code)