### PR TITLE
Fix DealBookingFlow silent budget allocation failure (ar-jbod)

### DIFF
--- a/src/ad_buyer/crews/portfolio_crew.py
+++ b/src/ad_buyer/crews/portfolio_crew.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 from crewai import Crew, Process, Task
+from pydantic import BaseModel, Field
 
 from ..agents.level1.portfolio_manager import create_portfolio_manager
 from ..agents.level2.branding_agent import create_branding_agent
@@ -14,6 +15,28 @@ from ..agents.level2.mobile_app_agent import create_mobile_app_agent
 from ..agents.level2.performance_agent import create_performance_agent
 from ..clients.opendirect_client import OpenDirectClient
 from ..config.settings import settings
+
+
+class _ChannelAllocationOut(BaseModel):
+    """Single-channel allocation field shape produced by the portfolio crew."""
+
+    budget: float = Field(default=0.0, ge=0)
+    percentage: float = Field(default=0.0, ge=0, le=100)
+    rationale: str = ""
+
+
+class BudgetAllocationOutput(BaseModel):
+    """Structured output for the budget allocation task.
+
+    Forcing crewai to emit this via ``output_pydantic`` makes the result
+    type-safe and removes the need for fragile string-based JSON extraction
+    in ``DealBookingFlow._parse_allocations``.
+    """
+
+    branding: _ChannelAllocationOut = Field(default_factory=_ChannelAllocationOut)
+    mobile_app: _ChannelAllocationOut = Field(default_factory=_ChannelAllocationOut)
+    ctv: _ChannelAllocationOut = Field(default_factory=_ChannelAllocationOut)
+    performance: _ChannelAllocationOut = Field(default_factory=_ChannelAllocationOut)
 
 
 def create_portfolio_crew(
@@ -68,6 +91,7 @@ Not all channels may be needed - allocate $0 to channels that don't fit the obje
     "performance": {"budget": X, "percentage": Y, "rationale": "..."}
 }""",
         agent=portfolio_manager,
+        output_pydantic=BudgetAllocationOutput,
     )
 
     # Define channel coordination task

--- a/src/ad_buyer/flows/deal_booking_flow.py
+++ b/src/ad_buyer/flows/deal_booking_flow.py
@@ -314,12 +314,12 @@ class DealBookingFlow(Flow[BookingState]):
 
             result = portfolio_crew.kickoff()
 
-            # Parse allocation result
-            # The result should be a JSON string with allocations
-            result_str = str(result)
-
-            # Try to extract JSON from the result
-            allocations = self._parse_allocations(result_str)
+            # The portfolio crew has two tasks; only the first
+            # (budget_allocation_task) carries the allocation output. The crew's
+            # top-level ``raw`` reflects the LAST task (channel coordination)
+            # which has a different schema and would silently produce zero
+            # allocations if used directly.
+            allocations = self._extract_allocations(result)
 
             # Store allocations
             for channel, alloc_data in allocations.items():
@@ -356,36 +356,78 @@ class DealBookingFlow(Flow[BookingState]):
             self.state.execution_status = ExecutionStatus.FAILED
             return {"status": "failed", "error": str(e)}
 
-    def _parse_allocations(self, result_str: str) -> dict[str, Any]:
-        """Parse allocation JSON from crew result."""
-        # Try to find JSON in the result
-        try:
-            # Look for JSON block
-            start_idx = result_str.find("{")
-            end_idx = result_str.rfind("}") + 1
-            if start_idx >= 0 and end_idx > start_idx:
-                json_str = result_str[start_idx:end_idx]
-                return json.loads(json_str)
-        except json.JSONDecodeError:
-            pass
+    def _extract_allocations(self, result: Any) -> dict[str, Any]:
+        """Pull the budget allocation from a portfolio_crew kickoff result.
 
