### PR TITLE
Fix ruff lint and format errors in Mixpeek contextual enrichment code

### DIFF
--- a/src/ad_buyer/clients/mixpeek_client.py
+++ b/src/ad_buyer/clients/mixpeek_client.py
@@ -18,22 +18,24 @@ _DEFAULT_TIMEOUT = 30.0
 
 # Brand-safety sensitive IAB categories that advertisers typically
 # want to avoid or require explicit opt-in for.
-BRAND_UNSAFE_CATEGORIES = frozenset({
-    "Poker and Professional Gambling",
-    "Casinos & Gambling",
-    "Casino Games",
-    "Lotteries and Scratchcards",
-    "Sensitive Topics",
-    "Adult Content",
-    "Illegal Content",
-    "Debated Sensitive Social Topics",
-    "Terrorism",
-    "Crime",
-    "Drugs",
-    "Tobacco",
-    "Arms & Ammunition",
-    "Death & Grieving",
-})
+BRAND_UNSAFE_CATEGORIES = frozenset(
+    {
+        "Poker and Professional Gambling",
+        "Casinos & Gambling",
+        "Casino Games",
+        "Lotteries and Scratchcards",
+        "Sensitive Topics",
+        "Adult Content",
+        "Illegal Content",
+        "Debated Sensitive Social Topics",
+        "Terrorism",
+        "Crime",
+        "Drugs",
+        "Tobacco",
+        "Arms & Ammunition",
+        "Death & Grieving",
+    }
+)
 
 
 class MixpeekError(Exception):
@@ -127,16 +129,12 @@ class MixpeekClient:
 
     async def list_taxonomies(self, namespace: str | None = None) -> list[dict]:
         """List available taxonomies in the namespace."""
-        data = await self._request(
-            "POST", "/v1/taxonomies/list", namespace=namespace, json={}
-        )
+        data = await self._request("POST", "/v1/taxonomies/list", namespace=namespace, json={})
         return data.get("results", [])
 
     async def list_retrievers(self, namespace: str | None = None) -> list[dict]:
         """List available retriever pipelines in the namespace."""
