### PR TITLE
Make agent memory respect crew_memory_enabled config (ar-i84f)

### DIFF
--- a/src/ad_buyer/agents/level1/portfolio_manager.py
+++ b/src/ad_buyer/agents/level1/portfolio_manager.py
@@ -60,5 +60,5 @@ not fill in CPMs from market knowledge or training data.""",
         tools=tools or [],
         allow_delegation=True,
         verbose=verbose,
-        memory=True,
+        memory=settings.crew_memory_enabled,
     )

--- a/src/ad_buyer/agents/level2/branding_agent.py
+++ b/src/ad_buyer/agents/level2/branding_agent.py
@@ -63,5 +63,5 @@ not fill in CPMs from market knowledge or training data.""",
         tools=tools or [],
         allow_delegation=True,
         verbose=verbose,
-        memory=True,
+        memory=settings.crew_memory_enabled,
     )

--- a/src/ad_buyer/agents/level2/buyer_deal_specialist_agent.py
+++ b/src/ad_buyer/agents/level2/buyer_deal_specialist_agent.py
@@ -90,5 +90,5 @@ not fill in CPMs from market knowledge or training data.""",
         tools=tools or [],
         allow_delegation=True,
         verbose=verbose,
-        memory=True,
+        memory=settings.crew_memory_enabled,
     )

--- a/src/ad_buyer/agents/level2/ctv_agent.py
+++ b/src/ad_buyer/agents/level2/ctv_agent.py
@@ -68,5 +68,5 @@ not fill in CPMs from market knowledge or training data.""",
         tools=tools or [],
         allow_delegation=True,
         verbose=verbose,
-        memory=True,
+        memory=settings.crew_memory_enabled,
     )

--- a/src/ad_buyer/agents/level2/deal_library_agent.py
+++ b/src/ad_buyer/agents/level2/deal_library_agent.py
@@ -99,5 +99,5 @@ not fill in CPMs from market knowledge or training data.""",
         tools=tools or [],
         allow_delegation=True,
         verbose=verbose,
-        memory=True,
+        memory=settings.crew_memory_enabled,
     )

--- a/src/ad_buyer/agents/level2/linear_tv_agent.py
+++ b/src/ad_buyer/agents/level2/linear_tv_agent.py
@@ -83,5 +83,5 @@ not fill in CPMs from market knowledge or training data.""",
         tools=tools or [],
         allow_delegation=True,
         verbose=verbose,
-        memory=True,
+        memory=settings.crew_memory_enabled,
     )

--- a/src/ad_buyer/agents/level2/mobile_app_agent.py
+++ b/src/ad_buyer/agents/level2/mobile_app_agent.py
@@ -66,5 +66,5 @@ not fill in CPMs from market knowledge or training data.""",
         tools=tools or [],
         allow_delegation=True,
         verbose=verbose,
-        memory=True,
+        memory=settings.crew_memory_enabled,
     )

--- a/src/ad_buyer/agents/level2/performance_agent.py
+++ b/src/ad_buyer/agents/level2/performance_agent.py
@@ -70,5 +70,5 @@ not fill in CPMs from market knowledge or training data.""",
         tools=tools or [],
         allow_delegation=True,
         verbose=verbose,
-        memory=True,
+        memory=settings.crew_memory_enabled,
     )

--- a/src/ad_buyer/agents/level3/audience_planner_agent.py
+++ b/src/ad_buyer/agents/level3/audience_planner_agent.py
@@ -95,7 +95,7 @@ def create_audience_planner_agent(
         not fill in CPMs from market knowledge or training data.""",
         verbose=verbose,
         allow_delegation=False,  # Makes final audience decisions
-        memory=True,
+        memory=settings.crew_memory_enabled,
         llm=llm,
         tools=tools or [],
     )

--- a/src/ad_buyer/agents/level3/execution_agent.py
+++ b/src/ad_buyer/agents/level3/execution_agent.py
@@ -76,5 +76,5 @@ not fill in CPMs from market knowledge or training data.""",
         tools=tools or [],
         allow_delegation=False,
         verbose=verbose,
-        memory=True,
+        memory=settings.crew_memory_enabled,
     )

