### PR TITLE
Docs: Phase 2 Campaign Automation guides

### DIFF
--- a/docs/guides/budget-pacing.md
+++ b/docs/guides/budget-pacing.md
@@ -1,13 +1,353 @@
 # Budget Pacing & Reallocation
 
-The budget pacing engine monitors campaign spend against plan in real time, detects over-delivery and under-delivery, and reallocates budget across channels and sellers mid-flight. After a campaign's deals are booked, pacing answers three questions continuously: Are we on pace? What is off? What should we do about it?
+The budget pacing engine monitors campaign spend against plan in real time, detects over-delivery and under-delivery, and proposes cross-channel budget reallocations mid-flight. After a campaign's deals are booked via the [campaign pipeline](campaign-pipeline.md), pacing answers three questions continuously: **Are we on pace? What is off? What should we do about it?**
 
-!!! info "Coming Soon --- Phase 2"
-    Budget pacing and reallocation is part of Phase 2: Campaign Intelligence. It depends on the [Campaign Brief to Deal Pipeline](campaign-pipeline.md).
+The pacing engine is implemented by `BudgetPacingEngine` in `ad_buyer.pacing.engine`. Snapshots are persisted by `PacingStore` in `ad_buyer.storage.pacing_store`, and pacing events flow through the [event bus](../event-bus/overview.md).
+
+---
+
+## How It Works
+
+The engine uses a **linear pacing model**: expected spend at any point is proportional to the fraction of the flight window that has elapsed. It calculates pacing at three levels --- campaign, channel, and deal --- and generates reallocation recommendations when channels deviate from plan.
+
+```mermaid
+flowchart LR
+    Spend["Collect\nSpend Data"]
+    Calculate["Calculate\nExpected vs Actual"]
+    Detect["Detect\nDeviations"]
+    Recommend["Propose\nReallocations"]
+    Snapshot["Save\nSnapshot"]
+
+    Spend --> Calculate --> Detect --> Recommend --> Snapshot
+```
+
+---
+
+## Quick Example
+
+```python
+from datetime import datetime, timezone
+from ad_buyer.pacing.engine import BudgetPacingEngine, PacingConfig
+from ad_buyer.storage.pacing_store import PacingStore
+from ad_buyer.events.bus import InMemoryEventBus
+
+# Setup
+engine = BudgetPacingEngine(
+    config=PacingConfig(),
+    event_bus=InMemoryEventBus(),
+)
+
+store = PacingStore("sqlite:///./ad_buyer.db")
+store.connect()
+
+# Generate a pacing snapshot
+snapshot = engine.generate_snapshot(
+    campaign_id="campaign-abc",
+    total_budget=150_000.0,
+    flight_start=datetime(2026, 7, 1, tzinfo=timezone.utc),
+    flight_end=datetime(2026, 9, 30, tzinfo=timezone.utc),
+    current_time=datetime(2026, 8, 15, tzinfo=timezone.utc),
+    channel_data={
+        "CTV": {"allocated_budget": 75_000, "spend": 30_000, "impressions": 1_200_000},
+        "DISPLAY": {"allocated_budget": 45_000, "spend": 28_000, "impressions": 2_800_000},
+        "AUDIO": {"allocated_budget": 30_000, "spend": 10_000, "impressions": 600_000},
+    },
+    deal_data=[
+        {"deal_id": "deal-001", "allocated_budget": 40_000, "spend": 16_000},
+        {"deal_id": "deal-002", "allocated_budget": 35_000, "spend": 14_000},
+    ],
+)
+
+# Inspect results
+print(f"Campaign pacing: {snapshot.pacing_pct:.1f}%")
+print(f"Deviation: {snapshot.deviation_pct:+.1f}%")
+
+for ch in snapshot.channel_snapshots:
+    print(f"  {ch.channel}: {ch.pacing_pct:.1f}% paced, ${ch.spend:,.0f} spent")
+
+for rec in snapshot.recommendations:
+    print(f"  Recommend: move ${rec.amount:,.0f} from {rec.source_channel} to {rec.target_channel}")
+
+# Persist the snapshot
+store.save_pacing_snapshot(snapshot)
+```
+
+---
+
+## Pacing Calculations
+
+### Expected Spend (Linear Model)
+
+Expected spend at any point in the campaign is:
+
+```
+expected_spend = total_budget * (elapsed_time / total_flight_duration)
+```
+
+The engine clamps the calculation to the flight window --- before the start date, expected spend is zero; after the end date, expected spend equals the total budget.
+
+```python
+expected = engine.calculate_expected_spend(
+    total_budget=150_000.0,
+    flight_start=datetime(2026, 7, 1, tzinfo=timezone.utc),
+    flight_end=datetime(2026, 9, 30, tzinfo=timezone.utc),
+    current_time=datetime(2026, 8, 15, tzinfo=timezone.utc),
+)
+# expected ≈ 73,770 (about 49.2% of flight elapsed)
+```
+
+### Pacing Percentage
+
+Pacing percentage is `(actual_spend / expected_spend) * 100`:
+
+| Value | Meaning |
+|-------|---------|
+| 100% | Exactly on pace |
+| < 100% | Underpacing (spending slower than planned) |
+| > 100% | Overpacing (spending faster than planned) |
+
+```python
+pacing = engine.calculate_pacing_pct(actual_spend=68_000, expected_spend=73_770)
+# pacing ≈ 92.2% (slightly underpacing)
+```
+
+### Deviation Percentage
+
+Deviation is `pacing_pct - 100`. Negative means underpacing, positive means overpacing:
+
+```python
+deviation = engine.calculate_deviation_pct(actual_spend=68_000, expected_spend=73_770)
+# deviation ≈ -7.8%
+```
+
+---
+
+## Deviation Detection
+
+The engine detects pacing deviations at two severity levels, for both underpacing and overpacing:
+
+| Direction | Warning Threshold | Critical Threshold |
+|-----------|------------------:|-----------------:|
+| Underpacing | > 10% below expected | > 25% below expected |
+| Overpacing | > 10% above expected | > 25% above expected |
+
+!!! tip "Configuring thresholds"
+    All thresholds are configurable via `PacingConfig`:
+
+    ```python
+    config = PacingConfig(
+        underpacing_warning_pct=10.0,
+        underpacing_critical_pct=25.0,
+        overpacing_warning_pct=10.0,
+        overpacing_critical_pct=25.0,
+    )
+    ```
+
+When a deviation exceeds a threshold, `detect_deviation()` returns a `PacingAlert`:
+
+```python
+alert = engine.detect_deviation(actual_spend=50_000, expected_spend=73_770)
+# alert.level = "warning"
+# alert.direction = "underpacing"
+# alert.deviation_pct ≈ -32.2
+# alert.message = "Critical underpacing: -32.2% deviation (threshold: -25.0%)"
+```
+
+Alerts at the **critical** level indicate the campaign is severely off-pace and likely needs intervention. Warning-level alerts are informational --- the campaign is drifting but may self-correct.
+
+---
+
+## Cross-Channel Budget Reallocation
+
+When the pacing engine detects that some channels are underpacing while others are overpacing, it proposes **budget reallocations** --- shifting money from underperforming channels to channels that are spending efficiently.
+
+### How Proposals Are Generated
+
+1. For each channel, the engine calculates expected spend proportionally: `channel_expected = campaign_expected * (channel_budget / total_budget)`
+2. Channels deviating below the underpacing warning threshold are classified as **sources** (potential budget donors)
+3. Channels deviating above the overpacing warning threshold are classified as **targets** (budget recipients)
+4. For each source-target pair, the reallocation amount is the minimum of the source's underspend, the target's overspend, and the max reallocation cap
+
+### Reallocation Constraints
+
+| Constraint | Default | Description |
+|-----------|---------|-------------|
+| `min_reallocation_amount` | $100 | Amounts below this are not worth the operational cost |
+| `max_reallocation_pct` | 30% | Maximum percentage of total budget that can be reallocated in a single proposal |
+
+```python
+config = PacingConfig(
+    min_reallocation_amount=500.0,   # Only propose if $500+
+    max_reallocation_pct=20.0,       # Cap at 20% of total budget
+)
+```
+
+### Proposal Data Model
+
+Each `ReallocationProposal` contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `source_channel` | `str` | Channel to take budget from (underpacing) |
+| `target_channel` | `str` | Channel to give budget to (overpacing) |
+| `amount` | `float` | Dollar amount to reallocate |
+| `reason` | `str` | Human-readable justification |
+
+```python
+proposals = engine.propose_reallocations(
+    channel_snapshots=snapshot.channel_snapshots,
+    total_budget=150_000.0,
+    expected_spend=73_770.0,
+)
+
+for p in proposals:
+    print(f"Move ${p.amount:,.0f} from {p.source_channel} to {p.target_channel}")
+    print(f"  Reason: {p.reason}")
+```
+
+!!! warning "Proposals require approval"
+    Reallocation proposals are **recommendations**, not automatic actions. By default, the `PACING_ADJUSTMENT` approval stage is disabled, meaning proposals can be applied automatically. Enable it in the campaign brief's `approval_config` to require human sign-off before budget is moved.
+
+---
+
+## Deal-Level Pacing
+
+In addition to campaign and channel-level pacing, the engine tracks pacing for individual deals:
+
+```python
+from ad_buyer.models.campaign import DealSnapshot
+
+deal_pacing = engine.calculate_deal_pacing(
+    deal_snapshot=DealSnapshot(
+        deal_id="deal-001",
+        allocated_budget=40_000,
+        spend=16_000,
+        impressions=640_000,
+        effective_cpm=25.0,
+    ),
+    flight_start=datetime(2026, 7, 1, tzinfo=timezone.utc),
+    flight_end=datetime(2026, 9, 30, tzinfo=timezone.utc),
+    current_time=datetime(2026, 8, 15, tzinfo=timezone.utc),
+)
+
+print(f"Deal {deal_pacing['deal_id']}: {deal_pacing['pacing_pct']:.1f}% paced")
+print(f"  Expected: ${deal_pacing['expected_spend']:,.0f}")
+print(f"  Actual: ${deal_pacing['actual_spend']:,.0f}")
+if deal_pacing["alert"]:
+    print(f"  Alert: {deal_pacing['alert'].message}")
+```
+
+---
+
+## Pacing Snapshots
+
+A `PacingSnapshot` is a point-in-time capture of the entire campaign's pacing state. The `generate_snapshot()` method produces one by computing pacing at all three levels and generating any applicable recommendations.
+
+### Snapshot Data Model
+
+```python
+class PacingSnapshot(BaseModel):
+    snapshot_id: str            # UUID
+    campaign_id: str
+    timestamp: datetime
+    total_budget: float
+    total_spend: float
+    pacing_pct: float           # Campaign-level pacing %
+    expected_spend: float
+    deviation_pct: float        # Positive = overpacing, negative = underpacing
+    channel_snapshots: list[ChannelSnapshot]
+    deal_snapshots: list[DealSnapshot]
+    recommendations: list[PacingRecommendation]
+```
+
+Each `ChannelSnapshot` captures:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `channel` | `str` | Channel name (CTV, DISPLAY, etc.) |
+| `allocated_budget` | `float` | Budget allocated to this channel |
+| `spend` | `float` | Actual spend to date |
+| `pacing_pct` | `float` | Channel pacing percentage |
+| `impressions` | `int` | Impressions delivered |
+| `effective_cpm` | `float` | Blended CPM |
+| `fill_rate` | `float` | Fill rate (0.0 to 1.0) |
+
+Each `DealSnapshot` adds `deal_id`, `win_rate`, and the same spend/impression metrics.
+
+### Persistence
+
+Snapshots are persisted via `PacingStore`, a SQLite-backed store with the same thread-safety pattern as `DealStore`:
+
+```python
+from ad_buyer.storage.pacing_store import PacingStore
+
+store = PacingStore("sqlite:///./ad_buyer.db")
+store.connect()
+
+# Save
+store.save_pacing_snapshot(snapshot)
+
+# Retrieve latest
+latest = store.get_latest_pacing_snapshot("campaign-abc")
+
+# List with time filter
+from datetime import datetime, timezone
+snapshots = store.list_pacing_snapshots(
+    campaign_id="campaign-abc",
+    start_time=datetime(2026, 8, 1, tzinfo=timezone.utc),
+    end_time=datetime(2026, 8, 15, tzinfo=timezone.utc),
+)
+```
+
+The `pacing_snapshots` table is indexed on `campaign_id` and `timestamp` for efficient time-series queries.
+
+---
+
+## Events Emitted
+
+The pacing engine emits three event types:
+
+| Event | When | Payload |
+|-------|------|---------|
+| `pacing.snapshot_taken` | After every snapshot generation | `snapshot_id`, budget/spend/pacing metrics, channel and deal counts |
+| `pacing.deviation_detected` | When campaign-level deviation exceeds a threshold | `alert_level`, `direction`, `deviation_pct`, `message` |
+| `pacing.reallocation_recommended` | For each reallocation proposal | `source_channel`, `target_channel`, `amount`, `reason` |
+
+Subscribe to these events to build dashboards, trigger alerts, or automate reallocation approval workflows.
+
+---
+
+## Integration with the Campaign Lifecycle
+
+Budget pacing operates on campaigns that have reached **ACTIVE** status. The typical flow:
+
+1. Campaign pipeline books deals and moves campaign to READY
+2. Campaign is activated (manually or on flight start date) --- status becomes ACTIVE
+3. Pacing engine begins generating snapshots at regular intervals
+4. If deviation exceeds the critical threshold, the state machine can transition the campaign to **PACING_HOLD** --- an automated hold distinct from manual PAUSED
+5. When deviation resolves, PACING_HOLD auto-transitions back to ACTIVE
+6. If it does not resolve, it can be escalated to PAUSED for manual intervention
+
+---
+
+## Configuration Reference
+
+`PacingConfig` controls all engine behavior:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `underpacing_warning_pct` | 10.0 | Warning threshold for underpacing |
+| `underpacing_critical_pct` | 25.0 | Critical threshold for underpacing |
+| `overpacing_warning_pct` | 10.0 | Warning threshold for overpacing |
+| `overpacing_critical_pct` | 25.0 | Critical threshold for overpacing |
+| `min_reallocation_amount` | 100.0 | Minimum amount for a reallocation proposal |
+| `max_reallocation_pct` | 30.0 | Max percentage of total budget per proposal |
+
+---
 
 ## Related
 
 - [Campaign Brief to Deal Pipeline](campaign-pipeline.md) --- Initial campaign setup (pacing monitors what the pipeline books)
 - [Deals API](../api/deals.md) --- Deal status and modification endpoints
 - [Multi-Seller Orchestration](multi-seller-orchestration.md) --- Cross-seller portfolio management
