### PR TITLE
Fix deployed seller product interop

### DIFF
--- a/src/ad_buyer/clients/opendirect_client.py
+++ b/src/ad_buyer/clients/opendirect_client.py
@@ -4,6 +4,7 @@
 """HTTP client for IAB OpenDirect 2.1 API."""
 
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -53,6 +54,52 @@ class OpenDirectClient:
             headers["X-API-Key"] = api_key
         return headers
 
+    def _default_publisher_id(self) -> str:
+        """Return a stable publisher id for seller payloads without OpenDirect metadata."""
+        host = urlparse(self.base_url).netloc or urlparse(f"https://{self.base_url}").netloc
+        return host or "unknown-publisher"
+
+    def _normalize_product_payload(self, product: dict[str, Any]) -> dict[str, Any]:
+        """Normalize deployed seller-agent product JSON to the buyer OpenDirect model shape."""
+        normalized = dict(product)
+
+        if "id" not in normalized and "product_id" in normalized:
+            normalized["id"] = normalized["product_id"]
+        if "publisherId" not in normalized:
+            normalized["publisherId"] = (
+                normalized.get("publisher_id")
+                or normalized.get("publisher")
+                or self._default_publisher_id()
+            )
+        if "basePrice" not in normalized and "base_cpm" in normalized:
+            normalized["basePrice"] = normalized["base_cpm"]
+        if "rateType" not in normalized:
+            normalized["rateType"] = normalized.get("rate_type") or "CPM"
+        if "deliveryType" not in normalized:
+            deal_types = {
+                str(deal_type).replace("_", "").replace("-", "").lower()
+                for deal_type in normalized.get("deal_types", [])
+            }
+            normalized["deliveryType"] = (
+                "Guaranteed" if "programmaticguaranteed" in deal_types else "PMP"
+            )
+        normalized.setdefault("currency", "USD")
+
+        if "ext" not in normalized:
+            normalized["ext"] = {}
+        if isinstance(normalized["ext"], dict):
+            normalized["ext"].setdefault("source", "seller-agent")
+            normalized["ext"].setdefault("raw_product", product)
+
+        return normalized
+
+    def _parse_products(self, data: Any) -> list[Product]:
+        products = data.get("products", data) if isinstance(data, dict) else data
+        return [
+            Product.model_validate(self._normalize_product_payload(p) if isinstance(p, dict) else p)
+            for p in products
+        ]
+
     # -------------------------------------------------------------------------
     # Products
     # -------------------------------------------------------------------------
@@ -71,9 +118,7 @@ class OpenDirectClient:
         params = {"$skip": skip, "$top": top, **filters}
         response = await self._client.get("/products", params=params)
         response.raise_for_status()
-        data = response.json()
-        products = data.get("products", data) if isinstance(data, dict) else data
-        return [Product.model_validate(p) for p in products]
+        return self._parse_products(response.json())
 
     async def get_product(self, product_id: str) -> Product:
         """Get a single product by ID.
@@ -86,7 +131,10 @@ class OpenDirectClient:
         """
         response = await self._client.get(f"/products/{product_id}")
         response.raise_for_status()
-        return Product.model_validate(response.json())
+        data = response.json()
+        return Product.model_validate(
+            self._normalize_product_payload(data) if isinstance(data, dict) else data
+        )
 
     async def search_products(self, filters: dict[str, Any]) -> list[Product]:
         """Search products with filters.
@@ -98,10 +146,13 @@ class OpenDirectClient:
             List of matching Product objects
         """
         response = await self._client.post("/products/search", json=filters)
