### PR TITLE
Resolve duplicate test name in test_deal_entry.py (ar-r82f.19)

### DIFF
--- a/tests/unit/test_deal_entry.py
+++ b/tests/unit/test_deal_entry.py
@@ -478,45 +478,6 @@ class TestDealDataStructure:
         # metadata key should no longer be present
         assert "metadata" not in data
 
-    def test_deal_data_includes_v2_fields_as_top_level_keys(self):  # noqa: F811
-        """V2 fields must also appear as top-level deal_data keys for save_deal()."""
-        from ad_buyer.tools.deal_library.deal_entry import (
-            ManualDealEntry,
-            create_manual_deal,
-        )
-
-        entry = ManualDealEntry(
-            display_name="V2 Top-Level Deal",
-            seller_url="https://seller.example.com",
-            seller_org="NBCUniversal",
-            seller_domain="nbcuniversal.com",
-            seller_type="PUBLISHER",
-            buyer_org="MediaCo",
-            buyer_id="buyer-001",
-            price_model="CPM",
-            fixed_price_cpm=15.50,
-            bid_floor_cpm=12.00,
-            currency="EUR",
-            media_type="CTV",
-            description="Premium CTV inventory",
-        )
-        result = create_manual_deal(entry)
-
-        data = result.deal_data
-        # These must be top-level keys so save_deal() writes to v2 columns
-        assert data["display_name"] == "V2 Top-Level Deal"
-        assert data["seller_org"] == "NBCUniversal"
-        assert data["seller_domain"] == "nbcuniversal.com"
-        assert data["seller_type"] == "PUBLISHER"
-        assert data["buyer_org"] == "MediaCo"
-        assert data["buyer_id"] == "buyer-001"
-        assert data["price_model"] == "CPM"
-        assert data["fixed_price_cpm"] == 15.50
-        assert data["bid_floor_cpm"] == 12.00
-        assert data["currency"] == "EUR"
-        assert data["media_type"] == "CTV"
-        assert data["description"] == "Premium CTV inventory"
-
     def test_deal_data_v2_fields_absent_when_not_provided(self):
         """Optional v2 fields should be absent from deal_data when not provided."""
         from ad_buyer.tools.deal_library.deal_entry import (


### PR DESCRIPTION
## Summary

Resolves bead `ar-r82f.19`. The file `tests/unit/test_deal_entry.py` had two functions named `test_deal_data_includes_v2_fields_as_top_level_keys` (lines 438 and 481). Python silently shadowed the first definition with the second, meaning the line-438 test never executed. PR #95's lint sweep masked the F811 warning with `# noqa: F811` to keep its scope pure; this PR fixes the real bug.

## What changed

- **Deleted** the redundant duplicate test at line 481.
- **Removed** the `# noqa: F811` marker on the same line.

The two tests were functional duplicates:
- Both imported the same `ManualDealEntry` / `create_manual_deal` from `ad_buyer.tools.deal_library.deal_entry`.
- Both built a `ManualDealEntry` with the same v2 fields (only the `display_name` and `description` string values differed).
- Both asserted that `data["seller_org"]`, `data["seller_domain"]`, `data["seller_type"]`, `data["buyer_org"]`, `data["buyer_id"]`, `data["price_model"]`, `data["fixed_price_cpm"]`, `data["bid_floor_cpm"]`, `data["currency"]`, `data["media_type"]`, `data["description"]` matched the supplied entry.

The retained test (line 438) is the canonical/newer version and is strictly stronger: it adds `assert "metadata" not in data`, which the deleted variant did not check. `git blame` confirmed line 438 was added in commit `633d813` (2026-03-25 14:07) after the now-removed variant in commit `0bf2992` (2026-03-25 13:43); the newer test was the intended replacement that simply never deleted its predecessor.

## Test plan

- [x] `python -c "import ast; ast.parse(open('tests/unit/test_deal_entry.py').read())"` -- syntax OK
- [x] Duplicate name check: `grep "^def test_\|^    def test_" tests/unit/test_deal_entry.py | sort | uniq -c` -- no duplicates
- [x] `ruff check tests/unit/test_deal_entry.py` -- all checks passed
- [ ] CI test job runs and the previously-shadowed test now executes (look for `test_deal_data_includes_v2_fields_as_top_level_keys` in pytest output)
- [ ] No new lint warnings

bead: ar-r82f.19