### PR TITLE
Fix main CI: dependency-drift repairs (crewai 1.15 flow internals, fastapi router enumeration, ruff findings)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=5.0.0",
-    "ruff>=0.5.0",
+    "ruff>=0.15,<0.16",
     "mypy>=1.11.0",
     # flask is imported transitively by demo/{campaign_demo,deal_library_dashboard}.py
     # which the demo Flask-app unit tests under tests/unit/ import. Without this,

--- a/scripts/generate_inventories.py
+++ b/scripts/generate_inventories.py
@@ -78,19 +78,36 @@ def generate_mcp_tools() -> str:
     return "\n".join(lines)
 
 
-def generate_endpoints() -> str:
-    """Walk the FastAPI app and enumerate its REST routes."""
+def _iter_api_routes(routes, prefix: str = ""):
+    """Yield ``(path, APIRoute)`` pairs, descending into included routers.
+
+    FastAPI < 0.141 flattens ``include_router`` calls directly into
+    ``app.routes``; newer versions instead append a lazy proxy route that
+    keeps the included routes on its ``original_router``. Descend into both
+    shapes so the inventory is identical regardless of the installed
+    FastAPI version.
+    """
     from fastapi.routing import APIRoute
 
+    for route in routes:
+        if isinstance(route, APIRoute):
+            yield prefix + route.path, route
+            continue
+        nested = getattr(route, "original_router", None)
+        if nested is not None:
+            nested_prefix = getattr(getattr(route, "include_context", None), "prefix", "")
+            yield from _iter_api_routes(nested.routes, prefix + nested_prefix)
+
+
+def generate_endpoints() -> str:
+    """Walk the FastAPI app and enumerate its REST routes."""
     from ad_buyer.interfaces.api.main import app
 
     seen: dict[tuple[str, str], str] = {}
-    for route in app.routes:
-        if not isinstance(route, APIRoute):
-            continue
+    for path, route in _iter_api_routes(app.routes):
         methods = sorted(m for m in route.methods if m not in {"HEAD", "OPTIONS"})
         for method in methods:
-            seen[(method, route.path)] = route.name or ""
+            seen[(method, path)] = route.name or ""
 
     rows = sorted(seen.items(), key=lambda kv: (kv[0][1], kv[0][0]))
 