-        # Default allocations if parsing fails
+        Prefers the typed ``output_pydantic`` on the first task. Falls back
+        to ``json_dict`` on the first task. Final fallback is a default split.
+
+        Note: the crew has two tasks (budget allocation, channel coordination).
+        The crew's top-level ``raw``/``str()`` carries the LAST task's output,
+        which has the wrong schema. We must read ``tasks_output[0]`` directly.
+        """
+        first_task = None
+        if getattr(result, "tasks_output", None):
+            first_task = result.tasks_output[0]
+
+        if first_task is not None:
+            # Typed pydantic output is the authoritative source.
+            pyd = getattr(first_task, "pydantic", None)
+            if pyd is not None and hasattr(pyd, "model_dump"):
+                dumped = pyd.model_dump()
+                if any(c.get("budget", 0) > 0 for c in dumped.values()):
+                    return dumped
+
+            # If output_pydantic didn't capture for some reason, try json_dict.
+            json_dict = getattr(first_task, "json_dict", None)
+            if isinstance(json_dict, dict) and any(
+                c.get("budget", 0) > 0 for c in json_dict.values() if isinstance(c, dict)
+            ):
+                return json_dict
+
+            # Last resort: extract JSON block from the first task's raw text.
+            raw = getattr(first_task, "raw", "") or ""
+            parsed = self._extract_json_block(str(raw))
+            if parsed is not None:
+                return parsed
+
+        self.state.errors.append(
+            "Budget allocation: could not extract typed output from portfolio crew; "
+            "falling back to default split."
+        )
+        return self._default_allocations()
+
+    @staticmethod
+    def _extract_json_block(text: str) -> dict[str, Any] | None:
+        """Find and parse the first ``{...}`` block in text. Returns None on failure."""
+        start_idx = text.find("{")
+        end_idx = text.rfind("}") + 1
+        if start_idx < 0 or end_idx <= start_idx:
+            return None
+        try:
+            parsed = json.loads(text[start_idx:end_idx])
+            return parsed if isinstance(parsed, dict) else None
+        except json.JSONDecodeError:
+            return None
+
+    def _default_allocations(self) -> dict[str, Any]:
+        """Default channel split used when the portfolio crew output is unusable."""
         total_budget = self.state.campaign_brief.get("budget", 0)
         return {
             "branding": {
                 "budget": total_budget * 0.4,
                 "percentage": 40,
-                "rationale": "Default allocation",
+                "rationale": "Default allocation (portfolio crew output unparseable)",
             },
             "performance": {
                 "budget": total_budget * 0.4,
                 "percentage": 40,
-                "rationale": "Default allocation",
+                "rationale": "Default allocation (portfolio crew output unparseable)",
             },
             "ctv": {
                 "budget": total_budget * 0.2,
                 "percentage": 20,
-                "rationale": "Default allocation",
+                "rationale": "Default allocation (portfolio crew output unparseable)",
             },
             "mobile_app": {"budget": 0, "percentage": 0, "rationale": "Not allocated"},
         }

--- a/src/ad_buyer/interfaces/api/main.py
+++ b/src/ad_buyer/interfaces/api/main.py
@@ -573,6 +573,11 @@ async def _run_booking_flow(job_id: str, request: BookingRequest) -> None:
         job["progress"] = 0.2
         _result = flow.kickoff()
 
+        # Propagate any errors captured by flow steps into the job response so
+        # the client can see what went wrong instead of silent-success (ar-jbod).
+        if flow.state.errors:
+            job["errors"].extend(flow.state.errors)
+
         job["progress"] = 0.8
         job["budget_allocations"] = {
             k: v.model_dump() for k, v in flow.state.budget_allocations.items()

--- a/tests/unit/test_allocate_budget_extraction.py
+++ b/tests/unit/test_allocate_budget_extraction.py
@@ -1,0 +1,133 @@
+"""Tests for DealBookingFlow._extract_allocations (ar-jbod).
+
+The portfolio crew has two tasks: budget allocation and channel coordination.
+``crew.kickoff()`` returns a CrewOutput whose top-level ``raw`` reflects the
+LAST task (channel coordination), not the first. Prior to the ar-jbod fix the
+flow used ``str(result)`` and did a naive ``find('{')..rfind('}')`` extract,
+which parsed the wrong task's JSON and produced empty budget_allocations.
+
+These tests pin the new behaviour: we must read from ``tasks_output[0]``
+(the budget allocation task), preferring ``pydantic`` then ``json_dict``,
+falling back to a JSON block in ``raw``, and finally falling back to the
+default split (with an error appended to flow.state.errors).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from ad_buyer.crews.portfolio_crew import BudgetAllocationOutput, _ChannelAllocationOut
+from ad_buyer.flows.deal_booking_flow import DealBookingFlow
+
+
+def _flow() -> DealBookingFlow:
+    """Make a DealBookingFlow with the minimal state needed for extraction tests."""
+    flow = DealBookingFlow(MagicMock(), campaign_brief={"budget": 100_000})
+    return flow
+
+
+def _crew_output_with(first_task: SimpleNamespace) -> SimpleNamespace:
+    """Build a fake CrewOutput that has the given object at tasks_output[0]."""
+    return SimpleNamespace(tasks_output=[first_task], raw="")
+
+
+def test_extract_from_pydantic_output() -> None:
+    """When the first task carries a typed BudgetAllocationOutput, use it."""
+    flow = _flow()
+    pyd = BudgetAllocationOutput(
+        branding=_ChannelAllocationOut(budget=40_000, percentage=40, rationale="brand"),
+        ctv=_ChannelAllocationOut(budget=20_000, percentage=20, rationale="ctv"),
+        performance=_ChannelAllocationOut(budget=40_000, percentage=40, rationale="perf"),
+    )
+    result = _crew_output_with(SimpleNamespace(pydantic=pyd, json_dict=None, raw=""))
+
+    allocations = flow._extract_allocations(result)
+
+    assert allocations["branding"]["budget"] == 40_000
+    assert allocations["ctv"]["budget"] == 20_000
+    assert allocations["performance"]["budget"] == 40_000
+    assert allocations["mobile_app"]["budget"] == 0
+    assert flow.state.errors == []
+
+
+def test_extract_from_json_dict_when_pydantic_missing() -> None:
+    """Fall through to json_dict when pydantic is None."""
+    flow = _flow()
+    json_dict = {
+        "branding": {"budget": 50_000, "percentage": 50, "rationale": "all-in branding"},
+        "ctv": {"budget": 50_000, "percentage": 50, "rationale": "ctv"},
+    }
+    result = _crew_output_with(SimpleNamespace(pydantic=None, json_dict=json_dict, raw=""))
+
+    allocations = flow._extract_allocations(result)
+
+    assert allocations["branding"]["budget"] == 50_000
+    assert allocations["ctv"]["budget"] == 50_000
+    assert flow.state.errors == []
+
+
+def test_extract_from_raw_text_when_others_missing() -> None:
+    """If pydantic and json_dict are absent, parse a JSON block from raw text."""
+    flow = _flow()
+    raw = (
+        "Here's the allocation:\n"
+        '{"branding": {"budget": 60000, "percentage": 60, "rationale": "x"},'
+        ' "performance": {"budget": 40000, "percentage": 40, "rationale": "y"}}'
+    )
+    result = _crew_output_with(SimpleNamespace(pydantic=None, json_dict=None, raw=raw))
+
+    allocations = flow._extract_allocations(result)
+
+    assert allocations["branding"]["budget"] == 60_000
+    assert allocations["performance"]["budget"] == 40_000
+
+
+def test_extract_falls_back_to_default_when_all_paths_fail() -> None:
+    """When typed output is empty/zero and raw is garbage, fall back + log error."""
+    flow = _flow()
+    # Pydantic present but all-zero (e.g., the LLM emitted an empty object).
+    pyd = BudgetAllocationOutput()
+    result = _crew_output_with(SimpleNamespace(pydantic=pyd, json_dict=None, raw="no json here"))
+
+    allocations = flow._extract_allocations(result)
+
+    # Default split should be applied: 40/40/20 across branding/performance/ctv.
+    assert allocations["branding"]["budget"] == 40_000
+    assert allocations["performance"]["budget"] == 40_000
+    assert allocations["ctv"]["budget"] == 20_000
+    assert allocations["mobile_app"]["budget"] == 0
+    # And an error should be surfaced for diagnostic visibility.
+    assert any("portfolio crew" in e.lower() for e in flow.state.errors)
+
+
+def test_extract_ignores_wrong_schema_from_last_task() -> None:
+    """Regression test for ar-jbod itself.
+
+    Before the fix the code did str(result) which captured the LAST task's
+    output (channel coordination, different schema). This test pins that
+    we never read from anywhere but tasks_output[0].
+    """
+    flow = _flow()
+    # Mimic the buggy situation: top-level raw has the channel-coordination
+    # schema (objectives/targeting_priorities), no budget keys anywhere.
+    wrong_schema_raw = (
+        '{"branding": {"objectives": ["awareness"], "targeting_priorities": ["18-34"]}}'
+    )
+    # tasks_output[0] has the RIGHT data via pydantic.
+    pyd = BudgetAllocationOutput(
+        branding=_ChannelAllocationOut(budget=30_000, percentage=30, rationale="brand"),
+        ctv=_ChannelAllocationOut(budget=70_000, percentage=70, rationale="ctv"),
+    )
+    result = SimpleNamespace(
+        tasks_output=[SimpleNamespace(pydantic=pyd, json_dict=None, raw="")],
+        raw=wrong_schema_raw,
+    )
+
+    allocations = flow._extract_allocations(result)
+
+    # Confirm we used tasks_output[0], not the top-level raw.
+    assert allocations["branding"]["budget"] == 30_000
+    assert allocations["ctv"]["budget"] == 70_000
+    # Wrong-schema "objectives" key must NOT appear.
+    assert "objectives" not in allocations["branding"]

