### PR TITLE
Add pluggable storage backends (SQLite/Redis/Postgres+Redis hybrid) (ar-r82f.3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,11 +15,30 @@ MANAGER_LLM_MODEL=anthropic/claude-opus-4-20250514
 LLM_TEMPERATURE=0.3
 LLM_MAX_TOKENS=4096
 
-# Database
+# Storage Configuration
+# STORAGE_TYPE: sqlite (default/local), redis, hybrid (postgres+redis)
+STORAGE_TYPE=sqlite
+
+# SQLite (default for local/test)
 DATABASE_URL=sqlite:///./ad_buyer.db
 
-# Optional Redis (for caching/pub-sub)
+# Redis (for production caching, sessions, pub/sub)
+# Install: pip install ad-buyer-system[redis]
 REDIS_URL=
+# REDIS_URL=redis://localhost:6379/0
+
+# PostgreSQL (for production durable storage)
+# Install: pip install ad-buyer-system[postgres]
+# DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/ad_buyer
+POSTGRES_POOL_MIN=2
+POSTGRES_POOL_MAX=10
+
+# Hybrid mode (recommended for production):
+#   STORAGE_TYPE=hybrid
+#   DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/ad_buyer
+#   REDIS_URL=redis://localhost:6379/0
+# Routes durable data (deals, campaigns, orders) to Postgres
+# and ephemeral data (sessions, caches, locks) to Redis
 
 # Environment
 ENVIRONMENT=development

--- a/docs/architecture/deal-store.md
+++ b/docs/architecture/deal-store.md
@@ -13,6 +13,9 @@ Without persistent storage, all deal state lives in memory and is lost on proces
 !!! info "Synchronous by design"
     The DealStore uses synchronous `sqlite3` (not `aiosqlite`) because CrewAI runs flows in worker threads that may not have an asyncio event loop. Thread safety is provided by `check_same_thread=False` and a `threading.Lock()`.
 
+!!! note "DealStore vs. pluggable storage backends"
+    This page describes the **DealStore** — a synchronous SQLite-only persistence layer dedicated to deal lifecycle, negotiation, and booking records. The buyer agent also has a separate, pluggable async [storage backend](storage-backends.md) abstraction (SQLite / Redis / Postgres+Redis hybrid) used by other domain stores (campaigns, orders, sessions, conversions, optimization, experiments, pacing). The two coexist; over time, callers may migrate from direct DealStore access to the pluggable backend.
+
 ---
 
 ## SQLite Schema

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -77,7 +77,8 @@ The Architecture section covers these topics:
 | **[Buyer Deal Flow](buyer-deal-flow.md)** | Single-deal flow for direct DSP integration without multi-channel orchestration |
 | **[Order State Machine](../state-machines/order-lifecycle.md)** | 12 deal states and 9 campaign states with guard conditions and audit trail |
 | **[Event Bus](../event-bus/overview.md)** | 13 event types providing structured observability across all flows |
-| **[Deal Store](deal-store.md)** | SQLite persistence for deals, events, and session state |
+| **[Deal Store](deal-store.md)** | Synchronous SQLite persistence for deal lifecycle, negotiation history, and audit trail |
+| **[Storage Backends](storage-backends.md)** | Pluggable async backend (SQLite / Redis / Postgres+Redis hybrid) used by domain stores beyond DealStore |
 | **[Models](models.md)** | Pydantic data models for API requests, flow state, and deal records |
 | **[Tools Reference](tools.md)** | CrewAI tools available to agents for research, booking, and negotiation |
 

--- a/docs/architecture/storage-backends.md
+++ b/docs/architecture/storage-backends.md
@@ -1,0 +1,124 @@
+# Storage Backends
+
+The buyer agent persists state through a pluggable `StorageBackend` abstraction. A factory selects one of three concrete backends at startup based on configuration: **SQLite** (default), **Redis**, or **Hybrid** (PostgreSQL + Redis). All backends implement the same key/value interface plus higher-level domain helpers (deals, campaigns, orders, sessions, conversions, optimization decisions, experiments, supply path scores, quotes, negotiations, model artifacts, pacing snapshots).
+
+This abstraction sits alongside the legacy [`DealStore`](deal-store.md), which uses synchronous `sqlite3` directly for CrewAI thread safety. Over time, callers are expected to migrate from direct DealStore access to the pluggable backend; for now, both coexist.
+
+## Why pluggable?
+
+A single SQLite file works fine for local development and demos, but breaks down for production:
+
+- **Single-writer constraint** — SQLite serializes writes, so horizontal scaling means one ECS task and tight contention under load.
+- **No native TTL** — Sessions and caches need expiry; SQLite emulates this with sweep queries.
+- **No pub/sub or distributed locks** — Multi-instance deployments need them; Redis provides them natively.
+
+The pluggable factory lets a single agent run on SQLite for development, swap to Redis for ephemeral-heavy workloads, or use a Hybrid mode that puts durable business data on PostgreSQL and short-lived data on Redis — all without code changes.
+
+## Backend selection
+
+Backend choice is driven by `settings.storage_type` (env var `STORAGE_TYPE`), with sensible auto-detection.
+
+| `STORAGE_TYPE` | Required env vars | When to use |
+|---|---|---|
+| `sqlite` *(default)* | `DATABASE_URL` (defaults to `sqlite:///./ad_buyer.db`) | Local dev, demos, single-task deployments |
+| `redis` | `REDIS_URL` | Ephemeral-heavy workloads where durability isn't required |
+| `hybrid` | `DATABASE_URL=postgresql+asyncpg://…` **and** `REDIS_URL` | Production multi-instance with durable + cached data |
+
+If `STORAGE_TYPE` is unset and `REDIS_URL` is provided, the factory auto-selects Redis; otherwise it falls back to SQLite. See `ad_buyer/storage/factory.py` for the selection logic.
+
+```python
+from ad_buyer.storage.factory import get_storage
+
+# Reads STORAGE_TYPE / DATABASE_URL / REDIS_URL from settings,
+# constructs the backend, and connects.
+storage = await get_storage()
+
+await storage.set_deal("deal-123", {"status": "active", "spend": 1500})
+deal = await storage.get_deal("deal-123")
+```
+
+## The three backends
+
+### SQLite (`SQLiteBackend`)
+
+A single key/value table with optional TTL, backed by `aiosqlite`.
+
+- **Schema**: `kv_store(key TEXT PRIMARY KEY, value TEXT, expires_at REAL)` plus an index on `expires_at`.
+- **TTL**: Honored on read via `_cleanup_expired()` and per-call expiry checks.
+- **Concurrency**: Single writer. Use `DesiredCount: 1` on ECS — multiple tasks will corrupt the file.
+- **Best for**: Local development, CI, demos.
+
+### Redis (`RedisBackend`)
+
+Async Redis client (`redis.asyncio`) with namespaced keys (`ad_buyer:` prefix by default).
+
+- **TTL**: Native `EX` / `PEXPIRE` — no sweep needed.
+- **Concurrency**: Multi-writer, distributed.
+- **Durability**: Configurable via Redis persistence (RDB / AOF). Treat Redis as a cache by default unless you've explicitly hardened it.
+- **Best for**: Workloads dominated by sessions, caches, and rate limits.
+
+### Hybrid (`HybridBackend`)
+
+Routes operations to PostgreSQL or Redis based on key prefix.
+
+| Goes to **Redis** (ephemeral) | Goes to **PostgreSQL** (durable) |
+|---|---|
+| `session:`, `session_index:` | `deal:`, `campaign:`, `order:` |
+| `cache:`, `lock:` | `conversion:`, `opt_decision:` |
+| `pubsub:`, `rate_limit:` | `experiment:`, `supply_path:` |
+| | `quote:`, `negotiation:` |
+| | `model:`, `pacing:` |
+
+Routing rules live in `ad_buyer/storage/hybrid_backend.py` (`_REDIS_PREFIXES`). The PostgreSQL backend (`PostgresBackend`) uses a JSONB key/value table via `asyncpg` connection pooling (configurable through `POSTGRES_POOL_MIN` / `POSTGRES_POOL_MAX`, defaults `2` / `10`).
+
+`hybrid` is the recommended production mode: business data survives a Redis flush, while sessions and caches benefit from in-memory speed and native TTL.
+
+## Optional dependencies
+
+Storage drivers are optional extras to keep the base install lean:
+
+```bash
+# SQLite only (default — already included)
+pip install -e .
+
+# Add Redis
+pip install -e ".[redis]"
+
+# Add PostgreSQL
+pip install -e ".[postgres]"
+
+# Production (Redis + PostgreSQL)
+pip install -e ".[production]"
+```
+
+`aiosqlite` ships in the base dependencies. `redis>=5.0.0` and `asyncpg>=0.29.0` are gated behind extras and imported lazily by the factory, so they aren't loaded unless the corresponding backend is selected.
+
+## Configuration reference
+
+| Variable | Default | Description |
+|---|---|---|
+| `STORAGE_TYPE` | `sqlite` | Backend selector — `sqlite`, `redis`, or `hybrid`. |
+| `DATABASE_URL` | `sqlite:///./ad_buyer.db` | Connection string for SQLite or PostgreSQL (use `postgresql+asyncpg://user:pass@host/db` for hybrid). |
+| `REDIS_URL` | `None` | Redis connection URL — required for `redis` and `hybrid` modes. |
+| `POSTGRES_POOL_MIN` | `2` | Minimum asyncpg connection pool size (hybrid only). |
+| `POSTGRES_POOL_MAX` | `10` | Maximum asyncpg connection pool size (hybrid only). |
+
+## Migrating from SQLite to Hybrid
+
+There is no automatic migration — the SQLite key/value table and the PostgreSQL key/value table share a schema, but data is not copied for you. For a clean cutover:
+
+1. Drain in-flight work and stop the agent.
+2. Set `STORAGE_TYPE=hybrid`, `DATABASE_URL=postgresql+asyncpg://…`, `REDIS_URL=redis://…`.
+3. Restart. The new backend will lazily create the `kv_store` table and indexes on first connect.
+4. Re-import durable state (deals, campaigns) from your source of truth if needed.
+
+For zero-downtime migration, run the agent against Hybrid in parallel with SQLite, dual-write at the application layer, then cut reads over once Postgres is hot. This is non-trivial and not currently scripted.
+
+## Implementation files
+
+- `ad_buyer/storage/base.py` — `StorageBackend` ABC and shared domain helpers
+- `ad_buyer/storage/factory.py` — `get_storage_backend()` selection logic
+- `ad_buyer/storage/sqlite_backend.py` — SQLite implementation (`aiosqlite`)
+- `ad_buyer/storage/redis_backend.py` — Redis implementation (`redis.asyncio`)
+- `ad_buyer/storage/postgres_backend.py` — PostgreSQL implementation (`asyncpg`)
+- `ad_buyer/storage/hybrid_backend.py` — Prefix-based routing between Postgres and Redis

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -106,35 +106,36 @@ While `LLM_TEMPERATURE` sets the global default, each agent type uses a tuned te
 
 ---
 
-### Database
+### Storage Backend
+
+The pluggable storage backend (used by campaigns, orders, sessions, conversions, optimization, experiments, pacing) is selected with `STORAGE_TYPE`. The legacy DealStore always uses SQLite directly via `DATABASE_URL`. See [Storage Backends](../architecture/storage-backends.md) for the full reference.
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `DATABASE_URL` | `str` | `sqlite:///./ad_buyer.db` | SQLAlchemy connection string for the deal store and local persistence. |
-
-Supports any SQLAlchemy-compatible database. SQLite is the default for development; use PostgreSQL or MySQL for production.
+| `STORAGE_TYPE` | `str` | `sqlite` | Backend selector — `sqlite`, `redis`, or `hybrid` (Postgres + Redis). |
+| `DATABASE_URL` | `str` | `sqlite:///./ad_buyer.db` | SQLite or PostgreSQL connection string. For `hybrid`, use `postgresql+asyncpg://user:pass@host/db`. |
+| `REDIS_URL` | `str` | `None` | Redis connection URL — required for `redis` and `hybrid`; optional otherwise. |
+| `POSTGRES_POOL_MIN` | `int` | `2` | Minimum asyncpg connection pool size (hybrid only). |
+| `POSTGRES_POOL_MAX` | `int` | `10` | Maximum asyncpg connection pool size (hybrid only). |
 
 ```bash
-# PostgreSQL
-DATABASE_URL=postgresql://user:pass@localhost:5432/ad_buyer
-
-# SQLite (default)
+# SQLite (default — single-instance, dev/demos)
+STORAGE_TYPE=sqlite
 DATABASE_URL=sqlite:///./ad_buyer.db
-```
 
----
-
-### Redis
-
-| Variable | Type | Default | Description |
-|----------|------|---------|-------------|
-| `REDIS_URL` | `str` | `None` | Redis connection URL for caching and session management. Optional. |
-
-When set, Redis is used for CrewAI memory persistence and session caching. When `None`, in-memory storage is used.
-
-```bash
+# Redis (ephemeral-heavy, no durable Postgres)
+STORAGE_TYPE=redis
 REDIS_URL=redis://localhost:6379/0
+
+# Hybrid (recommended for production multi-instance)
+STORAGE_TYPE=hybrid
+DATABASE_URL=postgresql+asyncpg://buyer:pass@db.example.com:5432/ad_buyer
+REDIS_URL=redis://cache.example.com:6379/0
 ```
+
+Redis is also used for CrewAI memory persistence and session caching whenever `REDIS_URL` is set, regardless of `STORAGE_TYPE`. When `REDIS_URL` is unset, CrewAI uses in-memory storage.
+
+The Redis (`pip install -e ".[redis]"`) and asyncpg (`pip install -e ".[postgres]"`) drivers are optional extras. Install `".[production]"` to get both.
 
 ---
 

--- a/docs/guides/deployment-ops-guide.md
+++ b/docs/guides/deployment-ops-guide.md
@@ -254,8 +254,8 @@ The buyer agent runs on **ECS Fargate** with **EFS-backed SQLite persistence**. 
 | Secrets | SSM Parameter Store (SecureString) | Anthropic API key |
 | Logging | CloudWatch Logs | 30-day retention by default |
 
-!!! warning "Single-task constraint"
-    SQLite supports only one concurrent writer. AWS deployments must run exactly **one ECS task** (`DesiredCount: 1`). Running multiple tasks will corrupt the database. A PostgreSQL migration is planned for horizontal scaling.
+!!! warning "Single-task constraint with SQLite"
+    SQLite supports only one concurrent writer. If you deploy with `STORAGE_TYPE=sqlite` (the default), you must run exactly **one ECS task** (`DesiredCount: 1`). Running multiple tasks against the same EFS-backed SQLite file will corrupt the database. For horizontal scaling, switch to `STORAGE_TYPE=hybrid` (PostgreSQL + Redis) — see [Storage Backends](../architecture/storage-backends.md).
 
 ### Prerequisites
 
@@ -449,25 +449,33 @@ DEFAULT_LLM_MODEL=openai/gpt-4o
 MANAGER_LLM_MODEL=anthropic/claude-opus-4-20250514
 ```
 
-### Database
+### Storage
+
+See [Storage Backends](../architecture/storage-backends.md) for the full backend reference.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DATABASE_URL` | `sqlite:///./ad_buyer.db` | SQLAlchemy connection string for deal storage. SQLite for development; PostgreSQL for production multi-instance deployments. |
+| `STORAGE_TYPE` | `sqlite` | Backend selector — `sqlite`, `redis`, or `hybrid` (Postgres + Redis). |
+| `DATABASE_URL` | `sqlite:///./ad_buyer.db` | SQLite or PostgreSQL connection string. Use `postgresql+asyncpg://…` for hybrid. |
+| `REDIS_URL` | `None` | Redis URL. Required for `redis` and `hybrid` backends; also used for CrewAI memory persistence and session caching when set. |
+| `POSTGRES_POOL_MIN` | `2` | Minimum asyncpg pool size (hybrid only). |
+| `POSTGRES_POOL_MAX` | `10` | Maximum asyncpg pool size (hybrid only). |
 
 ```dotenv
-# SQLite (default, development)
+# SQLite (default, development, single-task only)
+STORAGE_TYPE=sqlite
 DATABASE_URL=sqlite:///./ad_buyer.db
 
-# PostgreSQL (production, when horizontal scaling is needed)
-DATABASE_URL=postgresql://buyer:pass@db.example.com:5432/ad_buyer
+# Hybrid (production, horizontal scaling)
+STORAGE_TYPE=hybrid
+DATABASE_URL=postgresql+asyncpg://buyer:pass@db.example.com:5432/ad_buyer
+REDIS_URL=redis://cache.example.com:6379/0
 ```
 
 ### Agent Behavior
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `REDIS_URL` | `None` | Redis URL for CrewAI memory persistence and session caching. When unset, in-memory storage is used. |
 | `CREW_MEMORY_ENABLED` | `True` | Enable CrewAI agent memory across tasks. |
 | `CREW_VERBOSE` | `True` | Enable verbose CrewAI logging. Set to `False` in production. |
 | `CREW_MAX_ITERATIONS` | `15` | Maximum iterations per crew task before forced completion. |
@@ -497,7 +505,8 @@ API_KEY=your-service-api-key
 SELLER_ENDPOINTS=https://seller1.example.com,https://seller2.example.com
 IAB_SERVER_URL=https://primary-seller.example.com
 
-DATABASE_URL=postgresql://buyer:pass@db.example.com:5432/ad_buyer
+STORAGE_TYPE=hybrid
+DATABASE_URL=postgresql+asyncpg://buyer:pass@db.example.com:5432/ad_buyer
 REDIS_URL=redis://cache.example.com:6379/0
 
 CREW_VERBOSE=False

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -120,10 +120,11 @@ Both options deploy the same architecture:
 - **Secrets**: SSM Parameter Store (SecureString)
 - **Logging**: CloudWatch Logs
 
-!!! note "Single-Task Deployment"
-    The buyer agent uses SQLite, which supports only one concurrent writer.
-    AWS deployments run a single ECS task (`desired_count=1`) with EFS-backed
-    persistence. For horizontal scaling, a PostgreSQL migration is planned.
+!!! note "Single-Task Deployment with SQLite"
+    The default `STORAGE_TYPE=sqlite` supports only one concurrent writer, so AWS deployments
+    run a single ECS task (`desired_count=1`) with EFS-backed persistence. For horizontal
+    scaling, set `STORAGE_TYPE=hybrid` and provide `DATABASE_URL` (PostgreSQL) plus `REDIS_URL`.
+    See [Storage Backends](../architecture/storage-backends.md) for the full reference.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
       - Booking Flow: architecture/booking-flow.md
       - Buyer Deal Flow: architecture/buyer-deal-flow.md
       - Deal Store: architecture/deal-store.md
+      - Storage Backends: architecture/storage-backends.md
       - Models: architecture/models.md
       - Tools Reference: architecture/tools.md
       - MCP Server: architecture/mcp-server.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,16 @@ docs = [
     "mkdocs-material>=9.5.0",
     "mkdocs-mermaid2-plugin>=1.1.0",
 ]
+redis = [
+    "redis>=5.0.0",
+]
+postgres = [
+    "asyncpg>=0.29.0",
+]
+production = [
+    "redis>=5.0.0",
+    "asyncpg>=0.29.0",
+]
 
 [project.scripts]
 ad-buyer = "ad_buyer.interfaces.cli.main:app"

--- a/src/ad_buyer/config/settings.py
+++ b/src/ad_buyer/config/settings.py
@@ -67,11 +67,12 @@ class Settings(BaseSettings):
     llm_temperature: float = 0.3
     llm_max_tokens: int = 4096
 
-    # Database
+    # Database / Storage Configuration
     database_url: str = "sqlite:///./ad_buyer.db"
-
-    # Optional Redis
     redis_url: str | None = None
+    storage_type: str = "sqlite"  # sqlite, redis, hybrid
+    postgres_pool_min: int = 2
+    postgres_pool_max: int = 10
 
     # CrewAI Settings
     crew_memory_enabled: bool = True

--- a/src/ad_buyer/storage/__init__.py
+++ b/src/ad_buyer/storage/__init__.py
@@ -1,16 +1,28 @@
 # Author: Green Mountain Systems AI Inc.
 # Donated to IAB Tech Lab
 
-"""Deal state persistence layer.
+"""Storage layer for the Ad Buyer System.
 
-Exports the DealStore class, singleton factory, and schema utilities for
-SQLite-backed storage of deals, negotiations, bookings, jobs, and status
-transitions.
+Exports two complementary persistence APIs:
+
+- The legacy synchronous :class:`DealStore` (sqlite3-backed) plus its
+  singleton factory and schema utilities, used by CrewAI agents that
+  cannot safely cross an event loop.
+- The pluggable async :class:`StorageBackend` abstraction and its
+  :func:`get_storage_backend` factory, which selects SQLite (default),
+  Redis, or a Postgres+Redis hybrid at startup based on configuration.
+
+The pluggable backend mirrors the seller-agent's storage architecture and
+provides an async key/value interface plus higher-level domain helpers.
+Callers may migrate from direct DealStore access to the pluggable
+backend incrementally; the two coexist.
 """
 
 from typing import Optional
 
+from .base import StorageBackend
 from .deal_store import DealStore
+from .factory import get_storage_backend
 from .schema import SCHEMA_VERSION, create_tables, initialize_schema
 
 _store_instance: DealStore | None = None
@@ -35,7 +47,9 @@ def get_deal_store(database_url: str = "sqlite:///./ad_buyer.db") -> DealStore:
 
 __all__ = [
     "DealStore",
+    "StorageBackend",
     "get_deal_store",
+    "get_storage_backend",
     "SCHEMA_VERSION",
     "create_tables",
     "initialize_schema",

--- a/src/ad_buyer/storage/base.py
+++ b/src/ad_buyer/storage/base.py
@@ -1,0 +1,316 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Base storage backend interface.
+
+Mirrors the seller-agent's StorageBackend ABC to maintain structural
+consistency across the buyer/seller ecosystem.  All concrete backends
+(SQLite, Redis, Postgres, Hybrid) implement this interface.
+
+The base class provides low-level key-value primitives and higher-level
+domain helpers for buyer-specific entities (deals, campaigns, conversions,
+optimization decisions, experiments, etc.).
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Optional
+
+
+class StorageBackend(ABC):
+    """Abstract base class for storage backends."""
+
+    @abstractmethod
+    async def connect(self) -> None:
+        """Establish connection to storage backend."""
+
+    @abstractmethod
+    async def disconnect(self) -> None:
+        """Close connection to storage backend."""
+
+    @abstractmethod
+    async def get(self, key: str) -> Optional[Any]:
+        """Retrieve a value by key."""
+
+    @abstractmethod
+    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        """Store a value with optional TTL (seconds)."""
+
+    @abstractmethod
+    async def delete(self, key: str) -> bool:
+        """Delete a key. Returns True if key existed."""
+
+    @abstractmethod
+    async def exists(self, key: str) -> bool:
+        """Check if key exists."""
+
+    @abstractmethod
+    async def keys(self, pattern: str = "*") -> list[str]:
+        """List keys matching pattern."""
+
+    # ------------------------------------------------------------------
+    # Deal operations
+    # ------------------------------------------------------------------
+
+    async def get_deal(self, deal_id: str) -> Optional[dict]:
+        """Get a deal by ID."""
+        return await self.get(f"deal:{deal_id}")
+
+    async def set_deal(self, deal_id: str, deal_data: dict) -> None:
+        """Store a deal."""
+        await self.set(f"deal:{deal_id}", deal_data)
+
+    async def delete_deal(self, deal_id: str) -> bool:
+        """Delete a deal."""
+        return await self.delete(f"deal:{deal_id}")
+
+    async def list_deals(self, filters: Optional[dict] = None) -> list[dict]:
+        """List all deals, optionally filtered."""
+        keys = await self.keys("deal:*")
+        deals = []
+        for key in keys:
+            deal = await self.get(key)
+            if deal is None:
+                continue
+            if filters:
+                if "status" in filters and deal.get("status") != filters["status"]:
+                    continue
+                if "deal_type" in filters and deal.get("deal_type") != filters["deal_type"]:
+                    continue
+            deals.append(deal)
+        return deals
+
+    # ------------------------------------------------------------------
+    # Campaign operations
+    # ------------------------------------------------------------------
+
+    async def get_campaign(self, campaign_id: str) -> Optional[dict]:
+        """Get a campaign by ID."""
+        return await self.get(f"campaign:{campaign_id}")
+
+    async def set_campaign(self, campaign_id: str, data: dict) -> None:
+        """Store a campaign."""
+        await self.set(f"campaign:{campaign_id}", data)
+
+    async def list_campaigns(self, filters: Optional[dict] = None) -> list[dict]:
+        """List campaigns, optionally filtered by status."""
+        keys = await self.keys("campaign:*")
+        campaigns = []
+        for key in keys:
+            campaign = await self.get(key)
+            if campaign is None:
+                continue
+            if filters:
+                if "status" in filters and campaign.get("status") != filters["status"]:
+                    continue
+            campaigns.append(campaign)
+        return campaigns
+
+    # ------------------------------------------------------------------
+    # Order operations
+    # ------------------------------------------------------------------
+
+    async def get_order(self, order_id: str) -> Optional[dict]:
+        """Get an order by ID."""
+        return await self.get(f"order:{order_id}")
+
+    async def set_order(self, order_id: str, data: dict) -> None:
+        """Store an order."""
+        await self.set(f"order:{order_id}", data)
+
+    async def list_orders(self, filters: Optional[dict] = None) -> list[dict]:
+        """List orders, optionally filtered by status."""
+        keys = await self.keys("order:*")
+        orders = []
+        for key in keys:
+            order = await self.get(key)
+            if order is None:
+                continue
+            if filters:
+                if "status" in filters and order.get("status") != filters["status"]:
+                    continue
+            orders.append(order)
+        return orders
+
+    # ------------------------------------------------------------------
+    # Session operations
+    # ------------------------------------------------------------------
+
+    async def get_session(self, session_id: str) -> Optional[dict]:
+        """Get a session by ID."""
+        return await self.get(f"session:{session_id}")
+
+    async def set_session(
+        self, session_id: str, data: dict, ttl: Optional[int] = None
+    ) -> None:
+        """Store a session with optional TTL."""
+        await self.set(f"session:{session_id}", data, ttl=ttl)
+
+    async def delete_session(self, session_id: str) -> bool:
+        """Delete a session."""
+        return await self.delete(f"session:{session_id}")
+
+    async def list_sessions(self) -> list[dict]:
+        """List all sessions."""
+        keys = await self.keys("session:*")
+        sessions = []
+        for key in keys:
+            if key.startswith("session_index:"):
+                continue
+            session = await self.get(key)
+            if session:
+                sessions.append(session)
+        return sessions
+
+    # ------------------------------------------------------------------
+    # Conversion event operations (optimization)
+    # ------------------------------------------------------------------
+
+    async def get_conversion(self, event_id: str) -> Optional[dict]:
+        """Get a conversion event by ID."""
+        return await self.get(f"conversion:{event_id}")
+
+    async def set_conversion(self, event_id: str, data: dict) -> None:
+        """Store a conversion event."""
+        await self.set(f"conversion:{event_id}", data)
+
+    async def list_conversions(self, filters: Optional[dict] = None) -> list[dict]:
+        """List conversion events, optionally filtered."""
+        keys = await self.keys("conversion:*")
+        conversions = []
+        for key in keys:
+            conversion = await self.get(key)
+            if conversion is None:
+                continue
+            if filters:
+                if "deal_id" in filters and conversion.get("deal_id") != filters["deal_id"]:
+                    continue
+                if "campaign_id" in filters and conversion.get("campaign_id") != filters["campaign_id"]:
+                    continue
+            conversions.append(conversion)
+        return conversions
+
+    # ------------------------------------------------------------------
+    # Optimization decision operations
+    # ------------------------------------------------------------------
+
+    async def get_optimization_decision(self, decision_id: str) -> Optional[dict]:
+        """Get an optimization decision by ID."""
+        return await self.get(f"opt_decision:{decision_id}")
+
+    async def set_optimization_decision(self, decision_id: str, data: dict) -> None:
+        """Store an optimization decision."""
+        await self.set(f"opt_decision:{decision_id}", data)
+
+    async def list_optimization_decisions(self, filters: Optional[dict] = None) -> list[dict]:
+        """List optimization decisions, optionally filtered."""
+        keys = await self.keys("opt_decision:*")
+        decisions = []
+        for key in keys:
+            decision = await self.get(key)
+            if decision is None:
+                continue
+            if filters:
+                if "campaign_id" in filters and decision.get("campaign_id") != filters["campaign_id"]:
+                    continue
+            decisions.append(decision)
+        return decisions
+
+    # ------------------------------------------------------------------
+    # Experiment operations
+    # ------------------------------------------------------------------
+
+    async def get_experiment(self, experiment_id: str) -> Optional[dict]:
+        """Get an experiment by ID."""
+        return await self.get(f"experiment:{experiment_id}")
+
+    async def set_experiment(self, experiment_id: str, data: dict) -> None:
+        """Store an experiment."""
+        await self.set(f"experiment:{experiment_id}", data)
+
+    async def list_experiments(self, filters: Optional[dict] = None) -> list[dict]:
+        """List experiments, optionally filtered."""
+        keys = await self.keys("experiment:*")
+        experiments = []
+        for key in keys:
+            if key.startswith("experiment_result:"):
+                continue
+            experiment = await self.get(key)
+            if experiment is None:
+                continue
+            if filters:
+                if "campaign_id" in filters and experiment.get("campaign_id") != filters["campaign_id"]:
+                    continue
+                if "status" in filters and experiment.get("status") != filters["status"]:
+                    continue
+            experiments.append(experiment)
+        return experiments
+
+    # ------------------------------------------------------------------
+    # Supply path score operations
+    # ------------------------------------------------------------------
+
+    async def get_supply_path_score(self, supply_path_hash: str) -> Optional[dict]:
+        """Get a supply path score."""
+        return await self.get(f"supply_path:{supply_path_hash}")
+
+    async def set_supply_path_score(self, supply_path_hash: str, data: dict) -> None:
+        """Store a supply path score."""
+        await self.set(f"supply_path:{supply_path_hash}", data)
+
+    async def list_supply_path_scores(self) -> list[dict]:
+        """List all supply path scores."""
+        keys = await self.keys("supply_path:*")
+        scores = []
+        for key in keys:
+            score = await self.get(key)
+            if score:
+                scores.append(score)
+        return scores
+
+    # ------------------------------------------------------------------
+    # Quote operations
+    # ------------------------------------------------------------------
+
+    async def get_quote(self, quote_id: str) -> Optional[dict]:
+        """Get a quote by ID."""
+        return await self.get(f"quote:{quote_id}")
+
+    async def set_quote(self, quote_id: str, data: dict, ttl: int = 86400) -> None:
+        """Store a quote with TTL (default 24 hours)."""
+        await self.set(f"quote:{quote_id}", data, ttl=ttl)
+
+    # ------------------------------------------------------------------
+    # Negotiation operations
+    # ------------------------------------------------------------------
+
+    async def get_negotiation(self, proposal_id: str) -> Optional[dict]:
+        """Get negotiation history by proposal ID."""
+        return await self.get(f"negotiation:{proposal_id}")
+
+    async def set_negotiation(self, proposal_id: str, data: dict) -> None:
+        """Store negotiation history."""
+        await self.set(f"negotiation:{proposal_id}", data)
+
+    # ------------------------------------------------------------------
+    # Model artifact operations
+    # ------------------------------------------------------------------
+
+    async def get_model_artifact(self, model_name: str) -> Optional[dict]:
+        """Get a serialized model artifact."""
+        return await self.get(f"model:{model_name}")
+
+    async def set_model_artifact(self, model_name: str, data: dict) -> None:
+        """Store a serialized model artifact."""
+        await self.set(f"model:{model_name}", data)
+
+    # ------------------------------------------------------------------
+    # Pacing snapshot operations
+    # ------------------------------------------------------------------
+
+    async def get_pacing_snapshot(self, snapshot_id: str) -> Optional[dict]:
+        """Get a pacing snapshot by ID."""
+        return await self.get(f"pacing:{snapshot_id}")
+
+    async def set_pacing_snapshot(self, snapshot_id: str, data: dict) -> None:
+        """Store a pacing snapshot."""
+        await self.set(f"pacing:{snapshot_id}", data)

--- a/src/ad_buyer/storage/factory.py
+++ b/src/ad_buyer/storage/factory.py
@@ -1,0 +1,111 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Storage backend factory.
+
+Mirrors the seller-agent's factory pattern for structural consistency.
+Supports SQLite (default), Redis, and Hybrid backends.
+"""
+
+from typing import Optional
+
+from ad_buyer.storage.base import StorageBackend
+from ad_buyer.storage.sqlite_backend import SQLiteBackend
+
+
+def get_storage_backend(
+    storage_type: Optional[str] = None,
+    database_url: Optional[str] = None,
+    redis_url: Optional[str] = None,
+) -> StorageBackend:
+    """Create and return the appropriate storage backend.
+
+    Args:
+        storage_type: Type of storage ("sqlite", "redis", or "hybrid").
+                      If None, auto-detects from available config.
+        database_url: Database URL (for sqlite or hybrid backends)
+        redis_url: Redis connection URL (for redis or hybrid backends)
+
+    Returns:
+        StorageBackend instance
+
+    Raises:
+        ValueError: If invalid storage type or missing configuration
+    """
+    from ad_buyer.config.settings import settings
+
+    storage_type = storage_type or getattr(settings, "storage_type", "sqlite")
+    database_url = database_url or settings.database_url
+    redis_url = redis_url or getattr(settings, "redis_url", None)
+
+    if storage_type is None:
+        storage_type = "redis" if redis_url else "sqlite"
+
+    storage_type = storage_type.lower()
+
+    if storage_type == "sqlite":
+        if not database_url:
+            database_url = "sqlite:///./ad_buyer.db"
+        return SQLiteBackend(database_url=database_url)
+
+    elif storage_type == "redis":
+        if not redis_url:
+            raise ValueError(
+                "Redis URL required for redis storage. "
+                "Set REDIS_URL environment variable or pass redis_url parameter."
+            )
+        # Lazy import to avoid requiring redis dependency
+        from ad_buyer.storage.redis_backend import RedisBackend
+
+        return RedisBackend(redis_url=redis_url)
+
+    elif storage_type == "hybrid":
+        if not database_url or not database_url.startswith("postgresql"):
+            raise ValueError(
+                "PostgreSQL URL required for hybrid storage. "
+                "Set DATABASE_URL=postgresql+asyncpg://user:pass@host/db"
+            )
+        if not redis_url:
+            raise ValueError(
+                "Redis URL required for hybrid storage. Set REDIS_URL=redis://host:6379/0"
+            )
+        from ad_buyer.storage.hybrid_backend import HybridBackend
+        from ad_buyer.storage.postgres_backend import PostgresBackend
+        from ad_buyer.storage.redis_backend import RedisBackend
+
+        pg = PostgresBackend(
+            database_url=database_url,
+            pool_min=getattr(settings, "postgres_pool_min", 2),
+            pool_max=getattr(settings, "postgres_pool_max", 10),
+        )
+        redis = RedisBackend(redis_url=redis_url)
+        return HybridBackend(postgres=pg, redis=redis)
+
+    else:
+        raise ValueError(
+            f"Unknown storage type: {storage_type}. Supported types: sqlite, redis, hybrid"
+        )
+
+
+# Global storage instance (lazy initialization)
+_storage_instance: Optional[StorageBackend] = None
+
+
+async def get_storage() -> StorageBackend:
+    """Get the global storage instance, creating it if needed."""
+    global _storage_instance
+
+    if _storage_instance is None:
+        _storage_instance = get_storage_backend()
+        await _storage_instance.connect()
+
+    return _storage_instance
+
+
+async def close_storage() -> None:
+    """Close the global storage instance."""
+    global _storage_instance
+
+    if _storage_instance is not None:
+        await _storage_instance.disconnect()
+        _storage_instance = None

--- a/src/ad_buyer/storage/hybrid_backend.py
+++ b/src/ad_buyer/storage/hybrid_backend.py
@@ -1,0 +1,78 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Hybrid storage backend — routes keys to Postgres or Redis by prefix.
+
+Business data (deals, campaigns, orders, conversions, optimization decisions,
+experiments, etc.) goes to PostgreSQL for durability.  Sessions, caches, and
+ephemeral data go to Redis for speed and automatic TTL eviction.
+"""
+
+from typing import Any, Optional
+
+from ad_buyer.storage.base import StorageBackend
+
+# Key prefixes routed to Redis (sessions, caches, ephemeral)
+_REDIS_PREFIXES = frozenset(
+    {
+        "session:",
+        "session_index:",
+        "cache:",
+        "lock:",
+        "pubsub:",
+        "rate_limit:",
+    }
+)
+
+
+def _is_redis_key(key: str) -> bool:
+    """Return True if this key should be stored in Redis."""
+    for prefix in _REDIS_PREFIXES:
+        if key.startswith(prefix):
+            return True
+    return False
+
+
+class HybridBackend(StorageBackend):
+    """Routes storage operations to Postgres or Redis based on key prefix.
+
+    - **Postgres**: deals, campaigns, orders, conversions, optimization
+      decisions, experiments, supply path scores, model artifacts, quotes,
+      negotiations — anything that must survive a Redis flush.
+    - **Redis**: sessions, session indexes, caches, locks, pubsub, rate
+      limits — ephemeral data that benefits from in-memory speed and
+      native TTL.
+    """
+
+    def __init__(self, postgres: StorageBackend, redis: StorageBackend):
+        self._pg = postgres
+        self._redis = redis
+
+    def _backend_for(self, key: str) -> StorageBackend:
+        return self._redis if _is_redis_key(key) else self._pg
+
+    async def connect(self) -> None:
+        await self._pg.connect()
+        await self._redis.connect()
+
+    async def disconnect(self) -> None:
+        await self._redis.disconnect()
+        await self._pg.disconnect()
+
+    async def get(self, key: str) -> Optional[Any]:
+        return await self._backend_for(key).get(key)
+
+    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        await self._backend_for(key).set(key, value, ttl=ttl)
+
+    async def delete(self, key: str) -> bool:
+        return await self._backend_for(key).delete(key)
+
+    async def exists(self, key: str) -> bool:
+        return await self._backend_for(key).exists(key)
+
+    async def keys(self, pattern: str = "*") -> list[str]:
+        """Query both backends and merge results."""
+        pg_keys = await self._pg.keys(pattern)
+        redis_keys = await self._redis.keys(pattern)
+        return pg_keys + redis_keys

--- a/src/ad_buyer/storage/postgres_backend.py
+++ b/src/ad_buyer/storage/postgres_backend.py
@@ -1,0 +1,166 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""PostgreSQL storage backend implementation.
+
+Uses a JSONB key-value table, drop-in compatible with SQLite and Redis backends.
+Requires asyncpg: pip install asyncpg
+"""
+
+import json
+import time
+from typing import Any, Optional
+
+from ad_buyer.storage.base import StorageBackend
+
+
+class PostgresBackend(StorageBackend):
+    """PostgreSQL-based storage backend.
+
+    Uses a key-value store with JSONB values, matching the same interface
+    as SQLiteBackend and RedisBackend. Suitable for production multi-instance
+    deployments with durable storage.
+    """
+
+    def __init__(self, database_url: str, pool_min: int = 2, pool_max: int = 10):
+        """Initialize PostgreSQL backend.
+
+        Args:
+            database_url: PostgreSQL connection string.
+                          Accepts both ``postgresql://`` and ``postgresql+asyncpg://`` prefixes.
+            pool_min: Minimum connection pool size.
+            pool_max: Maximum connection pool size.
+        """
+        # Normalize URL — asyncpg expects ``postgresql://`` not ``postgresql+asyncpg://``
+        self._dsn = database_url.replace("postgresql+asyncpg://", "postgresql://")
+        self._pool_min = pool_min
+        self._pool_max = pool_max
+        self._pool = None
+
+    async def connect(self) -> None:
+        """Create connection pool and ensure the KV table exists."""
+        import asyncpg
+
+        self._pool = await asyncpg.create_pool(
+            dsn=self._dsn,
+            min_size=self._pool_min,
+            max_size=self._pool_max,
+        )
+
+        async with self._pool.acquire() as conn:
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS kv_store (
+                    key   TEXT PRIMARY KEY,
+                    value JSONB NOT NULL,
+                    expires_at DOUBLE PRECISION
+                )
+            """)
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_kv_expires
+                ON kv_store (expires_at)
+                WHERE expires_at IS NOT NULL
+            """)
+
+    async def disconnect(self) -> None:
+        """Close the connection pool."""
+        if self._pool:
+            await self._pool.close()
+            self._pool = None
+
+    def _ensure_pool(self) -> None:
+        if self._pool is None:
+            raise RuntimeError("Storage not connected. Call connect() first.")
+
+    async def get(self, key: str) -> Optional[Any]:
+        """Retrieve a value by key, respecting TTL."""
+        self._ensure_pool()
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT value, expires_at FROM kv_store WHERE key = $1",
+                key,
+            )
+            if row is None:
+                return None
+
+            expires_at = row["expires_at"]
+            if expires_at is not None and expires_at < time.time():
+                await conn.execute("DELETE FROM kv_store WHERE key = $1", key)
+                return None
+
+            # asyncpg returns JSONB as native Python objects
+            return row["value"]
+
+    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        """Store a value with optional TTL (seconds)."""
+        self._ensure_pool()
+        expires_at = time.time() + ttl if ttl else None
+
+        # asyncpg needs the value as a JSON string for JSONB parameter binding
+        json_value = json.dumps(value)
+
+        async with self._pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO kv_store (key, value, expires_at)
+                VALUES ($1, $2::jsonb, $3)
+                ON CONFLICT (key) DO UPDATE
+                SET value = EXCLUDED.value, expires_at = EXCLUDED.expires_at
+                """,
+                key,
+                json_value,
+                expires_at,
+            )
+
+    async def delete(self, key: str) -> bool:
+        """Delete a key. Returns True if key existed."""
+        self._ensure_pool()
+        async with self._pool.acquire() as conn:
+            result = await conn.execute("DELETE FROM kv_store WHERE key = $1", key)
+            # asyncpg returns 'DELETE N' where N is row count
+            return result != "DELETE 0"
+
+    async def exists(self, key: str) -> bool:
+        """Check if a non-expired key exists."""
+        self._ensure_pool()
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchval(
+                """
+                SELECT 1 FROM kv_store
+                WHERE key = $1
+                  AND (expires_at IS NULL OR expires_at > $2)
+                """,
+                key,
+                time.time(),
+            )
+            return row is not None
+
+    async def keys(self, pattern: str = "*") -> list[str]:
+        """List keys matching a glob pattern.
+
+        Translates ``*`` to ``%`` and ``?`` to ``_`` for SQL LIKE.
+        """
+        self._ensure_pool()
+        sql_pattern = pattern.replace("*", "%").replace("?", "_")
+
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT key FROM kv_store
+                WHERE key LIKE $1
+                  AND (expires_at IS NULL OR expires_at > $2)
+                """,
+                sql_pattern,
+                time.time(),
+            )
+            return [row["key"] for row in rows]
+
+    async def cleanup_expired(self) -> int:
+        """Remove all expired entries. Returns count of rows deleted."""
+        self._ensure_pool()
+        async with self._pool.acquire() as conn:
+            result = await conn.execute(
+                "DELETE FROM kv_store WHERE expires_at IS NOT NULL AND expires_at < $1",
+                time.time(),
+            )
+            # result is 'DELETE N'
+            return int(result.split()[-1])