--- a/src/ad_buyer/clients/contract_mappers.py
+++ b/src/ad_buyer/clients/contract_mappers.py
@@ -289,9 +289,7 @@ def to_wire_quote_request(
     """Build the shared ``QuoteRequest`` envelope from the buyer's model."""
     media_type = MediaType(req.media_type)
     wire_linear_tv = (
-        _to_wire_linear_tv_params(req.linear_tv)
-        if media_type is MediaType.LINEAR_TV
-        else None
+        _to_wire_linear_tv_params(req.linear_tv) if media_type is MediaType.LINEAR_TV else None
     )
     return WireQuoteRequest(
         idempotency_key=idempotency_key or uuid4().hex,
@@ -305,9 +303,7 @@ def to_wire_quote_request(
         agent_url=req.agent_url,
         media_type=media_type,
         linear_tv=wire_linear_tv,
-        audience_plan=(
-            req.audience_plan.model_dump(mode="json") if req.audience_plan else None
-        ),
+        audience_plan=(req.audience_plan.model_dump(mode="json") if req.audience_plan else None),
     )
 
 
@@ -352,9 +348,7 @@ def to_wire_deal_booking_request(
         quote_id=req.quote_id,
         buyer_identity=_to_wire_buyer_identity(req.buyer_identity),
         notes=req.notes,
-        audience_plan=(
-            req.audience_plan.model_dump(mode="json") if req.audience_plan else None
-        ),
+        audience_plan=(req.audience_plan.model_dump(mode="json") if req.audience_plan else None),
     )
 
 

--- a/src/ad_buyer/clients/opendirect_client.py
+++ b/src/ad_buyer/clients/opendirect_client.py
@@ -122,8 +122,7 @@ def _filter_wire_products(
         result = [
             p
             for p in result
-            if not p.ad_formats
-            or requested in {_normalize_ad_format(f) for f in p.ad_formats}
+            if not p.ad_formats or requested in {_normalize_ad_format(f) for f in p.ad_formats}
         ]
 
     delivery_type = filters.get("deliveryType")
@@ -387,9 +386,7 @@ class OpenDirectClient:
         Returns:
             AvailsResponse with availability and pricing info
         """
-        spec_dialect = (
-            self.account_id is not None and self.advertiser_brand_id is not None
-        )
+        spec_dialect = self.account_id is not None and self.advertiser_brand_id is not None
         if spec_dialect:
             search = request.to_spec(
                 account_id=self.account_id,
@@ -416,9 +413,7 @@ class OpenDirectClient:
             # refuses to fabricate a volume if availability is absent
             # (ValueError surfaces to the caller).
             matches = [
-                record
-                for record in parsed.avails
-                if record.product_id == request.product_id
+                record for record in parsed.avails if record.product_id == request.product_id
             ] or parsed.avails
             if not matches:
                 raise ValueError(

--- a/src/ad_buyer/events/helpers.py
+++ b/src/ad_buyer/events/helpers.py
@@ -188,9 +188,7 @@ def emit_event_sync(
                 # writes the fallback record (best effort, logged if it fails).
                 future = asyncio.ensure_future(bus.publish(event))
                 if event_type in AUDIT_EVENT_TYPES:
-                    future.add_done_callback(
-                        lambda fut, ev=event: _audit_publish_done(fut, ev)
-                    )
+                    future.add_done_callback(lambda fut, ev=event: _audit_publish_done(fut, ev))
             else:
                 loop.run_until_complete(bus.publish(event))
         except RuntimeError:

--- a/src/ad_buyer/flows/deal_booking_flow.py
+++ b/src/ad_buyer/flows/deal_booking_flow.py
@@ -234,9 +234,7 @@ class DealBookingFlow(Flow[BookingState]):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _pricing_rationale(
-        base_cpm: float | None, final_cpm: float | None
-    ) -> str | None:
+    def _pricing_rationale(base_cpm: float | None, final_cpm: float | None) -> str | None:
         """Assemble the truthful pricing audit line for a booked deal.
 
         The seller's own quote ``rationale`` is computed

--- a/src/ad_buyer/registry/aamp_client.py
+++ b/src/ad_buyer/registry/aamp_client.py
@@ -182,11 +182,7 @@ class AampRegistryClient:
         cards = [_to_agent_card(agent) for agent in agents]
         if capabilities_filter:
             wanted = {c.lower() for c in capabilities_filter}
-            cards = [
-                card
-                for card in cards
-                if wanted & {c.name.lower() for c in card.capabilities}
-            ]
+            cards = [card for card in cards if wanted & {c.name.lower() for c in card.capabilities}]
 
         self._cache.put_list(cache_key, cards)
         for card in cards:

--- a/src/ad_buyer/tools/buyer_deals/discover_inventory.py
+++ b/src/ad_buyer/tools/buyer_deals/discover_inventory.py
@@ -396,9 +396,7 @@ Returns:
                 output_lines.append(f"{i}. {sanitize_untrusted_text(product)}")
                 output_lines.append("")
 
-        output_lines.append(
-            "[END UNTRUSTED seller-provided inventory listing]"
-        )
+        output_lines.append("[END UNTRUSTED seller-provided inventory listing]")
         output_lines.append("-" * 50)
         output_lines.append(f"Total products found: {len(product_list)}")
         summary_line = self._filter_summary_line(filter_summary)

--- a/src/ad_buyer/tools/research/product_search.py
+++ b/src/ad_buyer/tools/research/product_search.py
@@ -175,9 +175,7 @@ Returns:
             if p.targeting:
                 capabilities = p.targeting.get("capabilities", [])
                 if capabilities:
-                    targeting_str = sanitize_untrusted_text(
-                        ", ".join(str(c) for c in capabilities)
-                    )
+                    targeting_str = sanitize_untrusted_text(", ".join(str(c) for c in capabilities))
 
             avail_str = f"{p.available_impressions:,}" if p.available_impressions else "N/A"
 

--- a/tests/integration/test_aamp_live_smoke.py
+++ b/tests/integration/test_aamp_live_smoke.py
@@ -20,8 +20,7 @@ _TOKEN = os.environ.get("AAMP_REGISTRY_AUTH_TOKEN")
 
 pytestmark = pytest.mark.skipif(
     not (_URL and _TOKEN),
-    reason="live AAMP registry smoke requires AAMP_REGISTRY_URL and "
-    "AAMP_REGISTRY_AUTH_TOKEN",
+    reason="live AAMP registry smoke requires AAMP_REGISTRY_URL and AAMP_REGISTRY_AUTH_TOKEN",
 )
 
 

--- a/tests/unit/test_audience_planner_wiring.py
+++ b/tests/unit/test_audience_planner_wiring.py
@@ -114,8 +114,7 @@ class TestPlannerStepProducesAudiencePlan:
         result = run_audience_planner_step(brief)
 
         assert result.plan is not None, (
-            "The Audience Planner step MUST populate a "
-            "typed plan from the brief."
+            "The Audience Planner step MUST populate a typed plan from the brief."
         )
         assert isinstance(result.plan, AudiencePlan)
         # Legacy migration policy: first item -> primary, type=standard.

--- a/tests/unit/test_booking_path_llm_free.py
+++ b/tests/unit/test_booking_path_llm_free.py
@@ -116,8 +116,7 @@ class TestBookingEngineImportClosureIsLLMFree:
         offenders = sorted(
             mod
             for mod in closure
-            if mod.split(".")[0] in _LLM_PACKAGES
-            or mod.startswith(_LLM_FIRST_PARTY_PREFIXES)
+            if mod.split(".")[0] in _LLM_PACKAGES or mod.startswith(_LLM_FIRST_PARTY_PREFIXES)
         )
         assert not offenders, (
             "The MultiSellerOrchestrator import closure must be LLM-free, but "
@@ -165,8 +164,10 @@ class TestDealBookingFlowBookingHalfIsLLMFree:
                 func_node = node.func
                 if isinstance(func_node, ast.Attribute) and func_node.attr == "kickoff":
                     return True
-                if isinstance(func_node, ast.Name) and func_node.id.startswith("create_") and (
-                    func_node.id.endswith("_crew")
+                if (
+                    isinstance(func_node, ast.Name)
+                    and func_node.id.startswith("create_")
+                    and (func_node.id.endswith("_crew"))
                 ):
                     return True
         return False

--- a/tests/unit/test_campaign_demo.py
+++ b/tests/unit/test_campaign_demo.py
@@ -20,8 +20,8 @@ import json
 
 import pytest
 
-from demo.campaign_demo import create_campaign_demo_app
 from ad_buyer.storage.campaign_store import CampaignStore
+from demo.campaign_demo import create_campaign_demo_app
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/unit/test_campaign_events.py
+++ b/tests/unit/test_campaign_events.py
@@ -681,9 +681,7 @@ class TestCampaignAutomationEventBus:
         from ad_buyer.events.models import Event, EventType
 
         received = []
-        asyncio.run(
-            bus.subscribe("campaign.ready", lambda e: received.append(e))
-        )
+        asyncio.run(bus.subscribe("campaign.ready", lambda e: received.append(e)))
 
         event = Event(event_type=EventType.CAMPAIGN_READY, campaign_id="camp-510")
         asyncio.run(bus.publish(event))
@@ -696,9 +694,7 @@ class TestCampaignAutomationEventBus:
         from ad_buyer.events.models import Event, EventType
 
         received = []
-        asyncio.run(
-            bus.subscribe("pacing.reallocation_recommended", lambda e: received.append(e))
-        )
+        asyncio.run(bus.subscribe("pacing.reallocation_recommended", lambda e: received.append(e)))
 
         event = Event(
             event_type=EventType.PACING_REALLOCATION_RECOMMENDED,
@@ -714,9 +710,7 @@ class TestCampaignAutomationEventBus:
         from ad_buyer.events.models import Event, EventType
 
         received = []
-        asyncio.run(
-            bus.subscribe("creative.matched", lambda e: received.append(e))
-        )
+        asyncio.run(bus.subscribe("creative.matched", lambda e: received.append(e)))
 
         event = Event(event_type=EventType.CREATIVE_MATCHED, campaign_id="camp-512")
         asyncio.run(bus.publish(event))
@@ -728,30 +722,18 @@ class TestCampaignAutomationEventBus:
         """Should filter events by campaign automation event types."""
         from ad_buyer.events.models import Event, EventType
 
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.CAMPAIGN_READY))
-        )
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.PACING_SNAPSHOT_TAKEN))
-        )
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.CREATIVE_UPLOADED))
-        )
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.DEAL_BOOKED))
-        )
+        asyncio.run(bus.publish(Event(event_type=EventType.CAMPAIGN_READY)))
+        asyncio.run(bus.publish(Event(event_type=EventType.PACING_SNAPSHOT_TAKEN)))
+        asyncio.run(bus.publish(Event(event_type=EventType.CREATIVE_UPLOADED)))
+        asyncio.run(bus.publish(Event(event_type=EventType.DEAL_BOOKED)))
 
         # Filter by campaign.ready