-        data = await self._request(
-            "POST", "/v1/retrievers/list", namespace=namespace, json={}
-        )
+        data = await self._request("POST", "/v1/retrievers/list", namespace=namespace, json={})
         return data.get("results", [])
 
     async def classify_content(

--- a/src/ad_buyer/crews/channel_crews.py
+++ b/src/ad_buyer/crews/channel_crews.py
@@ -61,11 +61,13 @@ def _create_research_tools(client: OpenDirectClient) -> list[Any]:
 
     # Add Mixpeek contextual enrichment tools when configured
     if settings.mixpeek_api_key:
-        tools.extend([
-            ClassifyContentTool(),
-            BrandSafetyTool(),
-            ContextualSearchTool(),
-        ])
+        tools.extend(
+            [
+                ClassifyContentTool(),
+                BrandSafetyTool(),
+                ContextualSearchTool(),
+            ]
+        )
 
     return tools
 

--- a/src/ad_buyer/interfaces/mcp_server.py
+++ b/src/ad_buyer/interfaces/mcp_server.py
@@ -44,6 +44,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.prompts.base import Message
 
 from ..auth.key_store import ApiKeyStore
+from ..clients.mixpeek_client import MixpeekClient, MixpeekError
 from ..config.settings import Settings
 from ..media_kit.client import MediaKitClient
 from ..media_kit.models import MediaKitError
@@ -69,7 +70,6 @@ from ..tools.deal_library.deal_entry import (
     ManualDealEntry,
     create_manual_deal,
 )
-from ..clients.mixpeek_client import MixpeekClient, MixpeekError
 
 logger = logging.getLogger(__name__)
 
@@ -2982,13 +2982,17 @@ async def classify_content(
         if not rid:
             rid = await _discover_iab_retriever(client)
             if not rid:
-                return json.dumps({
-                    "error": "No IAB retriever found in this namespace. "
-                    "Set MIXPEEK_NAMESPACE or pass retriever_id explicitly."
-                })
+                return json.dumps(
+                    {
+                        "error": "No IAB retriever found in this namespace. "
+                        "Set MIXPEEK_NAMESPACE or pass retriever_id explicitly."
+                    }
+                )
 
         result = await client.classify_content(
-            retriever_id=rid, text=text, limit=limit,
+            retriever_id=rid,
+            text=text,
+            limit=limit,
         )
         docs = result.get("documents", [])
         categories = [
@@ -3031,12 +3035,12 @@ async def check_brand_safety(
         if not rid:
             rid = await _discover_iab_retriever(client)
             if not rid:
-                return json.dumps({
-                    "error": "No IAB retriever found in this namespace."
-                })
+                return json.dumps({"error": "No IAB retriever found in this namespace."})
 
         result = await client.check_brand_safety(
-            retriever_id=rid, text=text, threshold=threshold,
+            retriever_id=rid,
+            text=text,
+            threshold=threshold,
         )
         return json.dumps(result, indent=2)
     except MixpeekError as exc:

--- a/src/ad_buyer/tools/research/contextual_enrichment.py
+++ b/src/ad_buyer/tools/research/contextual_enrichment.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import json
-from typing import Any
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
@@ -30,6 +29,7 @@ def _get_mixpeek_client() -> MixpeekClient:
 # -----------------------------------------------------------------------
 # 1. Content Classification (IAB Taxonomy)
 # -----------------------------------------------------------------------
+
 
 class ClassifyContentInput(BaseModel):
     """Input for contextual content classification."""
@@ -97,14 +97,18 @@ class ClassifyContentTool(BaseTool):
             if not rid:
                 rid = await _discover_iab_retriever(client)
                 if not rid:
-                    return json.dumps({
-                        "error": "No IAB retriever found in this namespace. "
-                        "Set MIXPEEK_NAMESPACE to a namespace with IAB data, "
-                        "or pass retriever_id explicitly."
-                    })
+                    return json.dumps(
+                        {
+                            "error": "No IAB retriever found in this namespace. "
+                            "Set MIXPEEK_NAMESPACE to a namespace with IAB data, "
+                            "or pass retriever_id explicitly."
+                        }
+                    )
 
             result = await client.classify_content(
-                retriever_id=rid, text=text, limit=limit,
+                retriever_id=rid,
+                text=text,
+                limit=limit,
             )
 
             # Simplify output for the agent
@@ -129,6 +133,7 @@ class ClassifyContentTool(BaseTool):
 # -----------------------------------------------------------------------
 # 2. Brand Safety Check
 # -----------------------------------------------------------------------
+
 
 class BrandSafetyInput(BaseModel):
     """Input for brand-safety evaluation."""
@@ -174,9 +179,7 @@ class BrandSafetyTool(BaseTool):
         retriever_id: str | None = None,
         threshold: float = 0.80,
     ) -> str:
-        return run_async(
-            self._arun(text=text, retriever_id=retriever_id, threshold=threshold)
-        )
+        return run_async(self._arun(text=text, retriever_id=retriever_id, threshold=threshold))
 
     async def _arun(
         self,
@@ -193,12 +196,12 @@ class BrandSafetyTool(BaseTool):
             if not rid:
                 rid = await _discover_iab_retriever(client)
                 if not rid:
-                    return json.dumps({
-                        "error": "No IAB retriever found in this namespace."
-                    })
+                    return json.dumps({"error": "No IAB retriever found in this namespace."})
 
             result = await client.check_brand_safety(
-                retriever_id=rid, text=text, threshold=threshold,
+                retriever_id=rid,
+                text=text,
+                threshold=threshold,
             )
             return json.dumps(result, indent=2)
 
@@ -211,6 +214,7 @@ class BrandSafetyTool(BaseTool):
 # -----------------------------------------------------------------------
 # 3. Contextual Search (inventory enrichment)
 # -----------------------------------------------------------------------
+
 
 class ContextualSearchInput(BaseModel):
     """Input for contextual inventory search."""
@@ -253,9 +257,7 @@ class ContextualSearchTool(BaseTool):
         retriever_id: str = "",
         limit: int = 10,
     ) -> str:
-        return run_async(
-            self._arun(query=query, retriever_id=retriever_id, limit=limit)
-        )
+        return run_async(self._arun(query=query, retriever_id=retriever_id, limit=limit))
 
     async def _arun(
         self,
@@ -280,6 +282,7 @@ class ContextualSearchTool(BaseTool):
 # -----------------------------------------------------------------------
 # Helpers
 # -----------------------------------------------------------------------
+
 
 async def _discover_iab_retriever(client: MixpeekClient) -> str | None:
     """Find an IAB text search retriever in the current namespace."""

--- a/tests/e2e/test_mixpeek_production.py
+++ b/tests/e2e/test_mixpeek_production.py
@@ -32,9 +32,7 @@ BASE_URL = os.environ.get("MIXPEEK_BASE_URL", "https://api.mixpeek.com")
 NAMESPACE = os.environ.get("MIXPEEK_NAMESPACE", "golden_adtech_iab")
 
 # Known retriever in golden_adtech_iab namespace
-IAB_TEXT_RETRIEVER = os.environ.get(
-    "MIXPEEK_IAB_RETRIEVER_ID", "ret_f7fbefced358bd"
-)
+IAB_TEXT_RETRIEVER = os.environ.get("MIXPEEK_IAB_RETRIEVER_ID", "ret_f7fbefced358bd")
 
 pytestmark = [
     pytest.mark.e2e,
@@ -45,6 +43,7 @@ pytestmark = [
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest_asyncio.fixture
 async def client():
@@ -60,6 +59,7 @@ async def client():
 # ---------------------------------------------------------------------------
 # 1. Health & Discovery
 # ---------------------------------------------------------------------------
+
 
 class TestHealthAndDiscovery:
     @pytest.mark.asyncio
@@ -85,14 +85,13 @@ class TestHealthAndDiscovery:
         retrievers = await client.list_retrievers()
         assert len(retrievers) > 0
         names = {r["retriever_name"] for r in retrievers}
-        assert any("iab" in n.lower() for n in names), (
-            f"No IAB retriever found. Available: {names}"
-        )
+        assert any("iab" in n.lower() for n in names), f"No IAB retriever found. Available: {names}"
 
 
 # ---------------------------------------------------------------------------
 # 2. IAB Content Classification
 # ---------------------------------------------------------------------------
+
 
 class TestIABClassification:
     @pytest.mark.asyncio
@@ -113,7 +112,9 @@ class TestIABClassification:
         assert "Sports" in top["iab_path"]
         # Top result should be American Football or Sports
         assert top["iab_category_name"] in (
-            "American Football", "Sports", "College Football",
+            "American Football",
+            "Sports",
+            "College Football",
         )
 
     @pytest.mark.asyncio
@@ -153,9 +154,7 @@ class TestIABClassification:
         top = docs[0]
         assert top["score"] > 0.80
         # Should be in Food & Drink or Cooking
-        paths_flat = [
-            cat for d in docs[:3] for cat in d.get("iab_path", [])
-        ]
+        paths_flat = [cat for d in docs[:3] for cat in d.get("iab_path", [])]
         assert "Food & Drink" in paths_flat or "Cooking" in paths_flat
 
     @pytest.mark.asyncio
@@ -195,6 +194,7 @@ class TestIABClassification:
 # ---------------------------------------------------------------------------
 # 3. Brand Safety
 # ---------------------------------------------------------------------------
+
 
 class TestBrandSafety:
     @pytest.mark.asyncio
@@ -255,6 +255,7 @@ class TestBrandSafety:
 # 4. Contextual Search
 # ---------------------------------------------------------------------------
 
+
 class TestContextualSearch:
     @pytest.mark.asyncio
     async def test_search_returns_results(self, client: MixpeekClient):
@@ -304,6 +305,7 @@ class TestContextualSearch:
 # ---------------------------------------------------------------------------
 # 5. Error Handling
 # ---------------------------------------------------------------------------
+
 
 class TestErrorHandling:
     @pytest.mark.asyncio

--- a/tests/unit/test_contextual_enrichment.py
+++ b/tests/unit/test_contextual_enrichment.py
@@ -61,9 +61,7 @@ class TestClassifyContentTool:
             "ad_buyer.tools.research.contextual_enrichment._get_mixpeek_client",
             return_value=mock_client,
         ):
-            result = await classify_tool._arun(
-                text="NFL scores", retriever_id="ret-123"
-            )
+            result = await classify_tool._arun(text="NFL scores", retriever_id="ret-123")
 
         data = json.loads(result)
         assert data["categories"][0]["category"] == "Sports"
@@ -83,10 +81,12 @@ class TestClassifyContentTool:
             "ad_buyer.tools.research.contextual_enrichment._get_mixpeek_client",
             return_value=mock_client,
         ):
-            result = await classify_tool._arun(text="test content")
+            await classify_tool._arun(text="test content")
 
         mock_client.classify_content.assert_called_once_with(
-            retriever_id="ret-1", text="test content", limit=10,
+            retriever_id="ret-1",
+            text="test content",
+            limit=10,
         )
 
     @pytest.mark.asyncio
@@ -141,9 +141,7 @@ class TestBrandSafetyTool:
         mock_client.check_brand_safety.return_value = {
             "safe": False,
             "risk_level": "high",
-            "flagged_categories": [
-                {"category": "Casinos & Gambling", "score": 0.88}
-            ],
+            "flagged_categories": [{"category": "Casinos & Gambling", "score": 0.88}],
             "categories": [],
         }
         mock_client.close = AsyncMock()
@@ -175,13 +173,13 @@ class TestContextualSearchTool:
             "ad_buyer.tools.research.contextual_enrichment._get_mixpeek_client",
             return_value=mock_client,
         ):
-            result = await search_tool._arun(
-                query="sports news", retriever_id="ret-1", limit=5
-            )
+            result = await search_tool._arun(query="sports news", retriever_id="ret-1", limit=5)
 
         data = json.loads(result)
         assert data["documents"][0]["score"] == 0.85
         mock_client.search_content.assert_called_once_with(
-            retriever_id="ret-1", query="sports news", limit=5,
+            retriever_id="ret-1",
+            query="sports news",
+            limit=5,
         )
         mock_client.close.assert_called_once()

--- a/tests/unit/test_mixpeek_client.py
+++ b/tests/unit/test_mixpeek_client.py
@@ -5,10 +5,8 @@
 
 from __future__ import annotations
 
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
 import pytest
 
 from ad_buyer.clients.mixpeek_client import (
@@ -65,7 +63,9 @@ class TestClassifyContent:
             ]
         }
 
-        with patch.object(client._client, "request", new_callable=AsyncMock, return_value=mock_resp):
+        with patch.object(
+            client._client, "request", new_callable=AsyncMock, return_value=mock_resp
+        ):
             result = await client.classify_content(
                 retriever_id="ret-123", text="NFL football scores"
             )
@@ -78,11 +78,11 @@ class TestClassifyContent:
         mock_resp.status_code = 401
         mock_resp.text = "Unauthorized"
 
-        with patch.object(client._client, "request", new_callable=AsyncMock, return_value=mock_resp):
+        with patch.object(
+            client._client, "request", new_callable=AsyncMock, return_value=mock_resp
+        ):
             with pytest.raises(MixpeekError, match="401"):
-                await client.classify_content(
-                    retriever_id="ret-123", text="test"
-                )
+                await client.classify_content(retriever_id="ret-123", text="test")
 
 
 class TestBrandSafety:
@@ -101,7 +101,9 @@ class TestBrandSafety:
             ]
         }
 
