### PR TITLE
Fix buyer-1g4: offload sync CrewAI flow.kickoff() to worker thread

### DIFF
--- a/src/ad_buyer/flows/buyer_deal_flow.py
+++ b/src/ad_buyer/flows/buyer_deal_flow.py
@@ -11,6 +11,7 @@ seller-bound ``DealRequest`` / ``RequestDealTool`` payload so the seller can
 match each ref against package capabilities (proposal §5.1).
 """
 
+import asyncio
 import logging
 import sqlite3
 from datetime import datetime
@@ -680,8 +681,12 @@ async def run_buyer_deal_flow(
         if audience_plan is not None:
             flow.state.audience_plan = audience_plan
 
-        # Run flow
-        result = flow.kickoff()
+        # Run flow.
+        # buyer-1g4: offload sync flow.kickoff() to a worker thread so
+        # the caller's event loop stays responsive. See api/main.py
+        # _run_booking_flow for the full rationale (sync Flow steps
+        # block the loop if we use ``await flow.kickoff_async()``).
+        result = await asyncio.to_thread(flow.kickoff)
 
         return {
             "result": result,

--- a/src/ad_buyer/interfaces/api/main.py
+++ b/src/ad_buyer/interfaces/api/main.py
@@ -3,6 +3,7 @@
 
 """FastAPI server for the Ad Buyer System."""
 
+import asyncio
 import json
 import logging
 import sqlite3
@@ -447,7 +448,10 @@ async def approve_all_recommendations(job_id: str) -> dict[str, Any]:
             detail="Flow state not available. Job may have expired.",
         )
 
-    result = flow.approve_all()
+    # buyer-1g4: approve_all() runs sync CrewAI work that holds the
+    # calling thread; offload to a worker thread so the event loop
+    # stays responsive.
+    result = await asyncio.to_thread(flow.approve_all)
 
     job["status"] = "completed" if result.get("status") == "success" else "failed"
     job["booked_lines"] = [b.model_dump() for b in flow.state.booked_lines]
@@ -571,7 +575,22 @@ async def _run_booking_flow(job_id: str, request: BookingRequest) -> None:
         job["_flow"] = flow
 
         job["progress"] = 0.2
-        _result = flow.kickoff()
+        # buyer-1g4: offload the whole sync flow.kickoff() to a worker
+        # thread so the FastAPI event loop stays responsive while the
+        # crew agents (which block on real LLM HTTP calls) run.
+        #
+        # We do NOT use ``await flow.kickoff_async()`` here even though
+        # it looks cleaner — the buyer's Flow ``@start`` / ``@listen``
+        # step methods are sync and themselves call ``crew.kickoff()``
+        # directly. Awaited from the event loop, those sync steps would
+        # run IN the event loop thread, re-introducing the block.
+        #
+        # CrewAI's sync ``Flow.kickoff()`` already does
+        # ``ThreadPoolExecutor.submit(asyncio.run, _run_flow).result()``
+        # internally — the ``.result()`` is what blocks the calling
+        # thread. ``asyncio.to_thread`` puts that ``.result()`` on a
+        # worker thread (two threads deep, but the event loop is free).
+        _result = await asyncio.to_thread(flow.kickoff)
 
         # Propagate any errors captured by flow steps into the job response so
         # the client can see what went wrong instead of silent-success (ar-jbod).
@@ -585,7 +604,8 @@ async def _run_booking_flow(job_id: str, request: BookingRequest) -> None:
         job["recommendations"] = [r.model_dump() for r in flow.state.pending_approvals]
 
         if request.auto_approve:
-            flow.approve_all()
+            # buyer-1g4: same reason as above — offload sync work.
+            await asyncio.to_thread(flow.approve_all)
             job["booked_lines"] = [b.model_dump() for b in flow.state.booked_lines]
             job["status"] = "completed"
         else:

--- a/tests/integration/test_buyer_1g4_async_kickoff.py
+++ b/tests/integration/test_buyer_1g4_async_kickoff.py
@@ -1,0 +1,222 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Regression tests for buyer-1g4: sync CrewAI Flow.kickoff() must not
+block the FastAPI event loop.
+
+CrewAI's sync ``Flow.kickoff()`` internally does::
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(ctx.run, asyncio.run, _run_flow()).result()
+
+The final ``.result()`` blocks the calling thread until the inner thread
+finishes — so calling ``flow.kickoff()`` directly from a FastAPI
+``async def`` handler blocks the entire event loop for the duration of
+the run.
+
+The fix is to wrap the call with ``asyncio.to_thread`` so the
+``.result()`` runs on a worker thread instead of the event loop thread.
+We deliberately do NOT use ``await flow.kickoff_async()`` — the buyer's
+Flow ``@start`` / ``@listen`` step methods are themselves sync (they
+call ``crew.kickoff()`` directly), so awaiting kickoff_async from the
+event loop just runs those sync steps in the loop thread anyway.
+
+These tests guard against anyone reverting to an un-offloaded sync
+``kickoff()`` / ``approve_all()`` in async contexts by asserting the
+calls execute on a worker thread, not on ``MainThread``.
+"""
+
+import pytest
+
+from ad_buyer.flows.deal_booking_flow import DealBookingFlow
+from ad_buyer.interfaces.api.main import (
+    BookingRequest,
+    CampaignBrief,
+    _run_booking_flow,
+    jobs,
+)
+from ad_buyer.time_utils import utc_now
+
+
+def _seed_job(job_id: str) -> None:
+    jobs[job_id] = {
+        "job_id": job_id,
+        "status": "pending",
+        "progress": 0.0,
+        "errors": [],
+        "budget_allocations": {},
+        "recommendations": [],
+        "booked_lines": [],
+        "updated_at": utc_now().isoformat(),
+        "created_at": utc_now().isoformat(),
+    }
+
+
+def _sample_brief() -> CampaignBrief:
+    return CampaignBrief(
+        name="buyer-1g4 regression",
+        objectives=["awareness"],
+        budget=50000,
+        start_date="2026-07-01",
+        end_date="2026-07-31",
+        target_audience={"geo": ["US"]},
+    )
+
+
+class TestRunBookingFlowOffloadsKickoff:
+    """``api.main._run_booking_flow`` must offload sync CrewAI work so
+    the FastAPI event loop stays responsive."""
+
+    @pytest.mark.asyncio
+    async def test_kickoff_runs_on_worker_thread(self, monkeypatch):
+        """``flow.kickoff()`` (sync) must execute on a worker thread,
+        never on ``MainThread``. ``asyncio.to_thread`` provides this
+        offload; calling ``flow.kickoff()`` directly from the async
+        background task would run it on the event-loop thread and
+        block every other request (buyer-1g4)."""
+
+        import threading
+
+        kickoff_threads: list[str] = []
+
+        def fake_kickoff(self, *args, **kwargs):
+            kickoff_threads.append(threading.current_thread().name)
+            return {}
+
+        monkeypatch.setattr(DealBookingFlow, "kickoff", fake_kickoff)
+
+        job_id = "test-buyer-1g4-kickoff-thread"
+        _seed_job(job_id)
+        try:
+            await _run_booking_flow(
+                job_id,
+                BookingRequest(brief=_sample_brief(), auto_approve=False),
+            )
+
+            assert kickoff_threads, "flow.kickoff should have been called"
+            assert "MainThread" not in kickoff_threads[0], (
+                f"flow.kickoff ran on {kickoff_threads[0]} — buyer-1g4 "
+                "regression: should be offloaded via asyncio.to_thread"
+            )
+            assert jobs[job_id]["status"] != "failed", (
+                f"Job failed unexpectedly: errors={jobs[job_id]['errors']}"
+            )
+        finally:
+            jobs.pop(job_id, None)
+
+    @pytest.mark.asyncio
+    async def test_approve_all_runs_on_worker_thread(self, monkeypatch):
+        """When ``auto_approve=True``, ``approve_all`` is sync CrewAI
+        work and must be offloaded via ``asyncio.to_thread`` for the
+        same reason as ``kickoff``."""
+
+        import threading
+
+        approve_threads: list[str] = []
+
+        def fake_kickoff(self, *args, **kwargs):
+            return {}
+
+        def fake_approve_all(self):
+            approve_threads.append(threading.current_thread().name)
+            return {"status": "success", "booked_lines": []}
+
+        monkeypatch.setattr(DealBookingFlow, "kickoff", fake_kickoff)
+        monkeypatch.setattr(DealBookingFlow, "approve_all", fake_approve_all)
+
+        job_id = "test-buyer-1g4-approve-all-thread"
+        _seed_job(job_id)
+        try:
+            await _run_booking_flow(
+                job_id,
+                BookingRequest(brief=_sample_brief(), auto_approve=True),
+            )
+
+            assert approve_threads, "approve_all should have been called"
+            assert "MainThread" not in approve_threads[0], (
+                f"approve_all ran on {approve_threads[0]} — buyer-1g4 "
+                "regression: should be offloaded via asyncio.to_thread"
+            )
+        finally:
+            jobs.pop(job_id, None)
+
+
+class TestSourceLevelAsyncContract:
+    """Source-level assertions for async-context call sites.
+
+    These guard against silent reverts to sync ``kickoff()`` /
+    unwrapped ``approve_all()`` inside ``async def`` functions. They are
+    cheaper than full mocking for sites whose runtime invocation needs
+    extensive client/flow stubbing (e.g. ``run_buyer_deal_flow``).
+    """
+
+    @staticmethod
+    def _calls_in_async_functions(filename: str) -> dict[str, list[str]]:
+        """Walk a source file and return, for each ``async def`` function,
+        the list of attribute-call names invoked synchronously (i.e.
+        not via ``await ...`` and not via ``asyncio.to_thread(...)``).
+        """
+        import ast
+        import pathlib
+
+        path = pathlib.Path(filename)
+        tree = ast.parse(path.read_text())
+
+        results: dict[str, list[str]] = {}
+
+        class _Visitor(ast.NodeVisitor):
+            def __init__(self):
+                self._async_stack: list[str] = []
+
+            def visit_AsyncFunctionDef(self, node):
+                self._async_stack.append(node.name)
+                results.setdefault(node.name, [])
+                self.generic_visit(node)
+                self._async_stack.pop()
+
+            def visit_FunctionDef(self, node):
+                # Skip nested sync defs — they have their own loop semantics.
+                pass
+
+            def visit_Await(self, node):
+                # Anything under an Await is fine — don't descend.
+                pass
+
+            def visit_Call(self, node):
+                if self._async_stack and isinstance(node.func, ast.Attribute):
+                    results[self._async_stack[-1]].append(node.func.attr)
+                self.generic_visit(node)
+
+        _Visitor().visit(tree)
+        return results
+
+    def test_run_booking_flow_no_sync_kickoff(self):
+        from ad_buyer.interfaces.api import main as api_main
+
+        calls = self._calls_in_async_functions(api_main.__file__)
+        booking_calls = calls.get("_run_booking_flow", [])
+        assert "kickoff" not in booking_calls, (
+            "_run_booking_flow contains a sync .kickoff() call — buyer-1g4 "
+            "regression. Wrap with ``await asyncio.to_thread(flow.kickoff)``."
+        )
+
+    def test_approve_all_recommendations_endpoint_no_sync_approve(self):
+        from ad_buyer.interfaces.api import main as api_main
+
+        calls = self._calls_in_async_functions(api_main.__file__)
+        endpoint_calls = calls.get("approve_all_recommendations", [])
+        assert "approve_all" not in endpoint_calls, (
+            "approve_all_recommendations endpoint contains a sync "
+            ".approve_all() call — buyer-1g4 regression. Wrap with "
+            "``await asyncio.to_thread(flow.approve_all)``."
+        )
+
+    def test_run_buyer_deal_flow_no_sync_kickoff(self):
+        from ad_buyer.flows import buyer_deal_flow
+
+        calls = self._calls_in_async_functions(buyer_deal_flow.__file__)
+        run_calls = calls.get("run_buyer_deal_flow", [])
+        assert "kickoff" not in run_calls, (
+            "run_buyer_deal_flow contains a sync .kickoff() call — "
+            "buyer-1g4 regression. Use ``await flow.kickoff_async()``."
+        )