--- a/tests/unit/test_deal_booking_flow.py
+++ b/tests/unit/test_deal_booking_flow.py
@@ -389,7 +389,7 @@ class TestExtractJsonBlock:
     def test_json_embedded_in_text(self, flow_with_brief):
         """JSON embedded in surrounding text is extracted."""
         text = (
-            'Here is my analysis:\n'
+            "Here is my analysis:\n"
             '{"branding": {"budget": 50000, "percentage": 50, "rationale": "Test"}}\nDone.'
         )
 
@@ -458,13 +458,9 @@ class TestAllocateBudget:
 
         pyd = BudgetAllocationOutput(
             branding=_ChannelAllocationOut(budget=40000, percentage=40, rationale="Awareness"),
-            performance=_ChannelAllocationOut(
-                budget=30000, percentage=30, rationale="Conversions"
-            ),
+            performance=_ChannelAllocationOut(budget=30000, percentage=30, rationale="Conversions"),
             ctv=_ChannelAllocationOut(budget=20000, percentage=20, rationale="Video reach"),
-            mobile_app=_ChannelAllocationOut(
-                budget=10000, percentage=10, rationale="App installs"
-            ),
+            mobile_app=_ChannelAllocationOut(budget=10000, percentage=10, rationale="App installs"),
         )
         crew_output = SimpleNamespace(
             tasks_output=[SimpleNamespace(pydantic=pyd, json_dict=None, raw="")],

--- a/tests/unit/test_deal_booking_flow.py
+++ b/tests/unit/test_deal_booking_flow.py
@@ -359,12 +359,17 @@ class TestPlanAudience:
 
 
 # ===========================================================================
-# 3. _parse_allocations (private helper)
+# 3. JSON-block extraction + default allocation helpers
 # ===========================================================================
+# Per ar-jbod, the old _parse_allocations was split into:
+#   _extract_json_block(text) -> dict | None
+#   _default_allocations() -> dict
+# The combined behaviour (parse-or-default) now lives in the
+# _extract_allocations() pipeline (see test_allocate_budget_extraction.py).
 
 
-class TestParseAllocations:
-    """Tests for allocation JSON parsing."""
+class TestExtractJsonBlock:
+    """Tests for the JSON-block extraction helper."""
 
     def test_valid_json_parsed(self, flow_with_brief):
         """Valid JSON string is parsed correctly."""
@@ -375,45 +380,56 @@ class TestParseAllocations:
             }
         )
 
