### PR TITLE
fix: pass initial state via kickoff(inputs=) for CrewAI 1.10.1 compatibility

### DIFF
--- a/src/ad_buyer/interfaces/api/main.py
+++ b/src/ad_buyer/interfaces/api/main.py
@@ -545,13 +545,12 @@ async def _run_booking_flow(job_id: str, request: BookingRequest) -> None:
 
         client = _create_client()
         flow = DealBookingFlow(client, store=_get_store())
-        flow.state = BookingState(campaign_brief=request.brief.model_dump())
 
         # Store flow reference for approval
         job["_flow"] = flow
 
         job["progress"] = 0.2
-        result = flow.kickoff()
+        result = flow.kickoff(inputs={"campaign_brief": request.brief.model_dump()})
 
         job["progress"] = 0.8
         job["budget_allocations"] = {


### PR DESCRIPTION
## Summary

- CrewAI 1.10.1 removed the setter on `Flow.state`, making direct assignment (`flow.state = BookingState(...)`) raise `TypeError: property 'state' of 'DealBookingFlow' object has no setter` at runtime
- Remove the broken `flow.state = ...` assignment
- Pass the campaign brief via `flow.kickoff(inputs={"campaign_brief": ...})` instead — the correct API for initialising flow state in CrewAI 1.10.1

## Root cause

The pinned version (`crewai==1.10.1`, added in b80cc5d) changed `Flow.state` from a settable attribute to a read-only property backed by the pydantic model. Any code that assigned to it after construction broke silently at import time and raised at the first booking attempt.

## Test plan

- [ ] Start buyer agent and POST to `/bookings` with a valid `CampaignBrief`
- [ ] Confirm job reaches `awaiting_approval` status (previously crashed immediately with `TypeError`)
- [ ] Confirm `GET /bookings/{job_id}` returns `budget_allocations` and `recommendations`
- [ ] POST `/bookings/{job_id}/approve-all` and confirm job reaches `completed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)