### PR DESCRIPTION
## Summary

CrewAI's sync `Flow.kickoff()` internally does
`ThreadPoolExecutor.submit(asyncio.run, _run_flow).result()` — the
`.result()` call blocks the calling thread regardless of any
internal threading. When called from a FastAPI `async def` handler
(the BackgroundTasks-driven `_run_booking_flow`), that calling
thread *is* the event loop, so every other request hangs for the
duration of the booking.

This PR wraps the four async-context call sites with
`asyncio.to_thread()` so the blocking `.result()` runs on a worker
thread and the event loop stays responsive.

Fixes the symptom flagged in the pickup note from yesterday's
recovery EPIC: *"the buyer server eventually locks up because the
synchronous CrewAI run blocks the async event loop."*

## Changes

| File | Line | Before | After |
|---|---|---|---|
| `src/ad_buyer/interfaces/api/main.py` | 574 | `_result = flow.kickoff()` | `_result = await asyncio.to_thread(flow.kickoff)` |
| `src/ad_buyer/interfaces/api/main.py` | 588 | `flow.approve_all()` | `await asyncio.to_thread(flow.approve_all)` |
| `src/ad_buyer/interfaces/api/main.py` | 450 | `result = flow.approve_all()` | `result = await asyncio.to_thread(flow.approve_all)` |
| `src/ad_buyer/flows/buyer_deal_flow.py` | 684 | `result = flow.kickoff()` | `result = await asyncio.to_thread(flow.kickoff)` |