-        result = flow_with_brief._parse_allocations(json_str)
+        result = flow_with_brief._extract_json_block(json_str)
 
+        assert result is not None
         assert result["branding"]["budget"] == 40000
         assert result["ctv"]["percentage"] == 20
 
     def test_json_embedded_in_text(self, flow_with_brief):
         """JSON embedded in surrounding text is extracted."""
-        text = 'Here is my analysis:\n{"branding": {"budget": 50000, "percentage": 50, "rationale": "Test"}}\nDone.'  # noqa: E501
+        text = (
+            'Here is my analysis:\n'
+            '{"branding": {"budget": 50000, "percentage": 50, "rationale": "Test"}}\nDone.'
+        )
 
-        result = flow_with_brief._parse_allocations(text)
+        result = flow_with_brief._extract_json_block(text)
 
+        assert result is not None
         assert result["branding"]["budget"] == 50000
 
-    def test_invalid_json_returns_defaults(self, flow_with_brief):
-        """Invalid JSON falls back to default allocation."""
-        result = flow_with_brief._parse_allocations("This is not JSON at all")
+    def test_invalid_json_returns_none(self, flow_with_brief):
+        """Invalid JSON returns None (callers decide how to fall back)."""
+        assert flow_with_brief._extract_json_block("This is not JSON at all") is None
 