--- a/src/ad_buyer/storage/redis_backend.py
+++ b/src/ad_buyer/storage/redis_backend.py
@@ -1,0 +1,158 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Redis storage backend implementation.
+
+Suitable for production deployments requiring high availability,
+distributed access, pub/sub capabilities, and advanced caching with TTL.
+
+Requires redis package: pip install redis
+"""
+
+import json
+from typing import Any, Optional
+
+from ad_buyer.storage.base import StorageBackend
+
+try:
+    import redis.asyncio as redis
+
+    REDIS_AVAILABLE = True
+except ImportError:
+    REDIS_AVAILABLE = False
+
+
+class RedisBackend(StorageBackend):
+    """Redis-based storage backend.
+
+    Suitable for production deployments requiring:
+    - High availability
+    - Distributed access
+    - Pub/sub capabilities
+    - Advanced caching with TTL
+
+    Requires redis package: pip install redis
+    """
+
+    def __init__(self, redis_url: str, key_prefix: str = "ad_buyer:"):
+        """Initialize Redis backend.
+
+        Args:
+            redis_url: Redis connection URL (e.g., redis://localhost:6379/0)
+            key_prefix: Prefix for all keys to namespace the data
+        """
+        if not REDIS_AVAILABLE:
+            raise ImportError("Redis package not installed. Install with: pip install redis")
+
+        self.redis_url = redis_url
+        self.key_prefix = key_prefix
+        self._client: Optional[redis.Redis] = None
+
+    def _prefixed_key(self, key: str) -> str:
+        """Add prefix to key for namespacing."""
+        return f"{self.key_prefix}{key}"
+
+    def _unprefixed_key(self, key: str) -> str:
+        """Remove prefix from key."""
+        if key.startswith(self.key_prefix):
+            return key[len(self.key_prefix):]
+        return key
+
+    async def connect(self) -> None:
+        """Establish connection to Redis."""
+        self._client = redis.from_url(
+            self.redis_url,
+            encoding="utf-8",
+            decode_responses=True,
+        )
+        # Test connection
+        await self._client.ping()
+
+    async def disconnect(self) -> None:
+        """Close the Redis connection."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+    async def get(self, key: str) -> Optional[Any]:
+        """Retrieve a value by key."""
+        if not self._client:
+            raise RuntimeError("Storage not connected. Call connect() first.")
+
+        value = await self._client.get(self._prefixed_key(key))
+        if value is None:
+            return None
+
+        return json.loads(value)
+
+    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        """Store a value with optional TTL (seconds)."""
+        if not self._client:
+            raise RuntimeError("Storage not connected. Call connect() first.")
+
+        json_value = json.dumps(value)
+        prefixed = self._prefixed_key(key)
+
+        if ttl:
+            await self._client.setex(prefixed, ttl, json_value)
+        else:
+            await self._client.set(prefixed, json_value)
+
+    async def delete(self, key: str) -> bool:
+        """Delete a key. Returns True if key existed."""
+        if not self._client:
+            raise RuntimeError("Storage not connected. Call connect() first.")
+
+        result = await self._client.delete(self._prefixed_key(key))
+        return result > 0
+
+    async def exists(self, key: str) -> bool:
+        """Check if key exists."""
+        if not self._client:
+            raise RuntimeError("Storage not connected. Call connect() first.")
+
+        result = await self._client.exists(self._prefixed_key(key))
+        return result > 0
+
+    async def keys(self, pattern: str = "*") -> list[str]:
+        """List keys matching pattern."""
+        if not self._client:
+            raise RuntimeError("Storage not connected. Call connect() first.")
+
+        prefixed_pattern = self._prefixed_key(pattern)
+        keys = await self._client.keys(prefixed_pattern)
+        return [self._unprefixed_key(k) for k in keys]
+
+    # Redis-specific methods
+
+    async def publish(self, channel: str, message: Any) -> int:
+        """Publish a message to a channel (pub/sub).
+
+        Returns the number of subscribers that received the message.
+        """
+        if not self._client:
+            raise RuntimeError("Storage not connected. Call connect() first.")
+
+        json_message = json.dumps(message)
+        return await self._client.publish(f"{self.key_prefix}channel:{channel}", json_message)
+
+    async def incr(self, key: str) -> int:
+        """Increment a counter. Returns new value."""
+        if not self._client:
+            raise RuntimeError("Storage not connected. Call connect() first.")
+
+        return await self._client.incr(self._prefixed_key(key))
+
+    async def get_stats(self) -> dict:
+        """Get Redis server statistics."""
+        if not self._client:
+            raise RuntimeError("Storage not connected. Call connect() first.")
+
+        info = await self._client.info()
+        return {
+            "connected_clients": info.get("connected_clients"),
+            "used_memory_human": info.get("used_memory_human"),
+            "total_commands_processed": info.get("total_commands_processed"),
+            "keyspace_hits": info.get("keyspace_hits"),
+            "keyspace_misses": info.get("keyspace_misses"),
+        }

--- a/src/ad_buyer/storage/sqlite_backend.py
+++ b/src/ad_buyer/storage/sqlite_backend.py
@@ -1,0 +1,165 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""SQLite storage backend implementation.
+
+Mirrors the seller-agent's SQLiteBackend for structural consistency.
+Uses a simple key-value store pattern with JSON serialization.
+Suitable for development and single-instance deployments.
+"""
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+import aiosqlite
+
+from ad_buyer.storage.base import StorageBackend
+
+
+class SQLiteBackend(StorageBackend):
+    """SQLite-based storage backend.
+
+    Uses a simple key-value store pattern with JSON serialization.
+    Suitable for development and single-instance deployments.
+    """
+
+    def __init__(self, database_url: str):
+        """Initialize SQLite backend.
+
+        Args:
+            database_url: SQLite connection string (e.g., sqlite:///./ad_buyer.db)
+        """
+        if database_url.startswith("sqlite:///"):
+            self.db_path = database_url[len("sqlite:///"):]
+        elif database_url.startswith("sqlite://"):
+            self.db_path = database_url[len("sqlite://"):]
+        else:
+            self.db_path = database_url
+
+        self._connection: Optional[aiosqlite.Connection] = None
+
+    async def connect(self) -> None:
+        """Establish connection and create tables."""
+        db_dir = Path(self.db_path).parent
+        if db_dir and str(db_dir) != "." and not db_dir.exists():
+            db_dir.mkdir(parents=True, exist_ok=True)
+
+        self._connection = await aiosqlite.connect(self.db_path)
+
+        await self._connection.execute("""
+            CREATE TABLE IF NOT EXISTS kv_store (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                expires_at REAL
+            )
+        """)
+
+        await self._connection.execute("""
+            CREATE INDEX IF NOT EXISTS idx_expires_at ON kv_store(expires_at)
+        """)
+
+        await self._connection.commit()
+
+    async def disconnect(self) -> None:
+        """Close the database connection."""
+        if self._connection:
+            await self._connection.close()
+            self._connection = None
+
+    async def _cleanup_expired(self) -> None:
+        """Remove expired entries."""
+        if self._connection:
+            current_time = time.time()
+            await self._connection.execute(
+                "DELETE FROM kv_store WHERE expires_at IS NOT NULL AND expires_at < ?",
+                (current_time,),
+            )
+            await self._connection.commit()
+
+    async def get(self, key: str) -> Optional[Any]:
+        """Retrieve a value by key."""
+        if not self._connection:
+            raise RuntimeError("Storage not connected. Call connect() first.")
+
+        await self._cleanup_expired()
+
+        async with self._connection.execute(
+            "SELECT value, expires_at FROM kv_store WHERE key = ?", (key,)
+        ) as cursor:
+            row = await cursor.fetchone()
+
+            if row is None:
+                return None
+
+            value, expires_at = row
+
+            if expires_at is not None and expires_at < time.time():
+                await self.delete(key)
+                return None
+
+            return json.loads(value)
+
+    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        """Store a value with optional TTL (seconds)."""
+        if not self._connection:
+            raise RuntimeError("Storage not connected. Call connect() first.")
+
+        expires_at = time.time() + ttl if ttl else None
+        json_value = json.dumps(value)
+
+        await self._connection.execute(
+            """
+            INSERT OR REPLACE INTO kv_store (key, value, expires_at)
+            VALUES (?, ?, ?)
+            """,
+            (key, json_value, expires_at),
+        )
+        await self._connection.commit()
+
+    async def delete(self, key: str) -> bool:
+        """Delete a key. Returns True if key existed."""
+        if not self._connection:
+            raise RuntimeError("Storage not connected. Call connect() first.")
+
+        async with self._connection.execute(
+            "DELETE FROM kv_store WHERE key = ?", (key,)
+        ) as cursor:
+            await self._connection.commit()
+            return cursor.rowcount > 0
+
+    async def exists(self, key: str) -> bool:
+        """Check if key exists."""
+        if not self._connection:
+            raise RuntimeError("Storage not connected. Call connect() first.")
+
+        await self._cleanup_expired()
+
+        async with self._connection.execute(
+            "SELECT 1 FROM kv_store WHERE key = ? AND (expires_at IS NULL OR expires_at > ?)",
+            (key, time.time()),
+        ) as cursor:
+            row = await cursor.fetchone()
+            return row is not None
+
+    async def keys(self, pattern: str = "*") -> list[str]:
+        """List keys matching pattern.
+
+        Supports basic wildcards:
+        - * matches any characters
+        - ? matches single character
+        """
+        if not self._connection:
+            raise RuntimeError("Storage not connected. Call connect() first.")
+
+        await self._cleanup_expired()
+
+        sql_pattern = pattern.replace("*", "%").replace("?", "_")
+
+        async with self._connection.execute(
+            "SELECT key FROM kv_store WHERE key LIKE ? AND (expires_at IS NULL OR expires_at > ?)",
+            (sql_pattern, time.time()),
+        ) as cursor:
+            rows = await cursor.fetchall()
+            return [row[0] for row in rows]

--- a/tests/unit/test_storage_backend.py
+++ b/tests/unit/test_storage_backend.py
@@ -1,0 +1,385 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Tests for the StorageBackend ABC, SQLiteBackend, and factory."""
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+from ad_buyer.storage.base import StorageBackend
+from ad_buyer.storage.factory import get_storage_backend
+from ad_buyer.storage.sqlite_backend import SQLiteBackend
+
+
+@pytest.fixture
+def tmp_db_path():
+    """Create a temporary database file path."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+@pytest.fixture
+def db_url(tmp_db_path):
+    """Create a SQLite URL from temp path."""
+    return f"sqlite:///{tmp_db_path}"
+
+
+class TestSQLiteBackend:
+    """Test the SQLiteBackend implementation."""
+
+    @pytest.mark.asyncio
+    async def test_connect_and_disconnect(self, db_url):
+        backend = SQLiteBackend(db_url)
+        await backend.connect()
+        assert backend._connection is not None
+        await backend.disconnect()
+        assert backend._connection is None
+
+    @pytest.mark.asyncio
+    async def test_set_and_get(self, db_url):
+        backend = SQLiteBackend(db_url)
+        await backend.connect()
+        try:
+            await backend.set("test:key", {"hello": "world"})
+            result = await backend.get("test:key")
+            assert result == {"hello": "world"}
+        finally:
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent(self, db_url):
+        backend = SQLiteBackend(db_url)
+        await backend.connect()
+        try:
+            result = await backend.get("nonexistent")
+            assert result is None
+        finally:
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_delete(self, db_url):
+        backend = SQLiteBackend(db_url)
+        await backend.connect()
+        try:
+            await backend.set("test:del", "value")
+            assert await backend.delete("test:del") is True
+            assert await backend.get("test:del") is None
+            assert await backend.delete("test:del") is False
+        finally:
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_exists(self, db_url):
+        backend = SQLiteBackend(db_url)
+        await backend.connect()
+        try:
+            assert await backend.exists("test:exists") is False
+            await backend.set("test:exists", "val")
+            assert await backend.exists("test:exists") is True
+        finally:
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_keys_pattern(self, db_url):
+        backend = SQLiteBackend(db_url)
+        await backend.connect()
+        try:
+            await backend.set("deal:1", {"id": 1})
+            await backend.set("deal:2", {"id": 2})
+            await backend.set("campaign:1", {"id": 1})
+
+            deal_keys = await backend.keys("deal:*")
+            assert len(deal_keys) == 2
+            assert "deal:1" in deal_keys
+            assert "deal:2" in deal_keys
+
+            campaign_keys = await backend.keys("campaign:*")
+            assert len(campaign_keys) == 1
+        finally:
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_ttl_expiration(self, db_url):
+        backend = SQLiteBackend(db_url)
+        await backend.connect()
+        try:
+            # Set with 1-second TTL and wait for expiration
+            await backend.set("test:ttl", "expired", ttl=1)
+            # Verify it exists immediately
+            result = await backend.get("test:ttl")
+            assert result == "expired"
+            # Wait for expiration
+            await asyncio.sleep(1.1)
+            result = await backend.get("test:ttl")
+            assert result is None
+        finally:
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_upsert(self, db_url):
+        backend = SQLiteBackend(db_url)
+        await backend.connect()
+        try:
+            await backend.set("test:up", {"v": 1})
+            await backend.set("test:up", {"v": 2})
+            result = await backend.get("test:up")
+            assert result == {"v": 2}
+        finally:
+            await backend.disconnect()
+
+
+class TestStorageBackendDomainHelpers:
+    """Test the domain helper methods on StorageBackend."""
+
+    @pytest.mark.asyncio
+    async def test_deal_helpers(self, db_url):
+        backend = SQLiteBackend(db_url)
+        await backend.connect()
+        try:
+            deal = {"deal_id": "DEAL-001", "status": "active", "deal_type": "PG"}
+            await backend.set_deal("DEAL-001", deal)
+            result = await backend.get_deal("DEAL-001")
+            assert result["deal_id"] == "DEAL-001"
+
+            deals = await backend.list_deals()
+            assert len(deals) == 1
+
+            deals_filtered = await backend.list_deals({"status": "inactive"})
+            assert len(deals_filtered) == 0
+        finally:
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_campaign_helpers(self, db_url):
+        backend = SQLiteBackend(db_url)
+        await backend.connect()
+        try:
+            campaign = {"campaign_id": "C-001", "status": "active"}
+            await backend.set_campaign("C-001", campaign)
+            result = await backend.get_campaign("C-001")
+            assert result["campaign_id"] == "C-001"
+        finally:
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_conversion_helpers(self, db_url):
+        backend = SQLiteBackend(db_url)
+        await backend.connect()
+        try:
+            conversion = {"event_id": "E-001", "deal_id": "D-001", "campaign_id": "C-001"}
+            await backend.set_conversion("E-001", conversion)
+            result = await backend.get_conversion("E-001")
+            assert result["event_id"] == "E-001"
+
+            conversions = await backend.list_conversions({"deal_id": "D-001"})
+            assert len(conversions) == 1
+
+            conversions_miss = await backend.list_conversions({"deal_id": "D-999"})
+            assert len(conversions_miss) == 0
+        finally:
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_experiment_helpers(self, db_url):
+        backend = SQLiteBackend(db_url)
+        await backend.connect()
+        try:
+            exp = {"experiment_id": "EXP-001", "campaign_id": "C-001", "status": "active"}
+            await backend.set_experiment("EXP-001", exp)
+            result = await backend.get_experiment("EXP-001")
+            assert result["experiment_id"] == "EXP-001"
+
+            exps = await backend.list_experiments({"campaign_id": "C-001"})
+            assert len(exps) == 1
+        finally:
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_supply_path_helpers(self, db_url):
+        backend = SQLiteBackend(db_url)
+        await backend.connect()
+        try:
+            score = {"supply_path_hash": "abc123", "composite_score": 0.85}
+            await backend.set_supply_path_score("abc123", score)
+            result = await backend.get_supply_path_score("abc123")
+            assert result["composite_score"] == 0.85
+
+            scores = await backend.list_supply_path_scores()
+            assert len(scores) == 1
+        finally:
+            await backend.disconnect()
+
+
+class TestStorageFactory:
+    """Test the storage backend factory."""
+
+    def test_factory_returns_sqlite_by_default(self):
+        backend = get_storage_backend(
+            storage_type="sqlite",
+            database_url="sqlite:///./test_factory.db",
+        )
+        assert isinstance(backend, SQLiteBackend)
+
+    def test_factory_invalid_type(self):
+        with pytest.raises(ValueError, match="Unknown storage type"):
+            get_storage_backend(storage_type="invalid")
+
+    def test_factory_redis_requires_url(self):
+        with pytest.raises(ValueError, match="Redis URL required"):
+            get_storage_backend(storage_type="redis")
+
+    def test_factory_hybrid_requires_postgres_url(self):
+        with pytest.raises(ValueError, match="PostgreSQL URL required"):
+            get_storage_backend(
+                storage_type="hybrid",
+                database_url="sqlite:///./test.db",
+                redis_url="redis://localhost:6379/0",
+            )
+
+    def test_factory_hybrid_requires_redis_url(self):
+        with pytest.raises(ValueError, match="Redis URL required"):
+            get_storage_backend(
+                storage_type="hybrid",
+                database_url="postgresql+asyncpg://user:pass@localhost/db",
+            )
+
+    def test_sqlite_backend_is_storage_backend(self):
+        """Verify SQLiteBackend implements the StorageBackend ABC."""
+        backend = SQLiteBackend("sqlite:///./test.db")
+        assert isinstance(backend, StorageBackend)
+
+
+class TestPostgresBackendInit:
+    """Test PostgresBackend can be instantiated (no live connection)."""
+
+    def test_postgres_importable(self):
+        from ad_buyer.storage.postgres_backend import PostgresBackend
+
+        backend = PostgresBackend(
+            database_url="postgresql+asyncpg://user:pass@localhost/test",
+            pool_min=1,
+            pool_max=5,
+        )
+        assert backend._dsn == "postgresql://user:pass@localhost/test"
+        assert backend._pool_min == 1
+        assert backend._pool_max == 5
+        assert isinstance(backend, StorageBackend)
+
+    def test_postgres_url_normalization(self):
+        from ad_buyer.storage.postgres_backend import PostgresBackend
+
+        backend = PostgresBackend(database_url="postgresql://user:pass@host/db")
+        assert backend._dsn == "postgresql://user:pass@host/db"
+
+    @pytest.mark.asyncio
+    async def test_postgres_not_connected_raises(self):
+        from ad_buyer.storage.postgres_backend import PostgresBackend
+
+        backend = PostgresBackend(database_url="postgresql://localhost/test")
+        with pytest.raises(RuntimeError, match="not connected"):
+            await backend.get("test")
+
+
+class TestHybridBackendRouting:
+    """Test HybridBackend routes keys correctly."""
+
+    def test_hybrid_importable(self):
+        from ad_buyer.storage.hybrid_backend import HybridBackend
+
+        assert HybridBackend is not None
+
+    def test_redis_key_detection(self):
+        from ad_buyer.storage.hybrid_backend import _is_redis_key
+
+        # Should route to Redis
+        assert _is_redis_key("session:abc") is True
+        assert _is_redis_key("session_index:buyer:123") is True
+        assert _is_redis_key("cache:products") is True
+        assert _is_redis_key("lock:deal:123") is True
+        assert _is_redis_key("rate_limit:api") is True
+
+        # Should route to Postgres
+        assert _is_redis_key("deal:DEAL-001") is False
+        assert _is_redis_key("campaign:C-001") is False
+        assert _is_redis_key("order:O-001") is False
+        assert _is_redis_key("conversion:E-001") is False
+        assert _is_redis_key("opt_decision:D-001") is False
+        assert _is_redis_key("experiment:EXP-001") is False
+        assert _is_redis_key("supply_path:abc") is False
+        assert _is_redis_key("model:lightgbm") is False
+
+    @pytest.mark.asyncio
+    async def test_hybrid_routes_to_correct_backend(self, db_url):
+        """Hybrid backend routes durable keys to PG and ephemeral to Redis.
+
+        Since we can't spin up real PG/Redis in unit tests, we use two
+        SQLiteBackends to verify the routing logic.
+        """
+        from ad_buyer.storage.hybrid_backend import HybridBackend
+
+        # Use two separate SQLite backends as stand-ins
+        import tempfile
+
+        fd2, path2 = tempfile.mkstemp(suffix=".db")
+        os.close(fd2)
+
+        pg_backend = SQLiteBackend(db_url)
+        redis_backend = SQLiteBackend(f"sqlite:///{path2}")
+
+        hybrid = HybridBackend(postgres=pg_backend, redis=redis_backend)
+        await hybrid.connect()
+
+        try:
+            # Store a deal (should go to pg) and a session (should go to redis)
+            await hybrid.set("deal:D-001", {"id": "D-001"})
+            await hybrid.set("session:S-001", {"id": "S-001"})
+
+            # Verify deal is in pg, not redis
+            assert await pg_backend.get("deal:D-001") == {"id": "D-001"}
+            assert await redis_backend.get("deal:D-001") is None
+
+            # Verify session is in redis, not pg
+            assert await redis_backend.get("session:S-001") == {"id": "S-001"}
+            assert await pg_backend.get("session:S-001") is None
+
+            # Verify hybrid can read both
+            assert await hybrid.get("deal:D-001") == {"id": "D-001"}
+            assert await hybrid.get("session:S-001") == {"id": "S-001"}
+
+            # Verify keys merges from both
+            all_keys = await hybrid.keys("*")
+            assert "deal:D-001" in all_keys
+            assert "session:S-001" in all_keys
+        finally:
+            await hybrid.disconnect()
+            if os.path.exists(path2):
+                os.unlink(path2)
+
+
+class TestRedisBackendInit:
+    """Test RedisBackend initialization (no live Redis connection)."""
+
+    def test_redis_import_check(self):
+        """Verify redis_backend module is importable."""
+        from ad_buyer.storage.redis_backend import REDIS_AVAILABLE
+
+        # REDIS_AVAILABLE depends on whether redis is installed
+        assert isinstance(REDIS_AVAILABLE, bool)
+
+    def test_redis_is_storage_backend(self):
+        from ad_buyer.storage.redis_backend import REDIS_AVAILABLE
+
+        if not REDIS_AVAILABLE:
+            pytest.skip("redis package not installed")
+
+        from ad_buyer.storage.redis_backend import RedisBackend
+
+        backend = RedisBackend(redis_url="redis://localhost:6379/0")
+        assert isinstance(backend, StorageBackend)
+        assert backend.key_prefix == "ad_buyer:"

--- a/tests/unit/test_storage_backend.py
+++ b/tests/unit/test_storage_backend.py
@@ -230,9 +230,13 @@ class TestStorageFactory:
         with pytest.raises(ValueError, match="Unknown storage type"):
             get_storage_backend(storage_type="invalid")
 
-    def test_factory_redis_requires_url(self):
+    def test_factory_redis_requires_url(self, monkeypatch):
+        # Ensure ambient REDIS_URL (e.g. set by CI) does not satisfy the check.
+        from ad_buyer.config.settings import settings
+
+        monkeypatch.setattr(settings, "redis_url", None, raising=False)
         with pytest.raises(ValueError, match="Redis URL required"):
-            get_storage_backend(storage_type="redis")
+            get_storage_backend(storage_type="redis", redis_url=None)
 
     def test_factory_hybrid_requires_postgres_url(self):
         with pytest.raises(ValueError, match="PostgreSQL URL required"):
@@ -242,11 +246,16 @@ class TestStorageFactory:
                 redis_url="redis://localhost:6379/0",
             )
 
-    def test_factory_hybrid_requires_redis_url(self):
+    def test_factory_hybrid_requires_redis_url(self, monkeypatch):
+        # Ensure ambient REDIS_URL (e.g. set by CI) does not satisfy the check.
+        from ad_buyer.config.settings import settings
+
+        monkeypatch.setattr(settings, "redis_url", None, raising=False)
         with pytest.raises(ValueError, match="Redis URL required"):
             get_storage_backend(
                 storage_type="hybrid",
                 database_url="postgresql+asyncpg://user:pass@localhost/db",
+                redis_url=None,
             )
 
     def test_sqlite_backend_is_storage_backend(self):


### PR DESCRIPTION
## Summary

Adds a pluggable `StorageBackend` abstraction with four concrete implementations — **SQLite** (default), **Redis**, **PostgreSQL**, and a **Hybrid** mode that routes durable data to Postgres and ephemeral data to Redis. This mirrors the seller-agent's storage architecture and gives the buyer agent a path off the single-writer SQLite constraint that today caps deployments at one ECS task.

The legacy `DealStore` is untouched and remains the synchronous SQLite path used by CrewAI agents. Both APIs coexist; callers can migrate to the pluggable backend incrementally.

## Why

- **Horizontal scaling**: SQLite serializes writes, so production deployments are pinned to `DesiredCount: 1`. Hybrid mode lifts that.
- **Native TTL, pub/sub, distributed locks**: Sessions, caches, locks, and rate limits benefit from Redis primitives that SQLite can only emulate.
- **Structural consistency with seller-agent**: Same ABC shape (`connect`/`disconnect`/`get`/`set`/`delete`/`exists`/`keys` + domain helpers) and same factory pattern.

## What's added

**Storage code** (`src/ad_buyer/storage/`):
- `base.py` — `StorageBackend` ABC and async domain helpers (deal, campaign, order, session, conversion, optimization decision, experiment, supply path score, quote, negotiation, model artifact, pacing snapshot).
- `factory.py` — `get_storage_backend()` selects SQLite / Redis / Hybrid from settings or explicit args; lazy-imports Redis/asyncpg so the base install stays lean.
- `sqlite_backend.py` — `aiosqlite` KV implementation with optional TTL.
- `redis_backend.py` — `redis.asyncio` KV with namespaced keys, plus `publish` / `incr` / `get_stats` helpers. Importable without Redis installed (raises a clear `ImportError` only on construction).
- `postgres_backend.py` — `asyncpg` JSONB KV with connection pooling (`pool_min` / `pool_max`).
- `hybrid_backend.py` — Prefix-based routing: `session:`, `session_index:`, `cache:`, `lock:`, `pubsub:`, `rate_limit:` go to Redis; everything else to Postgres.
- `__init__.py` — Merged exports: legacy `DealStore` + new `StorageBackend` / `get_storage_backend`.

**Tests** (`tests/unit/test_storage_backend.py`):
- 27 tests covering SQLite KV, domain helpers, factory selection (sqlite default + invalid type + missing-URL paths for redis/hybrid), Postgres backend init + URL normalization + not-connected error, hybrid routing logic, and Redis backend availability gating.

**Config**:
- New settings: `storage_type`, `postgres_pool_min`, `postgres_pool_max`. All existing settings preserved; defaults keep SQLite behavior unchanged.
- `.env.example` gains `STORAGE_TYPE`, `POSTGRES_POOL_*`, and hybrid usage examples.
- `pyproject.toml` adds optional extras `[redis]`, `[postgres]`, `[production]`. Base dependencies and the `crewai==1.10.1` pin are preserved.

**Docs**:
- New `docs/architecture/storage-backends.md` with backend selection table, three-backend reference, routing rules, optional-extras install commands, configuration reference, and migration sketch.
- Cross-links added from `deal-store.md`, `overview.md`, `configuration.md`, `deployment.md`, `deployment-ops-guide.md`, and `mkdocs.yml` so the page is discoverable.

## Optional extras pattern

```bash
pip install -e .                  # SQLite only (default)
pip install -e ".[redis]"         # Add Redis
pip install -e ".[postgres]"      # Add PostgreSQL
pip install -e ".[production]"    # Both
```

The factory lazy-imports `redis` and `asyncpg`, so they're never loaded unless the corresponding backend is selected.

## Backwards compatibility

- **No upstream behavior changes.** Existing `DealStore` callers are unaffected.
- The factory is opt-in: leave `STORAGE_TYPE` unset (or set it to `sqlite`) to keep today's behavior.
- New optional extras don't affect the base install.

## What's left for follow-on

Callers still use `DealStore` directly. Migrating other domain stores (campaigns, orders, sessions, conversions, optimization, experiments, pacing) to the pluggable backend is incremental and out of scope here. The ABC includes the helper methods those migrations will need.

## Context

- Bead: `ar-r82f.3` (parent epic `ar-r82f`).
- This is the pluggable-storage piece of a larger upstreaming track. Optimization stores, engines/services/constants scaffolding, and other fork-side divergences (settings removals, ML deps, MCP path changes, doc renames) are intentionally NOT in this PR.

## Test plan

- [ ] CI green: full test suite passes (new `test_storage_backend.py`: 26 passed + 1 skipped locally; Redis test skips when `redis` package not installed).
- [ ] Import smoke test: `python -c "from ad_buyer.storage import StorageBackend, get_storage_backend, DealStore"` works in a fresh `uv sync --extra dev` env.
- [ ] Settings defaults preserved: existing `settings.database_url`, `settings.redis_url`, etc. unchanged; new `settings.storage_type = "sqlite"` by default.
- [ ] Optional extras: `pip install -e ".[redis]"` makes `RedisBackend` instantiable; `pip install -e ".[postgres]"` makes `PostgresBackend` connectable.
- [ ] Hybrid routing: durable keys (e.g. `deal:X`) land in Postgres; ephemeral keys (e.g. `session:X`) land in Redis (verified in test via dual-SQLite stand-ins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)