-- [Seller Agent Docs](https://iabtechlab.github.io/seller-agent/) --- Seller-side deal management
+- [Architecture Overview](../architecture/overview.md) --- Agent hierarchy and system design

--- a/docs/guides/campaign-pipeline.md
+++ b/docs/guides/campaign-pipeline.md
@@ -1,15 +1,373 @@
 # Campaign Brief to Deal Pipeline
 
-The campaign pipeline transforms a structured **campaign brief** into **booked deals** --- automating the entire workflow from audience planning through inventory discovery, pricing, negotiation, and booking. Hand the buyer agent a brief describing what you want to achieve, and it returns a portfolio of booked deals that satisfy the brief's objectives.
+The campaign pipeline transforms a structured **campaign brief** into **booked deals** --- automating the entire workflow from brief ingestion through channel planning, multi-seller deal orchestration, and campaign finalization. Hand the buyer agent a brief describing what you want to achieve, and it returns a portfolio of booked deals that satisfy the brief's objectives.
 
-!!! info "Coming Soon --- Phase 2"
-    The campaign pipeline is part of Phase 2: Campaign Intelligence. The foundation it builds on --- authentication, seller discovery, media kit browsing, negotiation, and the deals API --- is all shipped and documented.
+The pipeline is implemented by `CampaignPipeline` in `ad_buyer.pipelines.campaign_pipeline`. It coordinates the campaign brief parser, campaign store (state persistence), multi-seller orchestrator (deal booking), and event bus (lifecycle events) across four stages.
 
-The pipeline orchestrates five stages: audience planning, inventory discovery across multiple sellers, pricing and negotiation, portfolio optimization, and deal booking. It builds on the existing [Multi-Seller Discovery](multi-seller.md), [Deals API](../api/deals.md), and [Negotiation](negotiation.md) capabilities.
+---
+
+## Pipeline Stages
+
+```mermaid
+flowchart LR
+    Ingest["1. Ingest Brief\n(DRAFT)"]
+    Plan["2. Plan Campaign\n(PLANNING)"]
+    Book["3. Execute Booking\n(BOOKING)"]
+    Ready["4. Finalize\n(READY)"]
+
+    Ingest --> Plan --> Book --> Ready
+```
+
+Each stage transitions the campaign through the [campaign automation state machine](../state-machines/order-lifecycle.md):
+
+| Stage | Method | Status Transition | What Happens |
+|-------|--------|-------------------|-------------|
+| **Ingest** | `ingest_brief()` | &rarr; DRAFT | Parse and validate the brief, create campaign record |
+| **Plan** | `plan_campaign()` | DRAFT &rarr; PLANNING | Compute per-channel budget allocations and deal types |
+| **Book** | `execute_booking()` | PLANNING &rarr; BOOKING | Run multi-seller orchestration for each channel |
+| **Finalize** | `finalize()` | BOOKING &rarr; READY | Mark campaign ready for activation |
+
+You can call each stage independently or use `pipeline.run(brief)` to execute all four in sequence.
+
+---
+
+## The Campaign Brief
+
+The campaign brief is a structured JSON document that describes what an advertiser wants to achieve. It is validated against a Pydantic schema (`CampaignBrief`) before the pipeline accepts it.
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `advertiser_id` | `str` | Advertiser identifier |
+| `campaign_name` | `str` | Human-readable campaign name |
+| `objective` | `str` | `AWARENESS`, `CONSIDERATION`, `CONVERSION`, or `REACH` |
+| `total_budget` | `float` | Total campaign budget (must be > 0) |
+| `currency` | `str` | ISO 4217 currency code (e.g. `USD`) |
+| `flight_start` | `date` | Campaign start date (`YYYY-MM-DD`) |
+| `flight_end` | `date` | Campaign end date (must be after start) |
+| `channels` | `list` | Channel allocations (at least one; budget percentages must sum to 100) |
+| `target_audience` | `list[str]` | IAB Audience Taxonomy segment IDs |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agency_id` | `str` | Agency identifier |
+| `description` | `str` | Campaign objective/notes |
+| `target_geo` | `list` | Geographic targeting (country, state, DMA, metro, zip) |
+| `kpis` | `list` | Performance targets (CPM, CPC, CPCV, CTR, VCR, ROAS, GRP) |
+| `brand_safety` | `object` | Content exclusions (categories, keywords) |
+| `frequency_cap` | `object` | Cross-channel frequency cap (max impressions per period) |
+| `pacing_model` | `str` | `EVEN` (default), `FRONT_LOADED`, `BACK_LOADED`, or `CUSTOM` |
+| `preferred_sellers` | `list[str]` | Seller IDs to prioritize |
+| `excluded_sellers` | `list[str]` | Seller IDs to avoid |
+| `creative_ids` | `list[str]` | Pre-uploaded creative asset IDs |
+| `approval_config` | `object` | Human approval gates per stage |
+| `deal_preferences` | `object` | Preferred deal types and max CPM |
+| `exclusion_list` | `list[str]` | Domains/brands to exclude |
+| `notes` | `str` | Free-text notes |
+
+### Channel Allocations
+
+Each entry in the `channels` array specifies a channel and its share of the total budget:
+
+```json
+{
+  "channels": [
+    {"channel": "CTV", "budget_pct": 50, "format_prefs": ["pre-roll", "mid-roll"]},
+    {"channel": "DISPLAY", "budget_pct": 30, "format_prefs": ["300x250", "728x90"]},
+    {"channel": "AUDIO", "budget_pct": 20, "format_prefs": ["30s"]}
+  ]
+}
+```
+
+Supported channel types: `CTV`, `DISPLAY`, `AUDIO`, `NATIVE`, `DOOH`, `LINEAR_TV`.
+
+!!! warning "Budget percentages must sum to 100"
+    The brief validator rejects briefs where channel `budget_pct` values do not sum to exactly 100. Duplicate channel types are also rejected.
+
+### Example Brief
+
+```json
+{
+  "advertiser_id": "acme-corp",
+  "campaign_name": "Q3 Brand Awareness",
+  "objective": "AWARENESS",
+  "total_budget": 150000,
+  "currency": "USD",
+  "flight_start": "2026-07-01",
+  "flight_end": "2026-09-30",
+  "channels": [
+    {"channel": "CTV", "budget_pct": 50, "format_prefs": ["pre-roll"]},
+    {"channel": "DISPLAY", "budget_pct": 30},
+    {"channel": "AUDIO", "budget_pct": 20}
+  ],
+  "target_audience": ["IAB-AUD-1234", "IAB-AUD-5678"],
+  "target_geo": [
+    {"geo_type": "COUNTRY", "geo_value": "US"}
+  ],
+  "kpis": [
+    {"metric": "CPM", "target_value": 15.0},
+    {"metric": "VCR", "target_value": 75.0}
+  ],
+  "brand_safety": {
+    "excluded_categories": ["IAB25", "IAB26"],
+    "excluded_keywords": ["gambling", "tobacco"]
+  },
+  "pacing_model": "EVEN",
+  "excluded_sellers": ["seller-block-123"],
+  "deal_preferences": {
+    "preferred_deal_types": ["PG", "PD"],
+    "max_cpm": 35.0
+  },
+  "approval_config": {
+    "plan_review": true,
+    "booking": true,
+    "creative": false,
+    "pacing_adjustment": false
+  }
+}
+```
+
+---
+
+## Quick Example
+
+### End-to-End (All Stages)
+
+```python
+from ad_buyer.pipelines.campaign_pipeline import CampaignPipeline
+from ad_buyer.orchestration.multi_seller import MultiSellerOrchestrator
+from ad_buyer.storage.campaign_store import CampaignStore
+from ad_buyer.events.bus import InMemoryEventBus
+
+# Setup
+store = CampaignStore("sqlite:///./ad_buyer.db")
+store.connect()
+bus = InMemoryEventBus()
+
+orchestrator = MultiSellerOrchestrator(
+    registry_client=registry,
+    deals_client_factory=deals_factory,
+    event_bus=bus,
+)
+
+pipeline = CampaignPipeline(
+    store=store,
+    orchestrator=orchestrator,
+    event_bus=bus,
+)
+
+# Run the full pipeline
+summary = await pipeline.run({
+    "advertiser_id": "acme-corp",
+    "campaign_name": "Q3 Brand Awareness",
+    "objective": "AWARENESS",
+    "total_budget": 150000,
+    "currency": "USD",
+    "flight_start": "2026-07-01",
+    "flight_end": "2026-09-30",
+    "channels": [
+        {"channel": "CTV", "budget_pct": 50},
+        {"channel": "DISPLAY", "budget_pct": 30},
+        {"channel": "AUDIO", "budget_pct": 20},
+    ],
+    "target_audience": ["IAB-AUD-1234"],
+})
+
+print(f"Campaign: {summary['campaign_id']}")
+print(f"Status: {summary['status']}")  # "ready"
+for ch, info in summary["channels"].items():
+    print(f"  {ch}: {info['deals_booked']} deals, ${info['total_spend']:,.2f} spend")
+```
+
+### Stage-by-Stage
+
+For more control, call each stage independently:
+
+```python
+# Stage 1: Ingest brief
+campaign_id = await pipeline.ingest_brief(brief_json)
+
+# Stage 2: Plan (creates per-channel allocations)
+plan = await pipeline.plan_campaign(campaign_id)
+for cp in plan.channel_plans:
+    print(f"  {cp.channel.value}: ${cp.budget:,.2f} ({cp.budget_pct}%)")
+
+# Stage 3: Book deals (runs multi-seller orchestration per channel)
+results = await pipeline.execute_booking(campaign_id)
+for ch, result in results.items():
+    print(f"  {ch}: {len(result.selection.booked_deals)} deals booked")
+
+# Stage 4: Finalize
+await pipeline.finalize(campaign_id)
+```
+
+---
+
+## Stage Details
+
+### Stage 1: Ingest Brief
+
+`ingest_brief()` accepts a campaign brief as either a JSON string or a Python dict. It:
+
+1. **Parses and validates** the brief using the `CampaignBrief` Pydantic model. Invalid JSON raises `ValueError`; schema violations raise `pydantic.ValidationError`.
+2. **Computes budget amounts** --- Each channel's `budget_amount` is calculated from `total_budget * budget_pct / 100`.
+3. **Creates a campaign record** in the `CampaignStore` in DRAFT status.
+4. **Emits** a `campaign.created` event.
+
+### Stage 2: Plan Campaign
+
+`plan_campaign()` transitions the campaign from DRAFT to PLANNING and produces a `CampaignPlan` with per-channel `ChannelPlan` entries.
+
+For each channel in the brief, the planner determines:
+
+- **Media type** for seller discovery (e.g., CTV maps to `"ctv"`, DISPLAY maps to `"display"`)
+- **Deal types** to request (e.g., CTV defaults to `["PG", "PD"]`, DISPLAY to `["PD", "PA"]`)
+- **Budget** allocated from the total
+- **Format preferences** from the brief
+
+The channel-to-deal-type mapping:
+
+| Channel | Default Deal Types |
+|---------|-------------------|
+| CTV | PG, PD |
+| DISPLAY | PD, PA |
+| AUDIO | PD, PA |
+| NATIVE | PD, PA |
+| DOOH | PG, PD |
+| LINEAR_TV | PG |
+
+### Stage 3: Execute Booking
+
+`execute_booking()` transitions the campaign from PLANNING to BOOKING and calls the [MultiSellerOrchestrator](multi-seller-orchestration.md) once per channel.
+
+For each channel plan, the pipeline:
+
+1. Builds an `InventoryRequirements` from the channel's media type, deal types, and the brief's excluded sellers and max CPM
+2. Constructs `DealParams` with estimated impressions (derived from channel budget at an assumed $15 CPM)
+3. Calls `orchestrator.orchestrate()` with the channel's budget and a max of 3 deals per channel
+4. Collects the `OrchestrationResult`
+
+If a channel's orchestration fails, the error is logged and an empty result is recorded for that channel --- other channels proceed normally. After all channels complete, the pipeline emits a `campaign.booking_completed` event with a summary.
+
+### Stage 4: Finalize
+
+`finalize()` transitions the campaign from BOOKING to READY and emits a `campaign.ready` event. The campaign is now prepared for activation --- it awaits its flight start date or manual activation to move to ACTIVE status.
+
+---
+
+## Campaign State Machine
+
+The pipeline drives the campaign through a formal state machine. After the pipeline completes, the campaign is in READY. From there, it can be activated and managed through its full lifecycle:
+
+```mermaid
+stateDiagram-v2
+    [*] --> DRAFT
+    DRAFT --> PLANNING : plan_campaign()
+    PLANNING --> BOOKING : execute_booking()
+    BOOKING --> READY : finalize()
+    READY --> ACTIVE : activate (auto or manual)
+    ACTIVE --> COMPLETED : flight end
+    ACTIVE --> PAUSED : manual pause
+    ACTIVE --> PACING_HOLD : automated pacing threshold
+    PAUSED --> ACTIVE : resume
+    PACING_HOLD --> ACTIVE : deviation resolved
+    PACING_HOLD --> PAUSED : escalate to manual
+
+    PLANNING --> CANCELED : cancel
+    BOOKING --> CANCELED : cancel
+    READY --> CANCELED : cancel
+    ACTIVE --> CANCELED : cancel
+    PAUSED --> CANCELED : cancel
+    PACING_HOLD --> CANCELED : cancel
+
+    BOOKING --> PLANNING : replan
+    READY --> PLANNING : replan
+```
+
+!!! info "PAUSED vs PACING_HOLD"
+    **PAUSED** is a manual hold --- a human decided to pause the campaign. **PACING_HOLD** is an automated hold triggered by the [pacing engine](budget-pacing.md) when spend deviation exceeds a configurable threshold. PACING_HOLD can auto-resolve back to ACTIVE or be escalated to PAUSED.
+
+---
+
+## Human Approval Gates
+
+The pipeline supports configurable human approval gates at four stages, controlled by the brief's `approval_config`:
+
+| Stage | Default | Controls |
+|-------|---------|----------|
+| `plan_review` | **Enabled** | Approval after plan generation, before booking |
+| `booking` | **Enabled** | Approval after deals selected, before committing budget |
+| `creative` | Disabled | Approval after creative matched, before ad server push |
+| `pacing_adjustment` | Disabled | Approval after pacing reallocation recommended |
+
+Set all to `false` in the brief for fully automated execution:
+
+```json
+{
+  "approval_config": {
+    "plan_review": false,
+    "booking": false,
+    "creative": false,
+    "pacing_adjustment": false
+  }
+}
+```
+
+The `ApprovalGate` class integrates with the `CampaignStore` to persist approval requests and emits `approval.requested`, `approval.granted`, and `approval.rejected` events. See the `ad_buyer.pipelines.approval` module for full details.
+
+---
+
+## Events Emitted
+
+The pipeline emits these events across its lifecycle:
+
+| Event | Stage | Payload |
+|-------|-------|---------|
+| `campaign.created` | Ingest | `campaign_name`, `advertiser_id`, `total_budget`, `channels` |
+| `campaign.plan_generated` | Plan | Channel details with budget, media type, and deal types |
+| `campaign.booking_started` | Book | (no payload) |
+| `campaign.booking_completed` | Book | `channels_booked`, `total_deals`, `total_spend`, per-channel summary |
+| `campaign.ready` | Finalize | `campaign_id` |
+
+---
+
+## Persistence
+
+Campaign state is persisted in SQLite via `CampaignStore`. The store manages six tables:
+
+| Table | Purpose |
+|-------|---------|
+| `campaigns` | Core campaign records (brief fields, status, timestamps) |
+| `pacing_snapshots` | Periodic pacing data points |
+| `creative_assets` | Creative files and metadata |
+| `ad_server_campaigns` | Ad server integration records |
+| `campaign_events` | Lifecycle event audit trail |
+| `approval_requests` | Human approval gate requests |
+
+All status transitions are validated by the `CampaignAutomationStateMachine` before being persisted, ensuring the campaign never enters an invalid state.
+
+---
+
+## Tips
+
+**Start with the brief schema.** The most common pipeline error is a malformed brief. Validate your brief structure against the `CampaignBrief` model before calling the pipeline --- the `parse_campaign_brief()` function gives clear validation errors.
+
+**Use stage-by-stage for debugging.** If the pipeline produces unexpected results, call each stage individually and inspect the intermediate outputs: the `CampaignPlan` from `plan_campaign()` and the per-channel `OrchestrationResult` from `execute_booking()`.
+
+**Watch the events.** Subscribe to the event bus to monitor pipeline progress in real time. The `campaign.booking_completed` event gives you a per-channel breakdown of deals booked, spend, and failures.
+
+**Budget estimation.** The pipeline estimates impressions from budget using an assumed $15 CPM. This is a planning heuristic --- actual CPMs depend on what the sellers quote.
+
+---
 
 ## Related
 
 - [Multi-Seller Discovery](multi-seller.md) --- Manual multi-seller workflow (the pipeline automates this)
+- [Multi-Seller Orchestration](multi-seller-orchestration.md) --- The orchestration engine the pipeline calls internally
 - [Deals API](../api/deals.md) --- The underlying quote-then-book API
 - [Budget Pacing & Reallocation](budget-pacing.md) --- Mid-flight budget management (builds on the pipeline)
 - [Negotiation](negotiation.md) --- Automated multi-turn price negotiation
+- [Deal Booking](deal-booking.md) --- Lower-level booking flow details

--- a/docs/guides/creative-management.md
+++ b/docs/guides/creative-management.md
@@ -1,15 +1,327 @@
 # Creative Management
 
-The Creative Agent is a Level 3 sub-agent in the buyer's [agent hierarchy](../architecture/overview.md) responsible for managing creative assets throughout their lifecycle. It validates creative specs against IAB standards, manages creative rotation and A/B testing, and enforces compliance requirements before creatives are attached to deals.
+Creative management covers the lifecycle of ad creative assets within the buyer system --- from uploading and storing assets, through format validation against IAB standards, to binding creatives to deals on external ad servers. The system tracks creative assets per campaign, validates them before they can be attached to deals, and maintains integration records with ad server platforms like Innovid and Flashtalking.
 
-!!! info "Coming Soon --- Phase 2"
-    The Creative Management sub-agent is part of Phase 2: Campaign Intelligence. This capability is independent of the deal flow track and has no Phase 1 dependencies.
+---
 
-The Creative Agent handles three core responsibilities: spec validation (verifying creatives conform to IAB standards for display, VAST/VPAID, and SIMID formats), creative organization (libraries, rotation rules, and A/B test configurations), and compliance enforcement (brand safety, publisher restrictions, and regulatory requirements).
+## Core Concepts
+
+### Creative Assets
+
+A `CreativeAsset` represents a single ad creative --- a display banner, video, audio clip, interactive unit, or native ad. Each asset belongs to a campaign and carries metadata about its format, validation status, and source location.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `asset_id` | `str` | Unique identifier (UUID, auto-generated) |
+| `campaign_id` | `str` | The campaign this asset belongs to |
+| `asset_name` | `str` | Human-readable name |
+| `asset_type` | `AssetType` | `display`, `video`, `audio`, `interactive`, or `native` |
+| `format_spec` | `dict` | Format-specific metadata (varies by type) |
+| `source_url` | `str` | URL where the creative file is hosted |
+| `validation_status` | `ValidationStatus` | `pending`, `valid`, or `invalid` |
+| `validation_errors` | `list[str]` | Validation error/warning messages |
+| `created_at` | `datetime` | When the asset was created |
+
+### Asset Types
+
+The system supports five asset types, each with its own format specification structure:
+
+| Type | `asset_type` | Typical `format_spec` Fields |
+|------|-------------|------------------------------|
+| Display | `display` | `width`, `height`, `file_format` (e.g., `{"width": 300, "height": 250, "file_format": "png"}`) |
+| Video | `video` | `duration_sec`, `vast_version`, `resolution` (e.g., `{"duration_sec": 30, "vast_version": "4.2", "resolution": "1920x1080"}`) |
+| Audio | `audio` | `duration_sec`, `bitrate`, `file_format` (e.g., `{"duration_sec": 30, "bitrate": 192, "file_format": "mp3"}`) |
+| Interactive | `interactive` | `width`, `height`, `simid_version` (e.g., `{"width": 300, "height": 250, "simid_version": "1.1"}`) |
+| Native | `native` | `headline_length`, `body_length`, `image_dimensions` |
+
+### Validation Status
+
+Every asset starts in `pending` status and must pass validation before it can be attached to a deal:
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending : asset created
+    pending --> valid : passes IAB spec check
+    pending --> invalid : fails IAB spec check
+    invalid --> pending : re-upload / fix
+```
+
+---
+
+## Working with Creative Assets
+
+### Creating Assets
+
+Use `CampaignStore` to create and manage creative assets:
+
+```python
+from ad_buyer.storage.campaign_store import CampaignStore
+import json
+
+store = CampaignStore("sqlite:///./ad_buyer.db")
+store.connect()
+
+# Create a display creative
+asset_id = store.save_creative_asset(
+    campaign_id="campaign-abc",
+    asset_name="Q3 Hero Banner 300x250",
+    asset_type="display",
+    format_spec=json.dumps({
+        "width": 300,
+        "height": 250,
+        "file_format": "png",
+        "file_size_kb": 45,
+    }),
+    source_url="https://cdn.example.com/creatives/hero-300x250.png",
+)
+
+# Create a video creative
+video_id = store.save_creative_asset(
+    campaign_id="campaign-abc",
+    asset_name="Q3 Brand Spot 30s",
+    asset_type="video",
+    format_spec=json.dumps({
+        "duration_sec": 30,
+        "vast_version": "4.2",
+        "resolution": "1920x1080",
+        "codec": "h264",
+        "bitrate_kbps": 5000,
+    }),
+    source_url="https://cdn.example.com/creatives/brand-spot-30s.mp4",
+)
+```
+
+### Listing and Filtering
+
+```python
+# List all creatives for a campaign
+assets = store.list_creative_assets(campaign_id="campaign-abc")
+for a in assets:
+    print(f"  {a['asset_name']} ({a['asset_type']}) - {a['validation_status']}")
+
+# Filter by asset type
+video_assets = store.list_creative_assets(
+    campaign_id="campaign-abc",
+    asset_type="video",
+)
+```
+
+### Updating Validation Status
+
+After running spec validation, update the asset's status:
+
+```python
+# Mark as valid
+store.update_creative_asset(
+    asset_id=asset_id,
+    validation_status="valid",
+)
+
+# Mark as invalid with errors
+store.update_creative_asset(
+    asset_id=video_id,
+    validation_status="invalid",
+    validation_errors=json.dumps([
+        "Video duration 45s exceeds maximum 30s for pre-roll placement",
+        "Missing VPAID companion banner",
+    ]),
+)
+```
+
+---
+
+## Using the CreativeAsset Model
+
+For programmatic use outside the store's dict-based interface, the `CreativeAsset` dataclass provides serialization helpers:
+
+```python
+from ad_buyer.models.creative_asset import CreativeAsset, AssetType, ValidationStatus
+
+# Create from code
+asset = CreativeAsset(
+    campaign_id="campaign-abc",
+    asset_name="Q3 Hero Banner",
+    asset_type=AssetType.DISPLAY,
+    format_spec={"width": 300, "height": 250, "file_format": "png"},
+    source_url="https://cdn.example.com/creatives/hero.png",
+)
+
+# Serialize to dict (for JSON encoding, API responses, etc.)
+asset_dict = asset.to_dict()
+
+# Reconstruct from dict
+restored = CreativeAsset.from_dict(asset_dict)
+```
+
+---
+
+## Ad Server Integration
+
+After creatives are validated, they need to be trafficked to an external ad server for delivery. The buyer system supports integration with **Innovid** and **Flashtalking** through the ad server campaign binding model.
+
+### How It Works
+
+An `AdServerCampaign` record links a buyer campaign to its representation on the ad server. Within that record, `AdServerBinding` entries map individual deal + creative pairs to ad server line items.
+
+```mermaid
+flowchart TD
+    Campaign["Buyer Campaign"]
+    ASC["AdServerCampaign\n(Innovid or Flashtalking)"]
+    B1["Binding: deal-001 + creative-A\n→ ad server line 12345"]
+    B2["Binding: deal-002 + creative-B\n→ ad server line 12346"]
+    Delivery["AdServerDelivery\n(impressions, spend, discrepancy)"]
+
+    Campaign --> ASC
+    ASC --> B1
+    ASC --> B2
+    ASC --> Delivery
+```
+
+### Data Models
+
+**AdServerCampaign** --- the top-level integration record:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `str` | Record UUID |
+| `campaign_id` | `str` | FK to the buyer campaign |
+| `ad_server` | `AdServerType` | `INNOVID` or `FLASHTALKING` |
+| `ad_server_campaign_id` | `str` | The campaign ID on the ad server |
+| `status` | `AdServerCampaignStatus` | `PENDING`, `ACTIVE`, `PAUSED`, `COMPLETED`, or `ERROR` |
+| `bindings` | `list[AdServerBinding]` | Deal-to-line-item mappings |
+| `delivery` | `AdServerDelivery?` | Aggregated delivery data |
+| `created_at` | `datetime` | When the record was created |
+
+**AdServerBinding** --- one deal + creative mapped to an ad server line:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `deal_id` | `str` | The buyer deal ID |
+| `creative_id` | `str` | The creative asset ID |
+| `ad_server_line_id` | `str` | Line item ID on the ad server |
+| `serving_status` | `BindingServingStatus` | `ACTIVE`, `PAUSED`, or `ERROR` |
+| `last_sync_at` | `datetime` | Last synchronization timestamp |
+
+**AdServerDelivery** --- aggregated delivery data for discrepancy detection:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `impressions_served` | `int` | Impressions reported by the ad server |
+| `spend_reported` | `float` | Spend reported by the ad server |
+| `last_report_at` | `datetime` | When the last report was received |
+| `discrepancy_pct` | `float` | Discrepancy between buyer-side and ad-server-side counts |
+
+### Creating Ad Server Bindings
+
+Use `CampaignStore` or the dedicated `AdServerStore`:
+
+```python
+from ad_buyer.storage.campaign_store import CampaignStore
+
+store = CampaignStore("sqlite:///./ad_buyer.db")
+store.connect()
+
+# Create an ad server campaign binding
+binding_id = store.save_ad_server_campaign(
+    campaign_id="campaign-abc",
+    ad_server="INNOVID",
+    external_campaign_id="innovid-camp-789",
+    status="PENDING",
+    creative_assignments=json.dumps({
+        "deal-001": "asset-aaa",
+        "deal-002": "asset-bbb",
+    }),
+)
+
+# Update status after trafficking
+store.update_ad_server_campaign(
+    binding_id=binding_id,
+    status="ACTIVE",
+    last_sync_at=datetime.now(timezone.utc).isoformat(),
+)
+```
+
+For the Pydantic model-based interface with full serialization:
+
+```python
+from ad_buyer.models.campaign import (
+    AdServerCampaign,
+    AdServerType,
+    AdServerBinding,
+)
+from ad_buyer.storage.adserver_store import AdServerStore
+
+adserver_store = AdServerStore("sqlite:///./ad_buyer.db")
+adserver_store.connect()
+
+record = AdServerCampaign(
+    campaign_id="campaign-abc",
+    ad_server=AdServerType.FLASHTALKING,
+    ad_server_campaign_id="ft-camp-456",
+    bindings=[
+        AdServerBinding(
+            deal_id="deal-001",
+            creative_id="asset-aaa",
+            ad_server_line_id="ft-line-001",
+        ),
+        AdServerBinding(
+            deal_id="deal-002",
+            creative_id="asset-bbb",
+            ad_server_line_id="ft-line-002",
+        ),
+    ],
+)
+
+adserver_store.save_ad_server_campaign(record)
+
+# Query by campaign
+records = adserver_store.list_ad_server_campaigns(campaign_id="campaign-abc")
+```
+
+---
+
+## Creative Events
+
+The event bus tracks creative lifecycle events:
+
+| Event | When | Payload |
+|-------|------|---------|
+| `creative.uploaded` | A new creative asset is stored | Asset metadata |
+| `creative.validated` | Spec validation completes (pass or fail) | Validation result, errors |
+| `creative.matched` | A creative is assigned to a deal | Deal ID, creative ID |
+| `creative.rotation_updated` | Rotation rules change | Rotation config |
+| `creative.ad_server_pushed` | Creative trafficked to ad server | Ad server, line ID |
+
+---
+
+## Integration with the Campaign Pipeline
+
+The creative management system integrates with the [campaign pipeline](campaign-pipeline.md) at two points:
+
+1. **Brief submission** --- The campaign brief can include `creative_ids` referencing pre-uploaded assets. These are validated and associated with the campaign during ingestion.
+
+2. **Approval gate** --- The `CREATIVE` approval stage (disabled by default) can be enabled in the brief's `approval_config` to require human sign-off before creatives are pushed to ad servers.
+
+After deals are booked and the campaign reaches READY status, the creative-to-deal binding happens: validated creatives are matched to booked deals and trafficked to the appropriate ad server.
+
+---
+
+## Persistence
+
+Creative data lives in two SQLite tables managed by `CampaignStore`:
+
+| Table | Purpose |
+|-------|---------|
+| `creative_assets` | Creative files, format specs, and validation status |
+| `ad_server_campaigns` | Ad server integration records with deal-to-line bindings |
+
+The `AdServerStore` provides a separate, model-aware interface to the `ad_server_campaigns` table with full Pydantic serialization/deserialization of bindings and delivery data.
+
+---
 
 ## Related
 
 - [Architecture Overview](../architecture/overview.md) --- Agent hierarchy and system design
 - [Deals API](../api/deals.md) --- Deal booking and management
 - [Campaign Brief to Deal Pipeline](campaign-pipeline.md) --- Pipeline can auto-assign creatives from the library to deals
-- [Seller Agent Docs](https://iabtechlab.github.io/seller-agent/) --- Seller-side creative requirements
+- [Budget Pacing & Reallocation](budget-pacing.md) --- Pacing engine that monitors deal delivery

--- a/docs/guides/multi-seller-orchestration.md
+++ b/docs/guides/multi-seller-orchestration.md
@@ -2,10 +2,285 @@
 
 Multi-seller deal orchestration extends the buyer agent from shopping multiple sellers individually to **coordinating deals across sellers as a unified portfolio**. Where the existing [multi-seller discovery](multi-seller.md) guide covers finding and comparing inventory, orchestration adds strategic deal execution: running parallel negotiations, applying cross-seller optimization, and managing a portfolio of deals as a coordinated whole.
 
-!!! info "Coming Soon --- Phase 2"
-    Multi-seller deal orchestration is part of Phase 2: Campaign Intelligence. For the existing multi-seller *discovery and shopping* workflow, see [Multi-Seller Discovery](multi-seller.md).
+The orchestration layer is implemented by `MultiSellerOrchestrator` in `ad_buyer.orchestration.multi_seller`. It connects the registry client (for seller discovery), deals client (for quoting and booking), quote normalizer (for cross-seller comparison), and event bus (for observability) into a single end-to-end flow.
 
-The orchestration layer adds parallel quote requests across sellers, cross-seller negotiation strategy (using competing offers as leverage), Portfolio Manager agent coordination for optimal deal selection, and atomic portfolio booking with rollback handling.
+---
+
+## How It Works
+
+The orchestrator runs four stages in sequence. Each stage produces data consumed by the next, and every stage emits events to the [event bus](../event-bus/overview.md) for observability.
+
+```mermaid
+flowchart LR
+    Discover["1. Discover\nSellers"]
+    Quote["2. Parallel\nQuotes"]
+    Rank["3. Evaluate\n& Rank"]
+    Book["4. Select\n& Book"]
+
+    Discover --> Quote --> Rank --> Book
+```
+
+| Stage | What Happens | Key Class |
+|-------|-------------|-----------|
+| **Discover** | Query the agent registry for sellers matching media type and capabilities | `RegistryClient` |
+| **Parallel Quotes** | Send `QuoteRequest` to all discovered sellers concurrently | `DealsClient` via `asyncio.gather` |
+| **Evaluate & Rank** | Normalize quotes to effective CPM and score them | `QuoteNormalizer` |
+| **Select & Book** | Pick the top-ranked deals within budget and book them | `DealsClient` |
+
+---
+
+## Quick Example
+
+```python
+from ad_buyer.orchestration.multi_seller import (
+    MultiSellerOrchestrator,
+    InventoryRequirements,
+    DealParams,
+)
+from ad_buyer.registry.client import RegistryClient
+from ad_buyer.clients.deals_client import DealsClient
+from ad_buyer.events.bus import InMemoryEventBus
+
+# Setup
+registry = RegistryClient(registry_url="http://localhost:8080/agent-registry")
+bus = InMemoryEventBus()
+
+orchestrator = MultiSellerOrchestrator(
+    registry_client=registry,
+    deals_client_factory=lambda url, **kw: DealsClient(url, **kw),
+    event_bus=bus,
+)
+
+# Run the full flow
+result = await orchestrator.orchestrate(
+    inventory_requirements=InventoryRequirements(
+        media_type="ctv",
+        deal_types=["PD", "PG"],
+        max_cpm=35.0,
+    ),
+    deal_params=DealParams(
+        product_id="prod-ctv-001",
+        deal_type="PD",
+        impressions=500_000,
+        flight_start="2026-07-01",
+        flight_end="2026-09-30",
+    ),
+    budget=100_000.0,
+    max_deals=3,
+)
+
+# Inspect the result
+print(f"Sellers discovered: {len(result.discovered_sellers)}")
+print(f"Quotes received: {len([q for q in result.quote_results if q.quote])}")
+print(f"Deals booked: {len(result.selection.booked_deals)}")
+print(f"Total spend: ${result.selection.total_spend:,.2f}")
+print(f"Remaining budget: ${result.selection.remaining_budget:,.2f}")
+```
+
+---
+
+## Stage 1: Discover Sellers
+
+The orchestrator queries the [AAMP agent registry](multi-seller.md) for sellers matching the campaign's inventory requirements. Discovery filters on media type and applies exclusion rules.
+
+```python
+requirements = InventoryRequirements(
+    media_type="ctv",            # What kind of inventory
+    deal_types=["PD", "PG"],     # Acceptable deal types
+    content_categories=["IAB1"], # Optional content filter
+    excluded_sellers=["seller-block-123"],  # Sellers to skip
+    max_cpm=35.0,                # Used later in evaluation
+)
+
+sellers = await orchestrator.discover_sellers(requirements)
+```
+
+**Filtering rules:**
+
+- Sellers matching the `capabilities_filter` (derived from `media_type`) are returned from the registry
+- Sellers in the `excluded_sellers` list are removed
+- Sellers with `BLOCKED` trust level are removed
+
+After discovery, the orchestrator emits an `inventory.discovered` event with the count and IDs of qualifying sellers.
+
+---
+
+## Stage 2: Parallel Quote Requests
+
+The orchestrator sends quote requests to all discovered sellers **concurrently** using `asyncio.gather`. Each request runs independently --- a timeout or error on one seller does not block the others.
+
+```python
+quote_results = await orchestrator.request_quotes_parallel(
+    sellers=sellers,
+    deal_params=DealParams(
+        product_id="prod-ctv-001",
+        deal_type="PD",
+        impressions=500_000,
+        flight_start="2026-07-01",
+        flight_end="2026-09-30",
+        target_cpm=25.0,          # Hint to the seller
+        media_type="ctv",
+    ),
+)
+```
+
+Each result is a `SellerQuoteResult` containing either a successful `QuoteResponse` or an error string:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `seller_id` | `str` | The seller's agent ID |
+| `seller_url` | `str` | The seller's base URL |
+| `quote` | `QuoteResponse?` | The quote if successful, None on failure |
+| `deal_type` | `str` | The deal type that was requested |
+| `error` | `str?` | Error message if the request failed |
+
+!!! tip "Timeout handling"
+    The default quote timeout is **30 seconds** per seller. You can adjust this via the `quote_timeout` parameter on the orchestrator constructor. Timed-out sellers are recorded as errors, not exceptions --- the flow continues with whatever quotes came back.
+
+---
+
+## Stage 3: Evaluate and Rank
+
+Raw quotes from different sellers are not directly comparable. A $25 CPM Preferred Deal from Seller A is not the same as a $22 CPM Private Auction floor from Seller B (which will likely clear higher). The `QuoteNormalizer` accounts for these differences.
+
+### How Normalization Works
+
+The normalizer computes an **effective CPM** for each quote by applying three adjustments:
+
+1. **Deal-type adjustment** --- Private Auction (PA) floor CPMs are marked up by 20% to estimate the expected clearing price. PG and PD quotes are taken at face value.
+
+2. **Supply-path fee estimation** --- If supply-path data is available, intermediary fees (SSP take-rate, exchange fees) and tech fees (data, verification) are added to the raw CPM.
+
+3. **Effective CPM** = adjusted CPM + estimated fees
+
+### Scoring
+
+Each normalized quote receives a composite score (0--100, higher is better) based on three weighted components:
+
+| Component | Weight | Logic |
+|-----------|--------|-------|
+| Effective CPM | 60% | Lower CPM scores higher. Best CPM in the set gets 100. |
+| Deal type | 20% | PG = 100, PD = 70, PA = 40 |
+| Fill rate | 20% | Higher estimated fill rate scores higher. Default: 70% if not reported. |
+
+When comparing multiple quotes, the normalizer uses **relative scoring** --- the best effective CPM in the competitive set gets the maximum CPM sub-score, and others are scaled relative to it. This provides better differentiation within a single auction.
+
+```python
+from ad_buyer.booking.quote_normalizer import QuoteNormalizer, SupplyPathInfo
+
+# Optional: provide supply-path fee data for more accurate normalization
+normalizer = QuoteNormalizer(supply_paths={
+    "seller-a": SupplyPathInfo(
+        seller_id="seller-a",
+        intermediary_fee_pct=5.0,   # 5% SSP take-rate
+        tech_fee_cpm=0.50,          # $0.50/mille verification fees
+    ),
+})
+
+# Use within the orchestrator
+orchestrator = MultiSellerOrchestrator(
+    registry_client=registry,
+    deals_client_factory=deals_factory,
+    quote_normalizer=normalizer,
+)
+```
+
+!!! note "Default normalization"
+    If you don't supply a `QuoteNormalizer`, the orchestrator creates a default one with no supply-path data. Fee estimates will be zero, but deal-type adjustment and relative scoring still apply.
+
+---
+
+## Stage 4: Select and Book
+
+The orchestrator iterates through ranked quotes (best score first) and books deals until either the budget is exhausted or `max_deals` is reached.
+
+**Budget enforcement:**
+
+- Each quote's `minimum_spend` is checked against the remaining budget
+- Quotes whose minimum spend exceeds the remaining budget are skipped
+- Booking failures are recorded but do not abort the loop --- the orchestrator moves to the next-best quote
+
+```python
+# The orchestrator handles selection internally, but you can also
+# call select_and_book directly for custom flows:
+selection = await orchestrator.select_and_book(
+    ranked_quotes=ranked,
+    budget=100_000.0,
+    count=3,
+    quote_seller_map={"quote-abc": "http://seller-a:8001"},
+)
+
+print(f"Booked: {len(selection.booked_deals)}")
+print(f"Failed: {len(selection.failed_bookings)}")
+print(f"Spend: ${selection.total_spend:,.2f}")
+print(f"Remaining: ${selection.remaining_budget:,.2f}")
+```
+
+Each booked deal emits a `deal.booked` event. After all channels complete, a `campaign.booking_completed` event summarizes the results.
+
+---
+
+## The OrchestrationResult
+
+The `orchestrate()` method returns an `OrchestrationResult` that captures data from every stage:
+
+```python
+@dataclass
+class OrchestrationResult:
+    discovered_sellers: list[AgentCard]     # Stage 1 output
+    quote_results: list[SellerQuoteResult]  # Stage 2 output
+    ranked_quotes: list[NormalizedQuote]    # Stage 3 output
+    selection: DealSelection                # Stage 4 output
+```
+
+The `DealSelection` inside captures the booking outcome:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `booked_deals` | `list[DealResponse]` | Successfully booked deals |
+| `failed_bookings` | `list[dict]` | Quotes that failed to book (with error details) |
+| `total_spend` | `float` | Total estimated spend across booked deals |
+| `remaining_budget` | `float` | Budget left after booking |
+
+---
+
+## Integration with the Campaign Pipeline
+
+You don't need to call `MultiSellerOrchestrator` directly for most use cases. The [Campaign Pipeline](campaign-pipeline.md) calls it internally during its **execute_booking** stage --- once per channel in the campaign plan. The pipeline:
+
+1. Builds `InventoryRequirements` from each channel's media type
+2. Constructs `DealParams` from the channel plan and flight dates
+3. Calls `orchestrator.orchestrate()` with the channel budget
+4. Collects per-channel `OrchestrationResult` objects
+
+If you need finer control --- for example, to use a custom `QuoteNormalizer` with supply-path data, or to orchestrate outside of a campaign --- use the orchestrator directly as shown in this guide.
+
+---
+
+## Events Emitted
+
+The orchestrator emits these events to the [event bus](../event-bus/overview.md):
+
+| Event | When | Payload |
+|-------|------|---------|
+| `inventory.discovered` | After seller discovery | `media_type`, `sellers_found`, `seller_ids` |
+| `quote.received` | After parallel quote collection | `quotes_received`, `quotes_failed`, seller ID lists |
+| `deal.booked` | After each successful booking | `deal_id`, `quote_id`, `seller_id`, `deal_type`, `final_cpm` |
+| `campaign.booking_completed` | After all bookings finish | `deals_booked`, `deals_failed`, `total_spend`, `remaining_budget` |
+
+---
+
+## Error Handling
+
+The orchestrator is designed to be **resilient to partial failures**:
+
+- **Seller discovery returns zero results** --- The flow returns an empty `OrchestrationResult` immediately. No quotes are requested.
+- **A seller times out or errors during quoting** --- The error is captured in `SellerQuoteResult.error`. Other sellers' quotes proceed normally.
+- **All quotes are filtered out by max_cpm** --- The flow returns with an empty `ranked_quotes` list and no bookings.
+- **A booking fails** --- The failure is recorded in `DealSelection.failed_bookings`. The orchestrator moves to the next-best quote.
+- **Event bus fails** --- Events are emitted on a best-effort basis. A bus failure is logged as a warning and does not interrupt the flow.
+
+---
 
 ## Related
 

--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -67,6 +67,10 @@ Your [identity tier](identity.md) determines what the buyer can do with a given 
 | Guide | When to Read It |
 |-------|----------------|
 | [Deal Booking](deal-booking.md) | You want to understand the core booking lifecycle from brief to confirmed deal |
+| [Campaign Pipeline](campaign-pipeline.md) | You want to automate the full campaign lifecycle from brief to booked deals |
+| [Multi-Seller Orchestration](multi-seller-orchestration.md) | You need to coordinate deal booking across multiple sellers with quote normalization |
+| [Budget Pacing](budget-pacing.md) | You need to monitor spend against plan and manage mid-flight budget reallocations |
+| [Creative Management](creative-management.md) | You need to manage creative assets, validation, and ad server integration |
 | [Negotiation](negotiation.md) | You want to configure or customize how the buyer negotiates pricing |
 | [Identity Strategy](identity.md) | You need to understand access tiers and how they affect pricing and capabilities |
 | [Media Kit Browsing](media-kit.md) | You want to explore seller inventory before or outside of a booking flow |
@@ -75,14 +79,6 @@ Your [identity tier](identity.md) determines what the buyer can do with a given 
 | [Linear TV Buying](linear-tv.md) | You are buying linear TV inventory with DMA targeting and scatter/upfront pricing |
 | [Configuration](configuration.md) | You need to set environment variables, seller connections, or feature flags |
 | [Deployment](deployment.md) | You are deploying the buyer agent to production |
-
-!!! note "Coming Soon"
-    The following guides cover features that are planned but not yet implemented:
-
-    - **[Multi-Seller Orchestration](multi-seller-orchestration.md)** --- Coordinating bookings across multiple sellers in a single campaign
-    - **[Campaign Pipeline](campaign-pipeline.md)** --- Managing multiple campaigns with shared budgets and scheduling
-    - **[Budget Pacing](budget-pacing.md)** --- Controlling spend rate across a campaign's flight dates
-    - **[Creative Management](creative-management.md)** --- Associating and validating creative assets for booked deals
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Fills in the 4 existing "Coming Soon" stub pages with full documentation for Phase 2 Campaign Automation features
- Updates the Buyer Guide overview to remove the Coming Soon admonition

## Pages
- `docs/guides/multi-seller-orchestration.md` — MultiSellerOrchestrator 4-stage flow, quote normalization, composite scoring
- `docs/guides/campaign-pipeline.md` — CampaignPipeline stages, brief JSON schema, state machine, approval gates
- `docs/guides/budget-pacing.md` — BudgetPacingEngine, deviation detection, cross-channel reallocation
- `docs/guides/creative-management.md` — CreativeAsset model, validation lifecycle, Innovid/Flashtalking integration
- `docs/guides/overview.md` — Removed Coming Soon block, integrated guides as shipped features

## Test plan
- [x] Documentation only — no code changes
- [x] mkdocs serve builds and renders correctly
- [x] No nav changes needed — pages were already in mkdocs.yml as stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)