-        events = asyncio.run(
-            bus.list_events(event_type="campaign.ready")
-        )
+        events = asyncio.run(bus.list_events(event_type="campaign.ready"))
         assert len(events) == 1
         assert events[0].event_type == EventType.CAMPAIGN_READY
 
         # Filter by pacing.snapshot_taken
-        events = asyncio.run(
-            bus.list_events(event_type="pacing.snapshot_taken")
-        )
+        events = asyncio.run(bus.list_events(event_type="pacing.snapshot_taken"))
         assert len(events) == 1
         assert events[0].event_type == EventType.PACING_SNAPSHOT_TAKEN
 
@@ -760,19 +742,11 @@ class TestCampaignAutomationEventBus:
         from ad_buyer.events.models import Event, EventType
 
         received = []
-        asyncio.run(
-            bus.subscribe("*", lambda e: received.append(e))
-        )
+        asyncio.run(bus.subscribe("*", lambda e: received.append(e)))
 
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.CAMPAIGN_READY))
-        )
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.PACING_DEVIATION_DETECTED))
-        )
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.CREATIVE_VALIDATED))
-        )
+        asyncio.run(bus.publish(Event(event_type=EventType.CAMPAIGN_READY)))
+        asyncio.run(bus.publish(Event(event_type=EventType.PACING_DEVIATION_DETECTED)))
+        asyncio.run(bus.publish(Event(event_type=EventType.CREATIVE_VALIDATED)))
 
         assert len(received) == 3
 