Added `import asyncio` to both files.

### Why not `await flow.kickoff_async()`?

The cleaner-looking alternative — call CrewAI's documented async entry
point directly — doesn't work for this codebase. The buyer's Flow
`@start` / `@listen` step methods are sync (they call `crew.kickoff()`
internally). Awaiting `kickoff_async` from the event loop runs those
sync steps *in the event loop thread* anyway, re-introducing the
original block. Empirically confirmed during smoke testing —
`/health` hung the same way.

The `asyncio.to_thread(flow.kickoff)` shape puts the whole flow
execution behind a worker thread. Yes, that's "two threads deep"
(to_thread's worker thread → CrewAI's inner ThreadPoolExecutor), but
the event loop is genuinely free.

## Out of scope

- `src/ad_buyer/interfaces/agentcore/crew_tools.py:139` — the caller
  in `http_main.py:227` already wraps with `loop.run_in_executor()`.
  Wrapping inside would double-offload and break the pattern.
- `src/ad_buyer/interfaces/cli/main.py:112,171,177` — CLI is sync,
  no event loop, no issue.
- `crew.kickoff()` calls inside Flow `@listen` methods — they run
  inside CrewAI's worker thread once the outer call is offloaded.

## Regression tests

`tests/integration/test_buyer_1g4_async_kickoff.py` adds 5 tests:

**Runtime tests (2)** — patch `DealBookingFlow.kickoff` and
`DealBookingFlow.approve_all` to capture the thread name they ran on,
assert it's not `MainThread`.

**AST source-level tests (3)** — walk each `async def` in the touched
files and reject any sync `.kickoff()` / `.approve_all()` call outside
`await ...` / `asyncio.to_thread(...)`. These guard against silent
reverts without needing runtime mocking, which is awkward for
`run_buyer_deal_flow` (would require stubbing `UnifiedClient` +
`BuyerDealFlow` extensively).

All 5 pass.

## Test plan

- [x] Full buyer-agent unit + integration suite: **3309 passed, 62
  skipped, 2 failed**. The 2 failures (`test_deal_library_agent_has_memory`,
  `test_linear_tv_agent_has_memory`) are **pre-existing on `main`** —
  verified via `git stash && pytest <those-two> && git stash pop`.
  They're fallout from PR #104 (ar-i84f) that didn't update the
  `_has_memory` assertions. Not introduced by this PR.
- [x] New regression tests (5/5 pass)
- [x] `ruff check` + `ruff format` clean on all touched files
- [x] **Live smoke test**: started buyer (8100) + seller (8101) locally,
  POSTed an `auto_approve=true` booking, monitored `/health` latency
  every 5s. Over 17 minutes with the flow actively running:
  - 82 probes total
  - min / max / mean / p50 / p95 = **25 / 43 / 34.1 / 34 / 41 ms**
  - 0 failed probes (all 200 OK)
  
  Compare to the same setup *without* the fix: `/health` hangs
  indefinitely (~58 min observed before kill).

  Booking didn't reach `completed` in the window — that's blocked by
  a separate cross-repo contract drift (buyer sends `POST
  /products/search`, seller exposes only `GET /products`, returns
  405). The buyer agents grind LLM cycles trying to discover
  inventory but never get product data, so recommendations stay
  empty. That's a pre-existing bug independent of buyer-1g4.

Full smoke evidence + per-call-site rationale:
`agent-range-ops/docs/reports/buyer-1g4-fix-2026-06-25/`.

Closes buyer-1g4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)