### PR TITLE
Skip cross-repo integration test when sibling repos absent (ar-r82f.6)

### DIFF
--- a/tests/integration/test_path_a_audience_e2e.py
+++ b/tests/integration/test_path_a_audience_e2e.py
@@ -799,9 +799,17 @@ class TestCrossRepoAudiencePlanJSONRoundTrip:
                 None,
             )
             if buyer_repo_root is None:
-                raise RuntimeError(
-                    "Could not locate ad_buyer_system in path ancestry "
-                    f"of {here}; set AD_SELLER_SRC_PATH to override."
+                # CI / standalone clones (e.g. IABTechLab/buyer-agent) check
+                # out only the buyer repo, so the ad_buyer_system / sibling
+                # ad_seller_system layout this round-trip needs does not
+                # exist. Skip cleanly here rather than erroring; the test
+                # can still be opted in locally by setting
+                # AD_SELLER_SRC_PATH or by checking out the sibling repos
+                # alongside an ad_buyer_system-named buyer checkout.
+                pytest.skip(
+                    "Cross-repo round-trip requires the sibling "
+                    "ad_seller_system checkout; set AD_SELLER_SRC_PATH to "
+                    f"the seller src/ directory to override. (here={here})"
                 )
             agent_range_root = buyer_repo_root.parent
             seller_main = agent_range_root / "ad_seller_system" / "src"
@@ -827,6 +835,15 @@ class TestCrossRepoAudiencePlanJSONRoundTrip:
                 )
             else:
                 seller_src = str(seller_main)
+            # Even with an ad_buyer_system-named ancestor, the sibling
+            # ad_seller_system tree may be absent (partial checkout). Skip
+            # in that case too rather than failing on the import below.
+            if not Path(seller_src).is_dir():
+                pytest.skip(
+                    "Cross-repo round-trip requires the sibling "
+                    f"ad_seller_system checkout; resolved path {seller_src} "
+                    "does not exist. Set AD_SELLER_SRC_PATH to override."
+                )
         sys.path.insert(0, seller_src)
         try:
             from ad_seller.models.audience_ref import AudienceRef as SellerRef


### PR DESCRIPTION
## Summary

`tests/integration/test_path_a_audience_e2e.py::TestCrossRepoAudiencePlanJSONRoundTrip::test_cross_repo_audience_plan_json_round_trip` was the one remaining failure in CI. It exercises an AudiencePlan JSON round-trip through the seller repo's `AudienceRef` model and locates the seller `src/` either via `AD_SELLER_SRC_PATH` or by walking up the path ancestry looking for an `ad_buyer_system` directory with a sibling `ad_seller_system`.

Standalone clones of `IABTechLab/buyer-agent` (including the GitHub Actions runner) check out only this repo, in a directory named `buyer-agent` rather than `ad_buyer_system`, so the ancestry walk returned `None` and the test raised `RuntimeError: Could not locate ad_buyer_system in path ancestry ... ; set AD_SELLER_SRC_PATH to override.` This was pre-existing, but only became visible after the collection error fixed in `ar-r82f.5`.

This PR keeps the test logic and assertions unchanged. It just gates the cross-repo half on environment availability:

- If `AD_SELLER_SRC_PATH` is unset *and* no `ad_buyer_system` ancestor is found, `pytest.skip` cleanly with a message naming the env override.
- If an `ad_buyer_system` ancestor is found but the resolved seller `src/` directory does not exist on disk (partial checkout), `pytest.skip` instead of failing on the import.
- All other code paths (env var set; sibling repos / worktrees present locally) continue to run the test exactly as before.

## How to run locally

The test still runs whenever the cross-repo layout or env override is present:

- Check out the repo into a directory named `ad_buyer_system/` alongside a sibling `ad_seller_system/` containing `src/ad_seller/...`, or
- Set `AD_SELLER_SRC_PATH=/path/to/ad_seller_system/src` before invoking pytest.

Then: `uv run pytest tests/integration/test_path_a_audience_e2e.py -v`

## Expected CI impact

This should bring the CI Test job to GREEN (0 failures) for the first time in a long while: the cross-repo round-trip moves from FAILED to SKIPPED, every other integration test in the file continues to run, and the skip count goes up by one.

## References

- Bead: `ar-r82f.6`
- Parent epic: `ar-r82f`
- Sister test: `tests/integration/test_path_b_audience_e2e.py` (no cross-repo dependency, already passing)

## Test plan

- [ ] CI passes (target: 3196 passed, 0 failed, ~60 skipped)
- [ ] `uv run pytest tests/integration/test_path_a_audience_e2e.py -v` locally shows the cross-repo test as SKIPPED on a standalone clone