--- a/tests/unit/test_canonical_booking_path.py
+++ b/tests/unit/test_canonical_booking_path.py
@@ -250,18 +250,14 @@ class TestCanonicalBookingEndToEnd:
         assert "order_pending" not in state_dump
         assert not booked.deal_id.startswith("DEAL-")  # buyer's legacy local-mint prefix
 
-    def test_seller_booking_failure_yields_no_booked_line(
-        self, fake_deals_clients, deal_store
-    ):
+    def test_seller_booking_failure_yields_no_booked_line(self, fake_deals_clients, deal_store):
         """A seller that never confirms produces NO booking record at all."""
 
         class RejectingDealsClient(FakeDealsClient):
             async def book_deal(self, booking_request):
                 from ad_buyer.clients.deals_client import DealsClientError
 
-                raise DealsClientError(
-                    "booking rejected", status_code=409, detail="inventory gone"
-                )
+                raise DealsClientError("booking rejected", status_code=409, detail="inventory gone")
 
         orchestrator = MultiSellerOrchestrator(
             registry_client=FakeRegistry(),
@@ -329,6 +325,4 @@ class TestNoFakeBookingIdentifiersInSource:
             if "deal_id import generate_deal_id" in path.read_text()
             or "generate_deal_id(" in path.read_text()
         ]
-        assert not offenders, (
-            f"Flows must never mint local DEAL-xxxx ids: {offenders}"
-        )
+        assert not offenders, f"Flows must never mint local DEAL-xxxx ids: {offenders}"

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -247,9 +247,7 @@ class TestFilterWireProducts:
         display = self._wire_product("display_1", ["display"])
         video = self._wire_product("video_1", ["video"])
         undeclared = self._wire_product("undeclared_1", [])
-        result = _filter_wire_products(
-            [display, video, undeclared], {"adFormat": "display"}
-        )
+        result = _filter_wire_products([display, video, undeclared], {"adFormat": "display"})
         assert [p.product_id for p in result] == ["display_1", "undeclared_1"]
 
     def test_no_ad_format_filter_keeps_everything(self):

--- a/tests/unit/test_deal_library_dashboard.py
+++ b/tests/unit/test_deal_library_dashboard.py
@@ -18,9 +18,9 @@ import json
 
 import pytest
 
+from ad_buyer.storage.deal_store import DealStore
 from demo.deal_library_dashboard import create_app
 from demo.seed_data import seed_demo_data
-from ad_buyer.storage.deal_store import DealStore
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/unit/test_deal_library_events.py
+++ b/tests/unit/test_deal_library_events.py
@@ -218,9 +218,7 @@ class TestDealLibraryEventBus:
         from ad_buyer.events.models import Event, EventType
 
         received = []
-        asyncio.run(
-            bus.subscribe("deal.imported", lambda e: received.append(e))
-        )
+        asyncio.run(bus.subscribe("deal.imported", lambda e: received.append(e)))
 
         event = Event(event_type=EventType.DEAL_IMPORTED)
         asyncio.run(bus.publish(event))
@@ -233,9 +231,7 @@ class TestDealLibraryEventBus:
         from ad_buyer.events.models import Event, EventType
 
         received = []