-        response.raise_for_status()
-        data = response.json()
-        products = data.get("products", data) if isinstance(data, dict) else data
-        return [Product.model_validate(p) for p in products]
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 405:
+                raise
+            return await self.list_products()
+        return self._parse_products(response.json())
 
     async def check_avails(self, request: AvailsRequest) -> AvailsResponse:
         """Check availability and pricing for a product.

--- a/src/ad_buyer/models/opendirect.py
+++ b/src/ad_buyer/models/opendirect.py
@@ -79,7 +79,7 @@ class Product(BaseModel):
 
     id: str | None = None
     publisher_id: str = Field(..., alias="publisherId")
-    name: str = Field(..., max_length=38)
+    name: str = Field(..., max_length=100)
     description: str | None = None
     currency: str = Field(default="USD", description="ISO-4217 currency code")
     base_price: float = Field(..., alias="basePrice", ge=0)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -5,6 +5,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from ad_buyer.clients.opendirect_client import OpenDirectClient
@@ -71,6 +72,78 @@ class TestOpenDirectClient:
         assert len(products) == 1
         assert products[0].id == "prod_1"
         assert products[0].name == "Test Product"
+        mock_get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_list_products_normalizes_seller_agent_shape(self, client):
+        """Test listing products from the deployed seller-agent API shape."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "products": [
+                {
+                    "product_id": "prod-362e6cbd",
+                    "name": "Programmatic Linear Reach - A25-54 Primetime",
+                    "description": "Aggregated primetime linear reach",
+                    "inventory_type": "linear_tv",
+                    "base_cpm": 30.0,
+                    "floor_cpm": 20.0,
+                    "deal_types": ["programmaticguaranteed", "privateauction"],
+                }
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+            products = await client.list_products(skip=0, top=10)
+
+        assert len(products) == 1
+        assert products[0].id == "prod-362e6cbd"
+        assert products[0].publisher_id == "localhost:3000"
+        assert products[0].base_price == 30.0
+        assert products[0].rate_type.value == "CPM"
+        assert products[0].delivery_type == DeliveryType.GUARANTEED
+        assert products[0].ext["raw_product"]["base_cpm"] == 30.0
+        mock_get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_products_falls_back_to_list_when_seller_search_is_missing(self, client):
+        """Test deployed seller-agent compatibility when POST /products/search is absent."""
+        search_response = MagicMock()
+        request = httpx.Request("POST", "http://localhost:3000/api/v2.1/products/search")
+        response = httpx.Response(405, request=request)
+        search_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Method Not Allowed",
+            request=request,
+            response=response,
+        )
+
+        list_response = MagicMock()
+        list_response.json.return_value = {
+            "products": [
+                {
+                    "product_id": "prod-78b4269f",
+                    "name": "Standard Display - ROS",
+                    "base_cpm": 8.0,
+                    "deal_types": ["preferreddeal", "privateauction"],
+                }
+            ]
+        }
+        list_response.raise_for_status = MagicMock()
+
+        with (
+            patch.object(client._client, "post", new_callable=AsyncMock) as mock_post,
+            patch.object(client._client, "get", new_callable=AsyncMock) as mock_get,
+        ):
+            mock_post.return_value = search_response
+            mock_get.return_value = list_response
+            products = await client.search_products({"channel": "display"})
+
+        assert len(products) == 1
+        assert products[0].id == "prod-78b4269f"
+        assert products[0].base_price == 8.0
+        assert products[0].delivery_type == DeliveryType.PMP
+        mock_post.assert_called_once()
         mock_get.assert_called_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Normalize deployed seller-agent product payloads (`product_id`, `base_cpm`, `deal_types`) into the buyer OpenDirect `Product` shape before validation.
- Fall back from seller `POST /products/search` 405 responses to `GET /products`, matching the deployed seller API.
- Relax buyer product display-name validation so deployed seller catalog names are not rejected/truncated.

## Reproduction
- `curl -X POST https://iab-buyer.nicksworld.cc/products/search -H "Content-Type: application/json" -d "{\"query\":\"display advertising\"}"` currently returns a Pydantic validation error for missing `publisherId`, `basePrice`, and `rateType`.
- `curl https://iab-seller.nicksworld.cc/products` returns products using `product_id`, `base_cpm`, `floor_cpm`, and `deal_types`.

## Verification
- `git diff --check`
- `python3 -m py_compile src/ad_buyer/clients/opendirect_client.py src/ad_buyer/models/opendirect.py tests/unit/test_client.py`

Unable to run pytest in this execution environment: host has no `uv`, `pip`, or pytest; global Python lacks `httpx`/`pydantic`; Docker is installed but this user cannot access `/var/run/docker.sock`.

Refs LKMA-221.