### PR TITLE
Add flask to dev deps so test suite can run (ar-r82f.5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ dev = [
     "pytest-cov>=5.0.0",
     "ruff>=0.5.0",
     "mypy>=1.11.0",
+    # flask is imported transitively by src/ad_buyer/demo/{campaign_demo,deal_library_dashboard}.py
+    # which the demo Flask-app unit tests under tests/unit/ import. Without this,
+    # pytest collection fails with ModuleNotFoundError before any tests run.
+    "flask>=3.0",
 ]
 docs = [
     "mkdocs-material>=9.5.0",


### PR DESCRIPTION
## Why this matters

The IABTechLab/buyer-agent `main` branch has had **all three CI checks (Lint, Test, Docker Build) failing for weeks**. The most consequential failure is in the Test job: `tests/unit/test_campaign_demo.py` and `tests/unit/test_deal_library_dashboard.py` both transitively import `flask` (via `src/ad_buyer/demo/campaign_demo.py` and `src/ad_buyer/demo/deal_library_dashboard.py`), but `flask` is **not declared in any dependency group**. The CI install step (`pip install -e ".[dev]"`) therefore never installs flask, and pytest exits with code 2 at **collection time** before running any test.

The practical effect: recent PRs have looked "clean" on tests not because their tests passed but because **no tests ever ran**. PR #79 was merged on this basis and had to be reverted (#88). This blocks meaningful test verification for every subsequent PR.

## What was missing

`flask` was not in `[project.dependencies]` nor in any `[project.optional-dependencies]` group, despite being imported by:
- `src/ad_buyer/demo/campaign_demo.py:44` — `from flask import Flask, jsonify, render_template, request`
- `src/ad_buyer/demo/deal_library_dashboard.py:28` — `from flask import Flask, jsonify, render_template, request`

And then transitively by the two unit-test files above.

## What this PR does

Adds `flask>=3.0` to the `dev` extras in `pyproject.toml` — a single 4-line addition (plus a comment explaining why). CI installs `.[dev]`, so this is the minimal change that lets pytest finish collection.

## What still fails (intentionally out of scope)

- **Lint job**: ~463 pre-existing ruff errors. Cleanup is its own piece of work and would balloon this PR. Should be a follow-on.
- **Docker Build job**: separate failure mode; not investigated in this PR. Follow-on.
- **Runtime gap**: `flask` is genuinely a runtime dependency of `src/ad_buyer/demo/__main__.py` (`python -m ad_buyer.demo`). Putting it in `[project.dependencies]` would also be correct. Left for a follow-on so this PR stays minimal.

## Local verification (Python 3.11 via uv)

```
$ uv run pytest tests/unit/test_campaign_demo.py tests/unit/test_deal_library_dashboard.py --collect-only
66 tests collected in 4.25s

$ uv run pytest tests/unit/ --tb=short -q
2996 passed, 1 skipped, 1 warning in 196.31s
```

- Tests collected: 2997 (was: 0 — pytest aborted at collection)
- Tests passed: 2996
- Tests skipped: 1
- Tests failed: 0
- Tests errored: 0
- Collection errors: 0 (was: 2)

Real CI Test-job verification is what we actually care about — see the checks on this PR.

## Tracking

- Bead: `ar-r82f.5` (Fix CI env so test suite actually runs)
- Parent epic: `ar-r82f` (EPIC: Recovery 2026-05-28 — Restart buyer-agent work after 7-week dormancy)
- Blocks: re-merge of PR #79 (CPM hallucination fix) which was reverted in #88 because no tests were verifiable
- Plan: https://github.com/atc964/agent-range-ops/blob/main/docs/planning/BUYER_AGENT_RECOVERY_2026-05-28.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>