-        asyncio.run(
-            bus.subscribe("deal.manual_action_required", lambda e: received.append(e))
-        )
+        asyncio.run(bus.subscribe("deal.manual_action_required", lambda e: received.append(e)))
 
         event = Event(event_type=EventType.DEAL_MANUAL_ACTION_REQUIRED)
         asyncio.run(bus.publish(event))
@@ -247,19 +243,11 @@ class TestDealLibraryEventBus:
         """Should filter events by Phase 1 event types."""
         from ad_buyer.events.models import Event, EventType
 
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.DEAL_IMPORTED))
-        )
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.DEAL_BOOKED))
-        )
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.PORTFOLIO_INSPECTED))
-        )
+        asyncio.run(bus.publish(Event(event_type=EventType.DEAL_IMPORTED)))
+        asyncio.run(bus.publish(Event(event_type=EventType.DEAL_BOOKED)))
+        asyncio.run(bus.publish(Event(event_type=EventType.PORTFOLIO_INSPECTED)))
 
-        events = asyncio.run(
-            bus.list_events(event_type="deal.imported")
-        )
+        events = asyncio.run(bus.list_events(event_type="deal.imported"))
         assert len(events) == 1
         assert events[0].event_type == EventType.DEAL_IMPORTED
 
@@ -268,16 +256,10 @@ class TestDealLibraryEventBus:
         from ad_buyer.events.models import Event, EventType
 
         received = []
-        asyncio.run(
-            bus.subscribe("*", lambda e: received.append(e))
-        )
+        asyncio.run(bus.subscribe("*", lambda e: received.append(e)))
 
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.DEAL_IMPORTED))
-        )
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.DEAL_TEMPLATE_CREATED))
-        )
+        asyncio.run(bus.publish(Event(event_type=EventType.DEAL_IMPORTED)))
+        asyncio.run(bus.publish(Event(event_type=EventType.DEAL_TEMPLATE_CREATED)))
 
         assert len(received) == 2
 

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -137,9 +137,7 @@ class TestInMemoryEventBus:
         from ad_buyer.events.models import Event, EventType
 
         received = []
-        asyncio.run(
-            bus.subscribe("*", lambda e: received.append(e))
-        )
+        asyncio.run(bus.subscribe("*", lambda e: received.append(e)))
 
         e1 = Event(event_type=EventType.DEAL_BOOKED)
         e2 = Event(event_type=EventType.CAMPAIGN_CREATED)
@@ -183,9 +181,7 @@ class TestInMemoryEventBus:
         from ad_buyer.events.models import Event, EventType
 
         for _ in range(3):
-            asyncio.run(
-                bus.publish(Event(event_type=EventType.DEAL_BOOKED))
-            )
+            asyncio.run(bus.publish(Event(event_type=EventType.DEAL_BOOKED)))
 
         events = asyncio.run(bus.list_events())
         assert len(events) == 3
@@ -194,12 +190,8 @@ class TestInMemoryEventBus:
         """Should filter events by flow_id."""
         from ad_buyer.events.models import Event, EventType
 
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.DEAL_BOOKED, flow_id="f1"))
-        )
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.DEAL_BOOKED, flow_id="f2"))
-        )
+        asyncio.run(bus.publish(Event(event_type=EventType.DEAL_BOOKED, flow_id="f1")))
+        asyncio.run(bus.publish(Event(event_type=EventType.DEAL_BOOKED, flow_id="f2")))
 
         events = asyncio.run(bus.list_events(flow_id="f1"))
         assert len(events) == 1
@@ -209,28 +201,18 @@ class TestInMemoryEventBus:
         """Should filter events by event_type."""
         from ad_buyer.events.models import Event, EventType
 
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.DEAL_BOOKED))
-        )
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.CAMPAIGN_CREATED))
-        )
+        asyncio.run(bus.publish(Event(event_type=EventType.DEAL_BOOKED)))
+        asyncio.run(bus.publish(Event(event_type=EventType.CAMPAIGN_CREATED)))
 
-        events = asyncio.run(
-            bus.list_events(event_type="deal.booked")
-        )
+        events = asyncio.run(bus.list_events(event_type="deal.booked"))
         assert len(events) == 1
 
     def test_list_events_by_session_id(self, bus):
         """Should filter events by session_id."""
         from ad_buyer.events.models import Event, EventType
 
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.SESSION_CREATED, session_id="s1"))
-        )
-        asyncio.run(
-            bus.publish(Event(event_type=EventType.SESSION_CLOSED, session_id="s2"))
-        )
+        asyncio.run(bus.publish(Event(event_type=EventType.SESSION_CREATED, session_id="s1")))
+        asyncio.run(bus.publish(Event(event_type=EventType.SESSION_CLOSED, session_id="s2")))
 
         events = asyncio.run(bus.list_events(session_id="s1"))
         assert len(events) == 1