-        assert "branding" in result
-        assert "performance" in result
-        assert "ctv" in result
-        assert "mobile_app" in result
-        # Defaults should sum to 100%
-        total_pct = sum(v["percentage"] for v in result.values())
-        assert total_pct == 100
+    def test_empty_string_returns_none(self, flow_with_brief):
+        """Empty string returns None."""
+        assert flow_with_brief._extract_json_block("") is None
+
+
+class TestDefaultAllocations:
+    """Tests for the default allocation split used as a last-resort fallback."""
 
     def test_default_allocation_uses_budget(self, flow_with_brief):
-        """Default allocation uses campaign budget from state."""
+        """Default allocation distributes the full campaign budget."""
         budget = flow_with_brief.state.campaign_brief["budget"]
 
-        result = flow_with_brief._parse_allocations("garbage")
+        defaults = flow_with_brief._default_allocations()
 
-        total_budget = sum(v["budget"] for v in result.values())
+        total_budget = sum(v["budget"] for v in defaults.values())
         assert total_budget == budget
 
-    def test_empty_string_returns_defaults(self, flow_with_brief):
-        """Empty string falls back to defaults."""
-        result = flow_with_brief._parse_allocations("")
+    def test_default_allocation_percentages_sum_to_100(self, flow_with_brief):
+        """Default percentages add up to 100%."""
+        defaults = flow_with_brief._default_allocations()
+        total_pct = sum(v["percentage"] for v in defaults.values())
+        assert total_pct == 100
 
-        assert "branding" in result
+    def test_default_allocation_has_all_channels(self, flow_with_brief):
+        """Default split includes every channel name expected by downstream listeners."""
+        defaults = flow_with_brief._default_allocations()
+        for ch in ("branding", "performance", "ctv", "mobile_app"):
+            assert ch in defaults
 
 
 # ===========================================================================
@@ -433,16 +449,29 @@ class TestAllocateBudget:
     @patch("ad_buyer.flows.deal_booking_flow.create_portfolio_crew")
     def test_successful_allocation(self, mock_create_crew, flow_with_brief):
         """Valid crew result populates budget_allocations in state."""