--- a/src/ad_buyer/agents/level3/reporting_agent.py
+++ b/src/ad_buyer/agents/level3/reporting_agent.py
@@ -76,5 +76,5 @@ not fill in CPMs from market knowledge or training data.""",
         tools=tools or [],
         allow_delegation=False,
         verbose=verbose,
-        memory=True,
+        memory=settings.crew_memory_enabled,
     )

--- a/src/ad_buyer/agents/level3/research_agent.py
+++ b/src/ad_buyer/agents/level3/research_agent.py
@@ -70,5 +70,5 @@ not fill in CPMs from market knowledge or training data.""",
         tools=tools or [],
         allow_delegation=False,
         verbose=verbose,
-        memory=True,
+        memory=settings.crew_memory_enabled,
     )

--- a/tests/unit/test_agent_hierarchy.py
+++ b/tests/unit/test_agent_hierarchy.py
@@ -36,12 +36,22 @@ from ad_buyer.agents.level3.audience_planner_agent import create_audience_planne
 from ad_buyer.agents.level3.execution_agent import create_execution_agent
 from ad_buyer.agents.level3.reporting_agent import create_reporting_agent
 from ad_buyer.agents.level3.research_agent import create_research_agent
+from ad_buyer.config.settings import settings
 from ad_buyer.crews.channel_crews import (
     _create_audience_tools,
     _create_execution_tools,
     _create_research_tools,
     _format_audience_context,
 )
+
+
+# Per ar-i84f: agent constructors now honor settings.crew_memory_enabled
+# instead of hard-coding memory=True. Force the flag on for this test module
+# so memory-related assertions don't depend on ambient .env state.
+@pytest.fixture(autouse=True)
+def _force_memory_enabled(monkeypatch):
+    monkeypatch.setattr(settings, "crew_memory_enabled", True)
+
 
 # ---------------------------------------------------------------------------
 # Helper: create valid BaseTool instances for injection tests
@@ -603,6 +613,19 @@ class TestHierarchyInvariants:
         for factory in all_factories:
             agent = factory(verbose=False)
             assert agent.memory, f"{agent.role} should have memory"
+
+    def test_all_agents_honor_crew_memory_enabled_false(self, monkeypatch):
+        """ar-i84f regression: when settings.crew_memory_enabled is False,
+        every agent must construct WITHOUT memory (no chromadb / OpenAI
+        embedder dependency). Prior to the fix this assertion failed
+        because memory=True was hardcoded in every agent constructor."""
+        monkeypatch.setattr(settings, "crew_memory_enabled", False)
+        all_factories = self.L1_FACTORIES + self.L2_FACTORIES + self.L3_FACTORIES
+        for factory in all_factories:
+            agent = factory(verbose=False)
+            assert not agent.memory, (
+                f"{agent.role} should NOT have memory when crew_memory_enabled=False"
+            )
 
     def test_all_agents_have_non_empty_role(self):
         """Every agent must have a meaningful role string."""


### PR DESCRIPTION
## Summary

All 12 agent constructors hardcoded `memory=True`, ignoring `settings.crew_memory_enabled`. That hardcode forces crewai to attach a `search_memory` tool backed by chromadb + OpenAI embeddings, which fails at runtime when `CHROMA_OPENAI_API_KEY` is absent (the default for non-OpenAI deployments). The failure is then swallowed downstream and surfaces as silent `recommendations=[]` in /bookings responses.

## Fix

Replace hardcoded `memory=True` with `memory=settings.crew_memory_enabled` in all 12 agent files:
- L1: `portfolio_manager.py`
- L2: `branding_agent`, `buyer_deal_specialist_agent`, `ctv_agent`, `deal_library_agent`, `linear_tv_agent`, `mobile_app_agent`, `performance_agent`
- L3: `audience_planner_agent`, `execution_agent`, `reporting_agent`, `research_agent`

Settings default is `crew_memory_enabled = True`, so users with an OpenAI embedder configured see no behavior change.

## Tests

- Added module-level autouse fixture in `test_agent_hierarchy.py` that pins `crew_memory_enabled=True` so existing 'agent should have memory' assertions don't depend on ambient `.env` state.
- Added `test_all_agents_honor_crew_memory_enabled_false` as a regression test that pins the new contract: when the config flag is False, no agent constructs with memory.

108/108 tests pass on this branch.

## Context

Discovered 2026-05-29 during EOD smoke test (`ar-r82f.15`) Surface A. Smoke-fix used a bulk `memory=True → False` sed as an emergency workaround. This PR is the proper fix.

bead: ar-i84f

🤖 Generated with [Claude Code](https://claude.com/claude-code)