@@ -240,9 +222,7 @@ class TestInMemoryEventBus:
         from ad_buyer.events.models import Event, EventType
 
         for _ in range(10):
-            asyncio.run(
-                bus.publish(Event(event_type=EventType.DEAL_BOOKED))
-            )
+            asyncio.run(bus.publish(Event(event_type=EventType.DEAL_BOOKED)))
 
         events = asyncio.run(bus.list_events(limit=3))
         assert len(events) == 3
@@ -298,9 +278,7 @@ class TestEmitEvent:
             "ad_buyer.events.bus.get_event_bus",
             side_effect=RuntimeError("bus down"),
         ):
-            result = asyncio.run(
-                emit_event(event_type=EventType.QUOTE_REQUESTED)
-            )
+            result = asyncio.run(emit_event(event_type=EventType.QUOTE_REQUESTED))
             assert result is None
 
         bus_mod._event_bus_instance = None

--- a/tests/unit/test_meta_social_booking.py
+++ b/tests/unit/test_meta_social_booking.py
@@ -33,6 +33,29 @@ from ad_buyer.orchestration.multi_seller import (
 )
 
 
+def _listener_triggers(flow_cls, method_name):
+    """Return ``{"type": ..., "conditions": [...]}`` for a listener method.
+
+    CrewAI < 1.15 exposes a class-level ``_listeners`` registry populated by
+    ``FlowMeta``; CrewAI >= 1.15 removed it and stores the trigger condition
+    on the method's ``__flow_method_definition__`` (``listen`` is either a
+    plain trigger name or ``{"and"|"or": [...]}``). Normalize both layouts to
+    the pre-1.15 registry shape so the assertions stay version-independent.
+    """
+    registry = getattr(flow_cls, "_listeners", None)
+    if registry is not None:
+        return registry.get(method_name)
+
+    definition = getattr(getattr(flow_cls, method_name), "__flow_method_definition__", None)
+    listen = getattr(definition, "listen", None)
+    if isinstance(listen, str):
+        return {"type": "OR", "conditions": [listen]}
+    if isinstance(listen, dict) and len(listen) == 1:
+        condition_type, conditions = next(iter(listen.items()))
+        return {"type": condition_type.upper(), "conditions": conditions}
+    return None
+
+
 def _make_recommendation(product_id, channel, impressions=100000, cpm=10.0):
     return ProductRecommendation(
         product_id=product_id,
@@ -149,7 +172,7 @@ class TestResearchSocial:
 
     def test_consolidate_listens_to_research_social(self):
         """consolidate_recommendations must fire only after research_social too."""
-        triggers = DealBookingFlow._listeners.get("consolidate_recommendations")
+        triggers = _listener_triggers(DealBookingFlow, "consolidate_recommendations")
         assert triggers is not None
         assert triggers["type"] == "AND"
         assert "research_social" in triggers["conditions"]

--- a/tests/unit/test_negotiation_reachability.py
+++ b/tests/unit/test_negotiation_reachability.py
@@ -106,9 +106,7 @@ class GrantOrListDealsClient:
         return QuoteResponse(
             quote_id=quote_id,
             status="available",
-            product=ProductInfo(
-                product_id=quote_request.product_id, name="CTV Premium Streaming"
-            ),
+            product=ProductInfo(product_id=quote_request.product_id, name="CTV Premium Streaming"),
             pricing=PricingInfo(base_cpm=LIST_PRICE, final_cpm=final_cpm),
             terms=TermsInfo(
                 impressions=quote_request.impressions,
@@ -306,9 +304,7 @@ class TestBriefPriceSplitReachesOrchestrator:
     def test_partial_split_only_ceiling(self):
         """Only a ceiling in kpis: target still falls back to rec.cpm."""
         orch = CapturingOrchestrator()
-        flow = _flow(
-            orch, _brief(kpis={"max_cpm_usd": CEILING}), _rec(cpm=30.0)
-        )
+        flow = _flow(orch, _brief(kpis={"max_cpm_usd": CEILING}), _rec(cpm=30.0))
 
         flow.approve_all()
 
@@ -423,16 +419,12 @@ class TestBookedRationaleStatesTrueFinalPrice:
         def record_event(event_type, **kwargs):
             events.append((event_type, kwargs))
 
-        monkeypatch.setattr(
-            "ad_buyer.flows.deal_booking_flow.emit_event_sync", record_event
-        )
+        monkeypatch.setattr("ad_buyer.flows.deal_booking_flow.emit_event_sync", record_event)
 
         result = flow.approve_all()
         assert result["booked"] == 1
         booked = flow.state.booked_lines[0]
-        deal_events = [
-            kwargs for etype, kwargs in events if etype == EventType.DEAL_BOOKED
-        ]
+        deal_events = [kwargs for etype, kwargs in events if etype == EventType.DEAL_BOOKED]
         return booked, deal_events[0]["payload"]
 
     def test_rationale_reports_final_cpm_not_base(self, monkeypatch):

--- a/tests/unit/test_no_dep_cycle.py
+++ b/tests/unit/test_no_dep_cycle.py
@@ -52,9 +52,7 @@ def test_top_level_import_both_orders(first: str, second: str) -> None:
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0, (
-        f"importing {first} then {second} failed:\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"importing {first} then {second} failed:\n{result.stderr}"
 
 
 def test_clients_do_not_import_orchestration() -> None:
@@ -84,6 +82,4 @@ def test_clients_do_not_import_orchestration() -> None:
             ):
                 offenders.append(f"{path.name}:{lineno}: {stripped}")
 
-    assert not offenders, "clients/ must not import from orchestration/:\n" + "\n".join(
-        offenders
-    )
+    assert not offenders, "clients/ must not import from orchestration/:\n" + "\n".join(offenders)

--- a/tests/unit/test_opendirect_wire_conformance.py
+++ b/tests/unit/test_opendirect_wire_conformance.py
@@ -109,9 +109,7 @@ class TestSpecLowercaseAliases:
     def test_account_wire_names(self):
         account = Account(advertiser_id="adv-1", buyer_id="buy-1", name="ACME")
         dump = account.model_dump(by_alias=True, exclude_none=True)
-        self._assert_dialect(
-            dump, {"advertiserId": "advertiserid", "buyerId": "buyerid"}
-        )
+        self._assert_dialect(dump, {"advertiserId": "advertiserid", "buyerId": "buyerid"})
 
     def test_order_wire_names(self):
         order = Order(

--- a/tests/unit/test_order_status_audit.py
+++ b/tests/unit/test_order_status_audit.py
@@ -12,7 +12,7 @@ Covers:
 - Audit trail
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import httpx
 import pytest

--- a/tests/unit/test_recommendation_clamp.py
+++ b/tests/unit/test_recommendation_clamp.py
@@ -129,8 +129,16 @@ class TestParseClampsAndRejects:
     def test_out_of_bounds_cpm_clamped_via_parse(self):
         flow = _flow_with_bounds(max_cpm=20.0)
         payload = json.dumps(
-            [{"product_id": "p1", "product_name": "N", "publisher": "P",
-              "impressions": 100_000, "cpm": 200.0, "cost": 500.0}]
+            [
+                {
+                    "product_id": "p1",
+                    "product_name": "N",
+                    "publisher": "P",
+                    "impressions": 100_000,
+                    "cpm": 200.0,
+                    "cost": 500.0,
+                }
+            ]
         )
         recs = flow._parse_recommendations(payload, "branding")
         assert len(recs) == 1
@@ -139,8 +147,16 @@ class TestParseClampsAndRejects:
     def test_per_line_cost_clamped_to_channel_budget_via_parse(self):
         flow = _flow_with_bounds()
         payload = json.dumps(
-            [{"product_id": "p1", "product_name": "N", "publisher": "P",
-              "impressions": 100_000, "cpm": 10.0, "cost": 999_999.0}]
+            [
+                {
+                    "product_id": "p1",
+                    "product_name": "N",
+                    "publisher": "P",
+                    "impressions": 100_000,
+                    "cpm": 10.0,
+                    "cost": 999_999.0,
+                }
+            ]
         )
         recs = flow._parse_recommendations(payload, "branding")
         assert len(recs) == 1
@@ -149,8 +165,16 @@ class TestParseClampsAndRejects:
     def test_negative_impressions_clamped_via_parse(self):
         flow = _flow_with_bounds()
         payload = json.dumps(
-            [{"product_id": "p1", "product_name": "N", "publisher": "P",
-              "impressions": -100, "cpm": 10.0, "cost": 100.0}]
+            [
+                {
+                    "product_id": "p1",
+                    "product_name": "N",
+                    "publisher": "P",
+                    "impressions": -100,
+                    "cpm": 10.0,
+                    "cost": 100.0,
+                }
+            ]
         )
         recs = flow._parse_recommendations(payload, "branding")
         assert len(recs) == 1
@@ -165,8 +189,14 @@ class TestParseClampsAndRejects:
         payload = json.dumps(
             [
                 {"product_id": "bad", "cpm": "free", "impressions": 10, "cost": 1.0},
-                {"product_id": "good", "product_name": "N", "publisher": "P",
-                 "impressions": 100_000, "cpm": 500.0, "cost": 100.0},
+                {
+                    "product_id": "good",
+                    "product_name": "N",
+                    "publisher": "P",
+                    "impressions": 100_000,
+                    "cpm": 500.0,
+                    "cost": 100.0,
+                },
             ]
         )
         recs = flow._parse_recommendations(payload, "branding")
@@ -220,8 +250,16 @@ class TestBoundsFromKpisShapedBrief:
     def test_run13_shape_25_cpm_item_clamped_to_18_ceiling(self):
         flow = _flow_with_kpis_brief(kpis={"max_cpm_usd": 18.0})
         payload = json.dumps(
-            [{"product_id": "prod-b41e2339", "product_name": "N", "publisher": "P",
-              "impressions": 1_666_666, "cpm": 25.0, "cost": 24_999.99}]
+            [
+                {
+                    "product_id": "prod-b41e2339",
+                    "product_name": "N",
+                    "publisher": "P",
+                    "impressions": 1_666_666,
+                    "cpm": 25.0,
+                    "cost": 24_999.99,
+                }
+            ]
         )
         recs = flow._parse_recommendations(payload, "branding")
         assert len(recs) == 1
@@ -288,8 +326,16 @@ class TestClampProtectsBooking:
 
         # An LLM proposes a CPM 10x the buyer's max and a wild cost.
         payload = json.dumps(
-            [{"product_id": "p1", "product_name": "N", "publisher": "P",
-              "impressions": 100_000, "cpm": 200.0, "cost": 999_999.0}]
+            [
+                {
+                    "product_id": "p1",
+                    "product_name": "N",
+                    "publisher": "P",
+                    "impressions": 100_000,
+                    "cpm": 200.0,
+                    "cost": 999_999.0,
+                }
+            ]
         )
         recs = flow._parse_recommendations(payload, "branding")
         flow.state.pending_approvals = recs
@@ -318,8 +364,16 @@ class TestClampProtectsBooking:
         }
         flow._orchestrator = orchestrator
         payload = json.dumps(
-            [{"product_id": "p1", "product_name": "N", "publisher": "P",
-              "impressions": 100_000, "cpm": 10.0, "cost": 40_000.0}]
+            [
+                {
+                    "product_id": "p1",
+                    "product_name": "N",
+                    "publisher": "P",
+                    "impressions": 100_000,
+                    "cpm": 10.0,
+                    "cost": 40_000.0,
+                }
+            ]
         )
         recs = flow._parse_recommendations(payload, "branding")
         flow.state.pending_approvals = recs

--- a/tests/unit/test_spend_ceiling.py
+++ b/tests/unit/test_spend_ceiling.py
@@ -236,9 +236,7 @@ class TestBookingBudgetCeiling:
                 deal_type=deal_params.deal_type,
                 status="active",
                 quote_id=f"quote-{deal_params.product_id}",
-                product=ProductInfo(
-                    product_id=deal_params.product_id, name=deal_params.product_id
-                ),
+                product=ProductInfo(product_id=deal_params.product_id, name=deal_params.product_id),
                 pricing=PricingInfo(final_cpm=deal_params.target_cpm),
                 terms=TermsInfo(impressions=deal_params.impressions),
             )


### PR DESCRIPTION
Main's three CI failures were all dependency drift — CI installs unpinned (`pip install -e .[dev]`), resolving newer libs than the locked local env:

1. **test_meta_social_booking `_listeners` AttributeError**: crewai 1.15 removed the `FlowMeta` `_listeners` class attribute (moved to `__flow_method_definition__`). Test helper now reads either shape; assertions unchanged.
2. **endpoints.md 'drift'**: the doc was never stale — fastapi ≥0.141 stopped flattening `include_router`, so `generate_inventories.py` silently dropped 2 routes. Enumerator now descends included routers; output identical in both envs.
3. **ruff**: I001 ×2 + F401, auto-fixed.

Verified: full unit suite 3315 passed / 0 failed and ruff clean under BOTH the locked env (crewai 1.14.6) and a CI-like unpinned env (crewai 1.15.8 / fastapi 0.141.1).

Follow-up worth its own PR: make ci.yml install from the lockfile so CI and local can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuoSai9uDgCEkbqYmxQpQ6