-        allocation_json = json.dumps(
-            {
-                "branding": {"budget": 40000, "percentage": 40, "rationale": "Awareness"},
-                "performance": {"budget": 30000, "percentage": 30, "rationale": "Conversions"},
-                "ctv": {"budget": 20000, "percentage": 20, "rationale": "Video reach"},
-                "mobile_app": {"budget": 10000, "percentage": 10, "rationale": "App installs"},
-            }
+        from types import SimpleNamespace
+
+        from ad_buyer.crews.portfolio_crew import (
+            BudgetAllocationOutput,
+            _ChannelAllocationOut,
+        )
+
+        pyd = BudgetAllocationOutput(
+            branding=_ChannelAllocationOut(budget=40000, percentage=40, rationale="Awareness"),
+            performance=_ChannelAllocationOut(
+                budget=30000, percentage=30, rationale="Conversions"
+            ),
+            ctv=_ChannelAllocationOut(budget=20000, percentage=20, rationale="Video reach"),
+            mobile_app=_ChannelAllocationOut(
+                budget=10000, percentage=10, rationale="App installs"
+            ),
+        )
+        crew_output = SimpleNamespace(
+            tasks_output=[SimpleNamespace(pydantic=pyd, json_dict=None, raw="")],
+            raw="",
         )
         mock_crew = MagicMock()
-        mock_crew.kickoff.return_value = allocation_json
+        mock_crew.kickoff.return_value = crew_output
         mock_create_crew.return_value = mock_crew
 
         result = flow_with_brief.allocate_budget({"status": "success"})
@@ -454,16 +483,25 @@ class TestAllocateBudget:
     @patch("ad_buyer.flows.deal_booking_flow.create_portfolio_crew")
     def test_zero_budget_channels_excluded(self, mock_create_crew, flow_with_brief):
         """Channels with 0 budget are not stored in allocations."""
-        allocation_json = json.dumps(
-            {
-                "branding": {"budget": 50000, "percentage": 50, "rationale": "Main"},
-                "ctv": {"budget": 50000, "percentage": 50, "rationale": "Video"},
-                "performance": {"budget": 0, "percentage": 0, "rationale": "Not needed"},
-                "mobile_app": {"budget": 0, "percentage": 0, "rationale": "Not needed"},
-            }
+        from types import SimpleNamespace
+
+        from ad_buyer.crews.portfolio_crew import (
+            BudgetAllocationOutput,
+            _ChannelAllocationOut,
+        )
+
+        pyd = BudgetAllocationOutput(
+            branding=_ChannelAllocationOut(budget=50000, percentage=50, rationale="Main"),
+            ctv=_ChannelAllocationOut(budget=50000, percentage=50, rationale="Video"),
+            performance=_ChannelAllocationOut(budget=0, percentage=0, rationale="Not needed"),
+            mobile_app=_ChannelAllocationOut(budget=0, percentage=0, rationale="Not needed"),
+        )
+        crew_output = SimpleNamespace(
+            tasks_output=[SimpleNamespace(pydantic=pyd, json_dict=None, raw="")],
+            raw="",
         )
         mock_crew = MagicMock()
-        mock_crew.kickoff.return_value = allocation_json
+        mock_crew.kickoff.return_value = crew_output
         mock_create_crew.return_value = mock_crew
 
         _result = flow_with_brief.allocate_budget({"status": "success"})


### PR DESCRIPTION
## Summary

`POST /bookings` was completing with empty `budget_allocations[]`, `recommendations[]`, `booked_lines[]`, AND empty `errors[]` — silent-success on a broken flow.

**Root cause:** the portfolio crew has two tasks (budget allocation, channel coordination). `crew.kickoff()` returns a `CrewOutput` whose top-level `.raw` reflects the **last** task (channel coordination) with a completely different schema (`{"channel_name": {"objectives": [...], ...}}` — no `budget` keys). The old flow used `str(result)` + a naive `find("{")..rfind("}")` JSON extraction, parsed the wrong task's output, then the `budget > 0` filter rejected every channel → `state.budget_allocations` stayed empty → all downstream `@listen(allocate_budget)` channel research steps silently skipped.

## Changes

- `portfolio_crew.py`: declare `BudgetAllocationOutput` as `output_pydantic` on the first task. Typed extraction, no string scraping.
- `deal_booking_flow.py`: new `_extract_allocations()` reads `result.tasks_output[0]` preferring `pydantic`, then `json_dict`, then a JSON block in raw text. Falls back to a default split AND appends to `state.errors` so the failure is visible.
- `interfaces/api/main.py`: `_run_booking_flow` propagates `flow.state.errors` into the job response — no more silent-success.

## Tests

5 new unit tests in `tests/unit/test_allocate_budget_extraction.py` pin the extraction layering and include a regression test specifically asserting we never read the wrong-schema last-task output.

## Context

Discovered 2026-05-29 during the EOD smoke test (`ar-r82f.15`) Surface A. Was the P1 blocker preventing live e2e verification of yesterday's PRs. Once this lands, smoke test Surface G (cross-repo deal flow) becomes testable.

bead: ar-jbod

🤖 Generated with [Claude Code](https://claude.com/claude-code)