-        with patch.object(client._client, "request", new_callable=AsyncMock, return_value=mock_resp):
+        with patch.object(
+            client._client, "request", new_callable=AsyncMock, return_value=mock_resp
+        ):
             result = await client.check_brand_safety(
                 retriever_id="ret-123", text="local basketball game"
             )
@@ -131,7 +133,9 @@ class TestBrandSafety:
             ]
         }
 
-        with patch.object(client._client, "request", new_callable=AsyncMock, return_value=mock_resp):
+        with patch.object(
+            client._client, "request", new_callable=AsyncMock, return_value=mock_resp
+        ):
             result = await client.check_brand_safety(
                 retriever_id="ret-123", text="poker casino betting"
             )
@@ -155,7 +159,9 @@ class TestBrandSafety:
             ]
         }
 
-        with patch.object(client._client, "request", new_callable=AsyncMock, return_value=mock_resp):
+        with patch.object(
+            client._client, "request", new_callable=AsyncMock, return_value=mock_resp
+        ):
             result = await client.check_brand_safety(
                 retriever_id="ret-123",
                 text="card games",
@@ -177,10 +183,10 @@ class TestSearchContent:
         mock_resp.status_code = 200
         mock_resp.json.return_value = {"documents": []}
 
-        with patch.object(client._client, "request", new_callable=AsyncMock, return_value=mock_resp) as mock_req:
-            await client.search_content(
-                retriever_id="ret-456", query="sports news", limit=5
-            )
+        with patch.object(
+            client._client, "request", new_callable=AsyncMock, return_value=mock_resp
+        ) as mock_req:
+            await client.search_content(retriever_id="ret-456", query="sports news", limit=5)
 
         call_args = mock_req.call_args
         body = call_args.kwargs.get("json") or call_args[1].get("json")
@@ -194,12 +200,12 @@ class TestListRetrievers:
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = {
-            "results": [
-                {"retriever_id": "r1", "retriever_name": "iab_text_search"}
-            ]
+            "results": [{"retriever_id": "r1", "retriever_name": "iab_text_search"}]
         }
 
-        with patch.object(client._client, "request", new_callable=AsyncMock, return_value=mock_resp):
+        with patch.object(
+            client._client, "request", new_callable=AsyncMock, return_value=mock_resp
+        ):
             result = await client.list_retrievers()
 
         assert len(result) == 1
@@ -215,7 +221,9 @@ class TestListTaxonomies:
             "results": [{"taxonomy_id": "t1", "taxonomy_name": "IAB v3.0"}]
         }
 
-        with patch.object(client._client, "request", new_callable=AsyncMock, return_value=mock_resp):
+        with patch.object(
+            client._client, "request", new_callable=AsyncMock, return_value=mock_resp
+        ):
             result = await client.list_taxonomies()
 
         assert len(result) == 1


### PR DESCRIPTION
The Mixpeek/contextual-enrichment code (merged via #78) was never run through ruff before merging, leaving main failing CI's Lint job: unused imports, an unsorted import block in mcp_server.py, an unused test variable, and 8 over-length lines in test_mixpeek_client.py. Fixes are mechanical (ruff --fix + ruff format); no behavior change.