### PR TITLE
Use UTC date in default flight dates test (fails locally every US evening)

### DIFF
--- a/tests/unit/test_buyer_deal_discovery_pricing.py
+++ b/tests/unit/test_buyer_deal_discovery_pricing.py
@@ -12,7 +12,7 @@ Covers:
 - Cross-tier pricing consistency across tools and client
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -770,7 +770,7 @@ class TestRequestDealOutput:
         mock_client.get_product.return_value = MagicMock(success=True, data=_product())
         tool = RequestDealTool(client=mock_client, buyer_context=agency_context)
         result = await tool._arun(product_id="prod_001")
-        today = datetime.now().strftime("%Y-%m-%d")
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
         assert today in result
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`test_deal_uses_default_flight_dates` compares a local-time date against output the code builds in UTC, so the suite fails every evening for anyone west of UTC. One-line fix aligning the test with the code's own timezone discipline.

## Details

- The test asserted `datetime.now().strftime("%Y-%m-%d")` (naive local time) appears in `RequestDealTool` output.
- Production code builds those dates with `datetime.now(UTC)` (`src/ad_buyer/tools/buyer_deals/request_deal.py`).
- Whenever local date != UTC date (roughly 4pm to midnight in US timezones), the assertion fails. CI runners are UTC, so CI never catches it.

Reproduced on a clean checkout at 20:45 PDT on 2026-07-05 (UTC date was already 2026-07-06):

```
E       assert '2026-07-05' in "...DEAL CREATED SUCCESSFULLY..."
tests/unit/test_buyer_deal_discovery_pricing.py:774: AssertionError
1 failed, 3302 passed, 65 skipped
```

This is the only naive `datetime.now()` in the test suite (grep confirms).

## Verification

After the change, all 98 tests in the file pass regardless of local timezone; `ruff check` and `ruff format --check` clean.
