### PR TITLE
Improve seller domain matching in the IAB Diligence Platform approval gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,12 +123,24 @@ META_PAGE_ID=
 # Graph API version (for reach estimates)
 META_API_VERSION=v21.0
 
+# =============================================================================
 # IAB Diligence Platform Integration (via SafeGuard Privacy)
+# =============================================================================
 # optional; inert when SGP_API_KEY is empty
 SGP_API_KEY=
 # Staging Environment: https://api.safeguardprivacy-demo.com
 SGP_BASE_URL=https://api.safeguardprivacy.com
 SGP_ENFORCE=false
-# block | warn | allow
+# block | warn | allow (case-insensitive; empty falls back to block)
 SGP_UNKNOWN_VENDOR_POLICY=block
 SGP_CACHE_TTL_SECONDS=900
+# Per-request timeout for an approval lookup, in seconds.
+SGP_TIMEOUT_SECONDS=15
+# Extra attempts for transient failures (transport errors, 429/502/503/504).
+# Definite answers (200/400/401/404) are never retried. 0 disables retrying.
+# Each attempt can consume the full timeout, so the worst case for one batch of
+# 10 domains is about (1 + SGP_MAX_RETRIES) * SGP_TIMEOUT_SECONDS plus backoff.
+# Lower these two if the deployment sits behind a tighter request deadline.
+SGP_MAX_RETRIES=2
+# Base backoff in seconds, doubled per attempt (0.5 -> 1.0 -> 2.0...).
+SGP_RETRY_BACKOFF_SECONDS=0.5

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -212,8 +212,10 @@ Optional integration that gates deal requests against the buyer's [IAB Diligence
 | `SGP_API_KEY` | `str` | `""` | API key with the `iab:buyerAgent` scope. Empty with `SGP_ENFORCE=true` = the gate fails closed (no sellers pass discovery). |
 | `SGP_BASE_URL` | `str` | `https://api.safeguardprivacy.com` | SGP base URL. Staging: `https://api.safeguardprivacy-demo.com`. |
 | `SGP_ENFORCE` | `bool` | `False` | When `True`, the canonical booking pipeline excludes sellers without verified IAB buyer-agent approval at discovery, emitting `sgp.vendor_gate` events; SGP transport errors fail closed. When `False` (default): zero SGP calls, behavior unchanged. |
-| `SGP_UNKNOWN_VENDOR_POLICY` | `str` | `block` | Behavior when the vendor is not in the buyer's SGP portfolio (HTTP 404). One of `block`, `warn`, `allow`. |
+| `SGP_UNKNOWN_VENDOR_POLICY` | `str` | `block` | Behavior when the vendor is not in the buyer's SGP portfolio (HTTP 404). One of `block`, `warn`, `allow`, matched case-insensitively. An unrecognized value fails at settings load. |
 | `SGP_CACHE_TTL_SECONDS` | `int` | `900` | Per-domain cache lifetime for approval lookups. |
+
+Transient SGP failures (transport errors and HTTP `429`/`502`/`503`/`504`) are retried with exponential backoff before the gate concludes it cannot verify a vendor — three attempts by default. This is tuned via `SGPClient` constructor arguments rather than environment variables; see [Transient failures and retries](../integration/iab-diligence-platform.md#transient-failures-and-retries).
 
 See the [IAB Diligence Platform Approval](../integration/iab-diligence-platform.md) integration guide for endpoint contract, behavior matrix, and troubleshooting.
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -214,8 +214,11 @@ Optional integration that gates deal requests against the buyer's [IAB Diligence
 | `SGP_ENFORCE` | `bool` | `False` | When `True`, the canonical booking pipeline excludes sellers without verified IAB buyer-agent approval at discovery, emitting `sgp.vendor_gate` events; SGP transport errors fail closed. When `False` (default): zero SGP calls, behavior unchanged. |
 | `SGP_UNKNOWN_VENDOR_POLICY` | `str` | `block` | Behavior when the vendor is not in the buyer's SGP portfolio (HTTP 404). One of `block`, `warn`, `allow`, matched case-insensitively. An unrecognized value fails at settings load. |
 | `SGP_CACHE_TTL_SECONDS` | `int` | `900` | Per-domain cache lifetime for approval lookups. |
+| `SGP_TIMEOUT_SECONDS` | `float` | `15.0` | Per-request timeout for one approval lookup. |
+| `SGP_MAX_RETRIES` | `int` | `2` | Extra attempts for transient SGP failures. `0` disables retrying. |
+| `SGP_RETRY_BACKOFF_SECONDS` | `float` | `0.5` | Base retry backoff, doubled per attempt. |
 
-Transient SGP failures (transport errors and HTTP `429`/`502`/`503`/`504`) are retried with exponential backoff before the gate concludes it cannot verify a vendor — three attempts by default. This is tuned via `SGPClient` constructor arguments rather than environment variables; see [Transient failures and retries](../integration/iab-diligence-platform.md#transient-failures-and-retries).
+Transient SGP failures (transport errors and HTTP `429`/`502`/`503`/`504`) are retried with exponential backoff before the gate concludes it cannot verify a vendor — three attempts by default. Because each attempt can consume the full timeout, the worst case for one batch is roughly `(1 + SGP_MAX_RETRIES) * SGP_TIMEOUT_SECONDS` plus backoff; see [Transient failures and retries](../integration/iab-diligence-platform.md#transient-failures-and-retries).
 
 See the [IAB Diligence Platform Approval](../integration/iab-diligence-platform.md) integration guide for endpoint contract, behavior matrix, and troubleshooting.
 

--- a/docs/integration/iab-diligence-platform.md
+++ b/docs/integration/iab-diligence-platform.md
@@ -72,18 +72,18 @@ Because enforcement fails closed, a failed lookup and a denial have the same eff
 |---|---|
 | Retried | Transport errors (connect, timeout, DNS, read) and HTTP `429`, `502`, `503`, `504` |
 | Never retried | `200`, `400`, `401`, `404` — these are answers, not blips, and retrying only delays the verdict |
-| Attempts | `1 + max_retries`; `max_retries` defaults to `2`, so three attempts |
-| Backoff | Exponential — `retry_backoff_seconds * 2**attempt`, base `0.5s` by default, so `0.5s` then `1.0s` |
+| Attempts | `1 + SGP_MAX_RETRIES`; defaults to `2`, so three attempts |
+| Backoff | Exponential — `SGP_RETRY_BACKOFF_SECONDS * 2**attempt`, base `0.5s` by default, so `0.5s` then `1.0s` |
 | On exhaustion | The original failure is raised as `SGPClientError`, so enforcing callers still fail closed |
 
-`max_retries` and `retry_backoff_seconds` are `SGPClient` constructor arguments rather than environment variables; the defaults suit the enforcing paths, and `max_retries=0` disables retrying entirely. Each retry is logged at `WARNING` with the reason and the attempt number, and the final error names the attempt count — so a one-off `503` and a sustained outage read differently in logs.
+All three knobs are environment variables — `SGP_MAX_RETRIES`, `SGP_RETRY_BACKOFF_SECONDS`, and `SGP_TIMEOUT_SECONDS` — so tuning them needs no code change. `SGP_MAX_RETRIES=0` disables retrying entirely. Each retry is logged at `WARNING` with the reason and the attempt number, and the final error names the attempt count, so a one-off `503` and a sustained outage read differently in logs.
 
 Retries do not change any verdict. They only affect how long the gate waits before concluding it cannot verify a vendor.
 
 !!! warning "Retries multiply the worst-case wait"
-    The backoff itself is small, but each retry is a fresh request that can burn the full `timeout`. With the defaults (15s timeout, three attempts), a chunk that keeps timing out takes up to roughly **46s** — three timeouts plus 1.5s of backoff — where it previously took 15s. Chunks of 10 domains are fetched **sequentially**, so a lookup spanning several chunks multiplies that again: 30 distinct seller domains is three chunks, hence up to ~140s in the pathological case.
+    The backoff itself is small, but each retry is a fresh request that can burn the full `SGP_TIMEOUT_SECONDS`. With the defaults (15s timeout, three attempts), a chunk that keeps timing out takes up to roughly **46s** — three timeouts plus 1.5s of backoff — where it previously took 15s. Chunks of 10 domains are fetched **sequentially**, so a lookup spanning several chunks multiplies that again: 30 distinct seller domains is three chunks, hence up to ~140s in the pathological case.
 
-    This only bites when SGP is timing out; a reachable SGP that answers or refuses does so on the first attempt. If your deployment sits behind a tighter deadline, lower `max_retries`, lower the client `timeout`, or both.
+    This only bites when SGP is timing out; a reachable SGP that answers or refuses does so on the first attempt. If your deployment sits behind a tighter deadline, lower `SGP_MAX_RETRIES`, `SGP_TIMEOUT_SECONDS`, or both.
 
 ## Configuration
 
@@ -94,6 +94,9 @@ Retries do not change any verdict. They only affect how long the gate waits befo
 | `SGP_ENFORCE` | `bool` | `False` | When `True`, NOT APPROVED vendors are filtered out at discovery, the deal-request gate blocks Deal ID generation, and SGP transport errors halt the flow.            |
 | `SGP_UNKNOWN_VENDOR_POLICY` | `str` | `"block"` | Behavior for domains not in the SGP portfolio (HTTP 404). One of `block`, `warn`, `allow` — matched case-insensitively, so `BLOCK` and `Block` are accepted. An unrecognized value fails at settings load rather than being interpreted per call site. Applies at discovery, the deal-request stage, and the orchestrator gate when enforcement is on. |
 | `SGP_CACHE_TTL_SECONDS` | `int` | `900` | Per-domain cache lifetime. Discovery→pricing→booking reuse a single SGP call within the TTL.                                                                         |
+| `SGP_TIMEOUT_SECONDS` | `float` | `15.0` | Per-request timeout for one approval lookup. |
+| `SGP_MAX_RETRIES` | `int` | `2` | Extra attempts for transient failures. `0` disables retrying. See [Transient failures and retries](#transient-failures-and-retries). |
+| `SGP_RETRY_BACKOFF_SECONDS` | `float` | `0.5` | Base backoff, doubled per attempt. `0` retries immediately. |
 
 !!! warning "Enforcement without a key fails closed"
     If `SGP_ENFORCE=true` but `SGP_API_KEY` is empty, the canonical booking pipeline cannot verify any vendor and **fails closed**: no seller passes discovery until a key is configured. The buyer agent logs an error at orchestrator construction time, and each excluded seller gets an `sgp.vendor_gate` event with outcome `unconfigured` and a causeful reason. Enforcement never silently books unverified vendors because a key is missing.

--- a/docs/integration/iab-diligence-platform.md
+++ b/docs/integration/iab-diligence-platform.md
@@ -64,6 +64,27 @@ A record that cannot be paired with any requested domain is logged at `WARNING` 
 
 This matters for caching: whatever the client resolves is what gets cached for `SGP_CACHE_TTL_SECONDS`. An unresolved approval would otherwise report the vendor as UNKNOWN and suppress that verdict for the full TTL.
 
+### Transient failures and retries
+
+Because enforcement fails closed, a failed lookup and a denial have the same effect on a deal — and at the orchestrator stage a single failed lookup excludes *every* seller. A momentary blip should not carry that weight, so the client retries before giving up.
+
+| Aspect | Behavior |
+|---|---|
+| Retried | Transport errors (connect, timeout, DNS, read) and HTTP `429`, `502`, `503`, `504` |
+| Never retried | `200`, `400`, `401`, `404` — these are answers, not blips, and retrying only delays the verdict |
+| Attempts | `1 + max_retries`; `max_retries` defaults to `2`, so three attempts |
+| Backoff | Exponential — `retry_backoff_seconds * 2**attempt`, base `0.5s` by default, so `0.5s` then `1.0s` |
+| On exhaustion | The original failure is raised as `SGPClientError`, so enforcing callers still fail closed |
+
+`max_retries` and `retry_backoff_seconds` are `SGPClient` constructor arguments rather than environment variables; the defaults suit the enforcing paths, and `max_retries=0` disables retrying entirely. Each retry is logged at `WARNING` with the reason and the attempt number, and the final error names the attempt count — so a one-off `503` and a sustained outage read differently in logs.
+
+Retries do not change any verdict. They only affect how long the gate waits before concluding it cannot verify a vendor.
+
+!!! warning "Retries multiply the worst-case wait"
+    The backoff itself is small, but each retry is a fresh request that can burn the full `timeout`. With the defaults (15s timeout, three attempts), a chunk that keeps timing out takes up to roughly **46s** — three timeouts plus 1.5s of backoff — where it previously took 15s. Chunks of 10 domains are fetched **sequentially**, so a lookup spanning several chunks multiplies that again: 30 distinct seller domains is three chunks, hence up to ~140s in the pathological case.
+
+    This only bites when SGP is timing out; a reachable SGP that answers or refuses does so on the first attempt. If your deployment sits behind a tighter deadline, lower `max_retries`, lower the client `timeout`, or both.
+
 ## Configuration
 
 | Variable | Type | Default | Description                                                                                                                                                          |
@@ -71,7 +92,7 @@ This matters for caching: whatever the client resolves is what gets cached for `
 | `SGP_API_KEY` | `str` | `""` | API key from the SGP api. Empty = integration disabled.                                                                                                              |
 | `SGP_BASE_URL` | `str` | `https://api.safeguardprivacy.com` | Production endpoint. The staging environment is `https://api.safeguardprivacy-demo.com`.                                                                             |
 | `SGP_ENFORCE` | `bool` | `False` | When `True`, NOT APPROVED vendors are filtered out at discovery, the deal-request gate blocks Deal ID generation, and SGP transport errors halt the flow.            |
-| `SGP_UNKNOWN_VENDOR_POLICY` | `str` | `"block"` | Behavior for domains not in the SGP portfolio (HTTP 404). One of `block`, `warn`, `allow`. Applies at both discovery and deal-request stages when enforcement is on. |
+| `SGP_UNKNOWN_VENDOR_POLICY` | `str` | `"block"` | Behavior for domains not in the SGP portfolio (HTTP 404). One of `block`, `warn`, `allow` — matched case-insensitively, so `BLOCK` and `Block` are accepted. An unrecognized value fails at settings load rather than being interpreted per call site. Applies at discovery, the deal-request stage, and the orchestrator gate when enforcement is on. |
 | `SGP_CACHE_TTL_SECONDS` | `int` | `900` | Per-domain cache lifetime. Discovery→pricing→booking reuse a single SGP call within the TTL.                                                                         |
 
 !!! warning "Enforcement without a key fails closed"
@@ -165,7 +186,7 @@ With enforcement on (`SGP_ENFORCE=true`, `SGP_API_KEY` set), behavior is consist
 | `iabBuyerAgentApproval: true` | ✅ kept + approved banner | same | same |
 | `iabBuyerAgentApproval: false` | ❌ filtered at discovery; blocked at request | ❌ | ❌ |
 | 404 (not onboarded in SGP) | ❌ filtered at discovery; blocked at request | ✅ kept + warning annotation/banner | ✅ kept silently |
-| Transport error | ❌ flow halts | ❌ flow halts | ❌ flow halts |
+| Transport error (after retries) | ❌ flow halts | ❌ flow halts | ❌ flow halts |
 | Product has no seller domain field | ❌ filtered at discovery; blocked at request | ❌ | ❌ |
 
 The last row is the one to watch when enabling enforcement against a live catalog: a product the gate cannot resolve a domain for is blocked regardless of unknown-vendor policy, and SGP is never called. Populate the OpenDirect Product `domain` field — see [Domain matching](#domain-matching) for the full probe order.
@@ -201,7 +222,9 @@ The class is prefixed `SGP` so future vendor-approval integrations can coexist u
 | `IAB Diligence Platform rejected the api-key` (401) | The key is missing, revoked, or lacks the proper scope. Request a new key from SGP.                                                            |
 | `Deal blocked: <domain> is not in your IAB Diligence Platform portfolio` | The vendor is not onboarded in SGP. Add and approve the vendor in SGP, or switch `SGP_UNKNOWN_VENDOR_POLICY` to `warn` for soft-fail behavior. |
 | `Deal blocked: <vendor> does not carry the IAB buyer-agent approval flag` | The vendor is onboarded but not marked approved for IAB buyer-agent purchases. Toggle the approval in SGP.                                     |
-| `Deal blocked: IAB Diligence Platform lookup failed` | SGP was unreachable or returned a transient error. Enforcement fails closed; retry once the service is reachable.                              |
+| `Deal blocked: IAB Diligence Platform lookup failed` | SGP stayed unreachable across every attempt (the client already retried — see [Transient failures and retries](#transient-failures-and-retries)). Enforcement fails closed; retry once the service is reachable. The message and the preceding `WARNING` lines carry the attempt count and the underlying failure. |
+| `sgp.vendor_gate` events with outcome `check_failed` for every seller | One SGP lookup failed after retries, so the orchestrator failed closed for the whole discovery batch rather than booking unverified vendors. Check the event `reason` for the exception class and detail. |
+| `ValidationError` for `sgp_unknown_vendor_policy` at startup | `SGP_UNKNOWN_VENDOR_POLICY` is set to something outside `block` / `warn` / `allow`. Casing is not the problem (it is normalized); a typo is. |
 | Gate seems to do nothing | `SGP_ENFORCE=false` (the default) — the gate is fully inert. With `SGP_ENFORCE=true` and no key, the pipeline fails closed instead (no sellers pass discovery); check the logs and `sgp.vendor_gate` events. |
 | `Deal blocked: cannot determine seller domain` / discovery reports `N missing seller domain` | The product carries none of the domain fields the gate probes, so it is blocked without SGP being called. Populate the Product `domain` field — see [Domain matching](#domain-matching). |
 | Log: `SGP returned an approval record for <domain> that could not be paired with any requested domain` | SGP answered about a domain unrelated to any queried one. The record is ignored and the queried domain stays UNKNOWN. Confirm the vendor's domain in SGP matches the seller domain on the product. |

--- a/docs/integration/iab-diligence-platform.md
+++ b/docs/integration/iab-diligence-platform.md
@@ -49,6 +49,21 @@ Three response states matter to the buyer agent:
 | `iabBuyerAgentApproval: false` | Vendor exists but is not approved | ❌ Deal blocked |
 | HTTP 404 | Vendor is not in the buyer's SGP portfolio | Governed by `SGP_UNKNOWN_VENDOR_POLICY` |
 
+### Domain matching
+
+SGP is not required to echo back the exact spelling that was queried — it may answer with the vendor's canonical (apex) domain for a queried subdomain, or the reverse. The client therefore pairs each returned record back to the domain that was actually requested:
+
+1. Exact match on the normalized domain.
+2. Otherwise a parent/child match on a label boundary — so an `example.com` record resolves a queried `news.example.com`, while `notexample.com` is never matched by an `example.com` record.
+
+Matching is deliberately conservative, and there is no third step: a record for an unrelated domain is **never** accepted as the verdict for a queried one, not even when it is the only record in the response. Attributing another vendor's approval would make the gate fail open, and the deal-request stage always queries exactly one domain — precisely the shape where a permissive fallback does the most damage.
+
+When more than one record legitimately matches, the **most specific** (longest) matching domain wins, so a verdict never depends on the order records happen to appear in the response. Among equally specific records, a non-approval wins — a response carrying contradictory records can never upgrade a vendor to approved.
+
+A record that cannot be paired with any requested domain is logged at `WARNING` and ignored rather than silently dropped.
+
+This matters for caching: whatever the client resolves is what gets cached for `SGP_CACHE_TTL_SECONDS`. An unresolved approval would otherwise report the vendor as UNKNOWN and suppress that verdict for the full TTL.
+
 ## Configuration
 
 | Variable | Type | Default | Description                                                                                                                                                          |
@@ -85,7 +100,9 @@ The integration also plugs into two example buyer-agent tools. Behavior at each 
 
 ### Inventory discovery
 
-`DiscoverInventoryTool` accepts an optional `SGPClient`. When provided, it extracts the seller domain from each returned product (checking `seller_url`, `publisher_domain`, then `publisherId`/`publisher` if they contain a `.`), batches distinct domains into groups of 10, and annotates each product row in the formatted output:
+`DiscoverInventoryTool` accepts an optional `SGPClient`. When provided, it extracts the seller domain from each returned product, batches distinct domains into groups of 10, and annotates each product row in the formatted output.
+
+Domain extraction probes, in order: `domain` (the field the OpenDirect Product resource defines), `seller_domain` / `sellerDomain`, then the deal / SSP-connector names `publisherDomain`, `publisher_domain`, `seller_url` — and finally `publisherId` / `publisher` if they contain a `.`. Products should populate `domain`; the connector names are accepted only so a deal dict derived from an SSP connector also resolves.
 
 ```
 1. Premium CTV - Sports
@@ -151,6 +168,8 @@ With enforcement on (`SGP_ENFORCE=true`, `SGP_API_KEY` set), behavior is consist
 | Transport error | ❌ flow halts | ❌ flow halts | ❌ flow halts |
 | Product has no seller domain field | ❌ filtered at discovery; blocked at request | ❌ | ❌ |
 
+The last row is the one to watch when enabling enforcement against a live catalog: a product the gate cannot resolve a domain for is blocked regardless of unknown-vendor policy, and SGP is never called. Populate the OpenDirect Product `domain` field — see [Domain matching](#domain-matching) for the full probe order.
+
 The `iabBuyerAgentApproval: false` row is intentionally the same across all three unknown-vendor policies — an explicit non-approval is always fatal. The policies only govern the "unknown to SGP" case.
 
 ## Agent tool
@@ -184,6 +203,8 @@ The class is prefixed `SGP` so future vendor-approval integrations can coexist u
 | `Deal blocked: <vendor> does not carry the IAB buyer-agent approval flag` | The vendor is onboarded but not marked approved for IAB buyer-agent purchases. Toggle the approval in SGP.                                     |
 | `Deal blocked: IAB Diligence Platform lookup failed` | SGP was unreachable or returned a transient error. Enforcement fails closed; retry once the service is reachable.                              |
 | Gate seems to do nothing | `SGP_ENFORCE=false` (the default) — the gate is fully inert. With `SGP_ENFORCE=true` and no key, the pipeline fails closed instead (no sellers pass discovery); check the logs and `sgp.vendor_gate` events. |
+| `Deal blocked: cannot determine seller domain` / discovery reports `N missing seller domain` | The product carries none of the domain fields the gate probes, so it is blocked without SGP being called. Populate the Product `domain` field — see [Domain matching](#domain-matching). |
+| Log: `SGP returned an approval record for <domain> that could not be paired with any requested domain` | SGP answered about a domain unrelated to any queried one. The record is ignored and the queried domain stays UNKNOWN. Confirm the vendor's domain in SGP matches the seller domain on the product. |
 
 ## Related
 

--- a/docs/integration/iab-diligence-platform.md
+++ b/docs/integration/iab-diligence-platform.md
@@ -22,7 +22,7 @@ GET /api/v1/integrations/iab/buyer-agent-approval?domain=a.com,b.com
 | Domain       | `domain` query parameter - Up to 10 domains per request |
 | Tenant scope | Results are scoped to the caller's SGP tenant           |
 
-The response contains one `IabBuyerAgentResource` per matched vendor:
+The response contains one `IabBuyerAgentResource` per **resolved domain**, not per vendor — query two domains that resolve to the same vendor and two records come back, each naming the domain it answers:
 
 ```json
 {
@@ -34,6 +34,8 @@ The response contains one `IabBuyerAgentResource` per matched vendor:
       "vendorCompanyId": 456,
       "companyName": "Example Publisher",
       "domain": "example.com",
+      "requestedDomain": "news.example.com",
+      "matchType": "parent",
       "iabBuyerAgentApproval": true,
       "iabBuyerAgentApprovedAt": "2026-03-14T12:00:00Z"
     }
@@ -51,18 +53,24 @@ Three response states matter to the buyer agent:
 
 ### Domain matching
 
-SGP is not required to echo back the exact spelling that was queried — it may answer with the vendor's canonical (apex) domain for a queried subdomain, or the reverse. The client therefore pairs each returned record back to the domain that was actually requested:
+The seller domain read off an ad product is frequently a subdomain of the domain its vendor is registered under in SGP — a product on `news.example.com` belonging to the vendor `example.com`. **SGP resolves this server-side** and states on every record which query it answers:
 
-1. Exact match on the normalized domain.
-2. Otherwise a parent/child match on a label boundary — so an `example.com` record resolves a queried `news.example.com`, while `notexample.com` is never matched by an `example.com` record.
+| Field | Meaning |
+|---|---|
+| `domain` | The vendor's canonical domain, as registered in SGP |
+| `requestedDomain` | The domain from the `domain` query parameter that this record answers, echoed in the spelling it was sent in |
+| `matchType` | `exact` — the vendor is registered under the queried domain · `parent` — the queried domain is a subdomain of it · `unresolved` — SGP could not pair the record with anything queried |
 
-Matching is deliberately conservative, and there is no third step: a record for an unrelated domain is **never** accepted as the verdict for a queried one, not even when it is the only record in the response. Attributing another vendor's approval would make the gate fail open, and the deal-request stage always queries exactly one domain — precisely the shape where a permissive fallback does the most damage.
+The client pairs on `requestedDomain` and nothing else. That is a dictionary lookup, not an inference: no apex-versus-subdomain reasoning happens on this side, no model is involved at any point, and the same response always produces the same verdict.
 
-When more than one record legitimately matches, the **most specific** (longest) matching domain wins, so a verdict never depends on the order records happen to appear in the response. Among equally specific records, a non-approval wins — a response carrying contradictory records can never upgrade a vendor to approved.
+A record SGP marks `unresolved`, or one echoing a domain this client did not ask about, is logged at `WARNING` and ignored. A record is **never** attributed to a queried domain it does not name, not even when it is the only record in the response — attributing another vendor's approval would make the gate fail open, and the deal-request stage always queries exactly one domain, precisely the shape where a permissive fallback does the most damage.
 
-A record that cannot be paired with any requested domain is logged at `WARNING` and ignored rather than silently dropped.
+Resolution is one-directional. An `example.com` vendor answers a queried `news.example.com`; a vendor registered at `ads.example.com` does **not** answer a queried `example.com`. Domain control is inherited downward, not upward, so approving one subdomain says nothing about the parent domain or its siblings — a rule in the other direction would let one tenant's approval cover every sibling subdomain of a shared host.
 
-This matters for caching: whatever the client resolves is what gets cached for `SGP_CACHE_TTL_SECONDS`. An unresolved approval would otherwise report the vendor as UNKNOWN and suppress that verdict for the full TTL.
+This matters for caching: whatever resolves here is what gets cached for `SGP_CACHE_TTL_SECONDS`.
+
+!!! note "Requires an SGP deployment that echoes `requestedDomain`"
+    Records without `requestedDomain` are ignored, so an SGP environment predating the echo reports every seller as UNKNOWN, which the default `SGP_UNKNOWN_VENDOR_POLICY=block` then blocks. Production (`api.safeguardprivacy.com`) and staging (`api.safeguardprivacy-demo.com`) both return it. Point `SGP_BASE_URL` at one of those.
 
 ### Transient failures and retries
 
@@ -230,7 +238,9 @@ The class is prefixed `SGP` so future vendor-approval integrations can coexist u
 | `ValidationError` for `sgp_unknown_vendor_policy` at startup | `SGP_UNKNOWN_VENDOR_POLICY` is set to something outside `block` / `warn` / `allow`. Casing is not the problem (it is normalized); a typo is. |
 | Gate seems to do nothing | `SGP_ENFORCE=false` (the default) — the gate is fully inert. With `SGP_ENFORCE=true` and no key, the pipeline fails closed instead (no sellers pass discovery); check the logs and `sgp.vendor_gate` events. |
 | `Deal blocked: cannot determine seller domain` / discovery reports `N missing seller domain` | The product carries none of the domain fields the gate probes, so it is blocked without SGP being called. Populate the Product `domain` field — see [Domain matching](#domain-matching). |
-| Log: `SGP returned an approval record for <domain> that could not be paired with any requested domain` | SGP answered about a domain unrelated to any queried one. The record is ignored and the queried domain stays UNKNOWN. Confirm the vendor's domain in SGP matches the seller domain on the product. |
+| Log: `SGP returned an approval record for <domain> that it could not pair with any requested domain` | SGP answered with a record it marked `unresolved`. It is ignored and the queried domain stays UNKNOWN. Confirm the vendor's domain in SGP matches the seller domain on the product. |
+| Log: `SGP returned an approval record echoing <domain>, which was not requested` | The echoed `requestedDomain` is not one this client asked about. The record is ignored. This should not happen against a healthy SGP — check for a proxy rewriting the `domain` query parameter. |
+| Every seller reports UNKNOWN and no record pairs | `SGP_BASE_URL` points at an SGP deployment that does not return `requestedDomain` — see [Domain matching](#domain-matching). |
 
 ## Related
 

--- a/docs/integration/iab-diligence-platform.md
+++ b/docs/integration/iab-diligence-platform.md
@@ -61,16 +61,13 @@ The seller domain read off an ad product is frequently a subdomain of the domain
 | `requestedDomain` | The domain from the `domain` query parameter that this record answers, echoed in the spelling it was sent in |
 | `matchType` | `exact` — the vendor is registered under the queried domain · `parent` — the queried domain is a subdomain of it · `unresolved` — SGP could not pair the record with anything queried |
 
-The client pairs on `requestedDomain` and nothing else. That is a dictionary lookup, not an inference: no apex-versus-subdomain reasoning happens on this side, no model is involved at any point, and the same response always produces the same verdict.
+The client pairs on `requestedDomain` and nothing else.
 
-A record SGP marks `unresolved`, or one echoing a domain this client did not ask about, is logged at `WARNING` and ignored. A record is **never** attributed to a queried domain it does not name, not even when it is the only record in the response — attributing another vendor's approval would make the gate fail open, and the deal-request stage always queries exactly one domain, precisely the shape where a permissive fallback does the most damage.
+A record SGP marks `unresolved`, or one echoing a domain this client did not ask about, is logged at `WARNING` and ignored. A record is **never** attributed to a queried domain it does not name, not even when it is the only record in the response.
 
-Resolution is one-directional. An `example.com` vendor answers a queried `news.example.com`; a vendor registered at `ads.example.com` does **not** answer a queried `example.com`. Domain control is inherited downward, not upward, so approving one subdomain says nothing about the parent domain or its siblings — a rule in the other direction would let one tenant's approval cover every sibling subdomain of a shared host.
+Resolution is one-directional. An `example.com` vendor answers a queried `news.example.com`; a vendor registered at `ads.example.com` does **not** answer a queried `example.com`. Approving a subdomain never approves the domain above it.
 
 This matters for caching: whatever resolves here is what gets cached for `SGP_CACHE_TTL_SECONDS`.
-
-!!! note "Requires an SGP deployment that echoes `requestedDomain`"
-    Records without `requestedDomain` are ignored, so an SGP environment predating the echo reports every seller as UNKNOWN, which the default `SGP_UNKNOWN_VENDOR_POLICY=block` then blocks. Production (`api.safeguardprivacy.com`) and staging (`api.safeguardprivacy-demo.com`) both return it. Point `SGP_BASE_URL` at one of those.
 
 ### Transient failures and retries
 
@@ -239,8 +236,7 @@ The class is prefixed `SGP` so future vendor-approval integrations can coexist u
 | Gate seems to do nothing | `SGP_ENFORCE=false` (the default) — the gate is fully inert. With `SGP_ENFORCE=true` and no key, the pipeline fails closed instead (no sellers pass discovery); check the logs and `sgp.vendor_gate` events. |
 | `Deal blocked: cannot determine seller domain` / discovery reports `N missing seller domain` | The product carries none of the domain fields the gate probes, so it is blocked without SGP being called. Populate the Product `domain` field — see [Domain matching](#domain-matching). |
 | Log: `SGP returned an approval record for <domain> that it could not pair with any requested domain` | SGP answered with a record it marked `unresolved`. It is ignored and the queried domain stays UNKNOWN. Confirm the vendor's domain in SGP matches the seller domain on the product. |
-| Log: `SGP returned an approval record echoing <domain>, which was not requested` | The echoed `requestedDomain` is not one this client asked about. The record is ignored. This should not happen against a healthy SGP — check for a proxy rewriting the `domain` query parameter. |
-| Every seller reports UNKNOWN and no record pairs | `SGP_BASE_URL` points at an SGP deployment that does not return `requestedDomain` — see [Domain matching](#domain-matching). |
+| Log: `SGP returned an approval record echoing <domain>, which was not requested` | The echoed `requestedDomain` is not one this client asked about. The record is ignored. |
 
 ## Related
 

--- a/src/ad_buyer/clients/sgp_client.py
+++ b/src/ad_buyer/clients/sgp_client.py
@@ -31,17 +31,35 @@ _MAX_BATCH = 10
 _RETRYABLE_STATUS_CODES = {502, 503, 504}
 _ENDPOINT = "/api/v1/integrations/iab/buyer-agent-approval"
 
-# Ordered list of product-dict keys to probe when deriving a seller domain
-# for an SGP approval lookup. Explicit domain fields come first; publisher
-# identifiers are used only when they look like a hostname.
-_DOMAIN_KEYS = ("seller_url", "sellerUrl", "publisher_domain", "publisherDomain")
+# Ordered list of dict keys to probe when deriving a seller domain for an
+# SGP approval lookup.
+#
+# The first group is the product vocabulary: ``domain`` is the field the
+# OpenDirect Product resource defines (see models.opendirect.Product), and
+# ``seller_domain`` is this codebase's normalized name for it.
+#
+# The second group is the deal / SSP-connector vocabulary, kept so that a
+# connector-derived deal dict also resolves: ``publisherDomain`` comes from
+# Magnite and Index Exchange raw deals, ``publisher_domain`` from PubMatic
+# and CSV import, and ``seller_url`` from deal records (where it is the
+# seller *system endpoint*, hence lowest priority). These are not product
+# fields — do not treat them as authoritative for a product.
+_DOMAIN_KEYS = (
+    "domain",
+    "seller_domain",
+    "sellerDomain",
+    "publisherDomain",
+    "publisher_domain",
+    "seller_url",
+)
 _PUBLISHER_KEYS = ("publisherId", "publisher")
 
 
 def extract_product_domain(product: dict) -> str | None:
     """Best-guess seller domain from a product dict for an SGP lookup.
 
-    Checks explicit domain/URL fields first, then falls back to
+    Checks explicit domain fields first (product vocabulary before the
+    deal/SSP vocabulary — see ``_DOMAIN_KEYS``), then falls back to
     ``publisherId`` / ``publisher`` when those values contain a ``.``
     (i.e. look like a hostname rather than an opaque ID). Returns the
     raw value; ``SGPClient.normalize_domain`` handles cleanup.
@@ -55,6 +73,20 @@ def extract_product_domain(product: dict) -> str | None:
         if isinstance(value, str) and "." in value:
             return value
     return None
+
+
+def _same_site(requested: str, returned: str) -> bool:
+    """True when two hostnames are the same site, or one is a parent of the other.
+
+    Compares on a label boundary, so ``notexample.com`` never matches
+    ``example.com``. Used to pair an SGP response back to the domain that
+    was actually queried when the platform echoes a different spelling.
+    """
+    if not requested or not returned:
+        return False
+    if requested == returned:
+        return True
+    return requested.endswith("." + returned) or returned.endswith("." + requested)
 
 
 class SGPClientError(Exception):
@@ -117,8 +149,9 @@ class SGPClient:
     def normalize_domain(value: str) -> str:
         """Reduce a seller URL or raw domain to the form SGP accepts.
 
-        Strips scheme, ``www.``, path, query, and port; lowercases.
-        Returns an empty string for inputs that yield no host.
+        Strips scheme, ``www.``, path, query, port, and any trailing FQDN
+        dot; lowercases. Returns an empty string for inputs that yield no
+        host.
         """
         if not value:
             return ""
@@ -127,7 +160,7 @@ class SGPClient:
         if "://" not in raw:
             raw = "http://" + raw
         host = urlparse(raw).hostname or ""
-        host = host.lower()
+        host = host.lower().rstrip(".")
         if host.startswith("www."):
             host = host[4:]
         return host
@@ -227,13 +260,62 @@ class SGPClient:
 
         raw_records = payload.get("data") or []
         by_domain: dict[str, ApprovalRecord | None] = {d: None for d in domains}
+        requested = set(domains)
+
+        # Pass 1: records whose echoed domain matches a requested one exactly.
+        leftover: list[tuple[str, ApprovalRecord]] = []
         for raw in raw_records:
             try:
                 record = ApprovalRecord.model_validate(raw)
             except (ValueError, TypeError):
                 logger.warning("Skipping malformed SGP record: %r", raw)
                 continue
-            domain_key = self.normalize_domain(record.domain) or record.domain.lower()
-            by_domain[domain_key] = record
+            key = self.normalize_domain(record.domain) or record.domain.strip().lower()
+            if key in requested:
+                by_domain[key] = record
+            else:
+                leftover.append((key, record))
+
+        # Pass 2: SGP may answer with the vendor's canonical/apex domain for a
+        # queried subdomain (or the reverse). Resolve those against domains
+        # still unanswered so the record is not discarded -- dropping it would
+        # leave the requested domain looking UNKNOWN and, because
+        # ``check_approvals`` caches whatever lands here, would block an
+        # approved vendor for the full cache TTL.
+        #
+        # Matching is deliberately conservative: only a parent/child match on a
+        # label boundary counts. A record for an unrelated domain is never
+        # accepted as the verdict for a queried one, not even when it is the
+        # only record in the response -- attributing another vendor's approval
+        # would make this gate fail open.
+        used: set[int] = set()
+        for d in domains:
+            if by_domain[d] is not None:
+                continue
+            candidates = [
+                (key, record, i) for i, (key, record) in enumerate(leftover) if _same_site(d, key)
+            ]
+            if not candidates:
+                continue
+            # Most specific (longest) matching domain wins. Among equally
+            # specific records a non-approval wins, so a response carrying
+            # conflicting records can never upgrade a vendor to approved.
+            key, record, index = min(
+                candidates,
+                key=lambda c: (-len(c[0]), c[1].iab_buyer_agent_approval),
+            )
+            by_domain[d] = record
+            used.add(index)
+
+        for i, (key, record) in enumerate(leftover):
+            if i in used or any(_same_site(d, key) for d in domains):
+                # Either applied, or pairable but a more specific record won.
+                continue
+            logger.warning(
+                "SGP returned an approval record for %r that could not be paired "
+                "with any requested domain %s; ignoring it",
+                record.domain,
+                domains,
+            )
 
         return by_domain

--- a/src/ad_buyer/clients/sgp_client.py
+++ b/src/ad_buyer/clients/sgp_client.py
@@ -16,8 +16,10 @@ Limit: up to 10 domains per call (SGP-enforced).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
+from typing import Any
 from urllib.parse import urlparse
 
 import httpx
@@ -28,8 +30,13 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 15.0
 _MAX_BATCH = 10
-_RETRYABLE_STATUS_CODES = {502, 503, 504}
+# Statuses worth another attempt: gateway/availability blips and rate limiting.
+# Everything else (400/401/404) is a definite answer and is never retried.
+_RETRYABLE_STATUS_CODES = {429, 502, 503, 504}
+_DEFAULT_MAX_RETRIES = 2
+_DEFAULT_RETRY_BACKOFF_SECONDS = 0.5
 _ENDPOINT = "/api/v1/integrations/iab/buyer-agent-approval"
+
 
 # Ordered list of dict keys to probe when deriving a seller domain for an
 # SGP approval lookup.
@@ -117,6 +124,15 @@ class SGPClient:
             is at ``https://api.safeguardprivacy-demo.com``.
         timeout: Request timeout in seconds.
         cache_ttl_seconds: How long to cache per-domain results.
+        max_retries: Extra attempts for transport errors and the statuses in
+            ``_RETRYABLE_STATUS_CODES``. Callers enforcing approval fail
+            closed on exhaustion, so a transient blip should not be the same
+            event as a definite denial. ``0`` disables retrying.
+        retry_backoff_seconds: Base delay, doubled per attempt. ``0`` retries
+            immediately (used by tests).
+
+    Can be used as an async context manager, which closes the underlying
+    httpx client on exit.
     """
 
     def __init__(
@@ -125,20 +141,34 @@ class SGPClient:
         base_url: str = "https://api.safeguardprivacy.com",
         timeout: float = _DEFAULT_TIMEOUT,
         cache_ttl_seconds: int = 900,
+        max_retries: int = _DEFAULT_MAX_RETRIES,
+        retry_backoff_seconds: float = _DEFAULT_RETRY_BACKOFF_SECONDS,
     ) -> None:
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
         self._cache_ttl = cache_ttl_seconds
+        self._max_retries = max(0, max_retries)
+        self._retry_backoff = max(0.0, retry_backoff_seconds)
         self._cache: dict[str, tuple[float, ApprovalRecord | None]] = {}
+        self._closed = False
         self._http = httpx.AsyncClient(
             base_url=self._base_url,
             headers={"api-key": api_key},
             timeout=timeout,
         )
 
+    async def __aenter__(self) -> SGPClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.aclose()
+
     async def aclose(self) -> None:
-        """Close the underlying httpx client."""
+        """Close the underlying httpx client. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
         await self._http.aclose()
 
     # ------------------------------------------------------------------
@@ -212,17 +242,65 @@ class SGPClient:
     # ------------------------------------------------------------------
 
     async def _fetch_chunk(self, domains: list[str]) -> dict[str, ApprovalRecord | None]:
-        """Fetch approvals for up to 10 domains in a single HTTP call."""
+        """Fetch approvals for up to 10 domains, retrying transient failures.
+
+        Transport errors and the statuses in ``_RETRYABLE_STATUS_CODES`` get
+        up to ``max_retries`` extra attempts with exponential backoff. A
+        definite answer (200/400/401/404) is returned or raised on the first
+        attempt -- retrying those would only delay the verdict.
+
+        On exhaustion the original failure is raised as ``SGPClientError``,
+        so enforcing callers still fail closed.
+        """
         params = {"domain": ",".join(domains)}
-        try:
-            resp = await self._http.get(_ENDPOINT, params=params)
-        except httpx.RequestError as exc:
-            # Connection refused, timeout, DNS, read errors, etc. — surface
-            # as SGPClientError so callers catch it on a single type and
-            # the deal-request gate can fail closed.
-            raise SGPClientError(
-                f"IAB Diligence Platform request failed: {exc.__class__.__name__}: {exc}"
-            ) from exc
+        attempts = self._max_retries + 1
+
+        for attempt in range(attempts):
+            final = attempt == attempts - 1
+            try:
+                resp = await self._http.get(_ENDPOINT, params=params)
+            except httpx.RequestError as exc:
+                # Connection refused, timeout, DNS, read errors, etc. — surface
+                # as SGPClientError so callers catch it on a single type and
+                # the deal-request gate can fail closed.
+                if final:
+                    raise SGPClientError(
+                        f"IAB Diligence Platform request failed after "
+                        f"{attempts} attempt(s): {exc.__class__.__name__}: {exc}"
+                    ) from exc
+                await self._backoff(attempt, f"{exc.__class__.__name__}: {exc}")
+                continue
+
+            if resp.status_code in _RETRYABLE_STATUS_CODES and not final:
+                await self._backoff(attempt, f"HTTP {resp.status_code}")
+                continue
+
+            return self._parse_chunk_response(resp, domains, attempts=attempts)
+
+        # Unreachable: the final attempt always returns or raises above.
+        raise SGPClientError("IAB Diligence Platform retry loop exited unexpectedly")
+
+    async def _backoff(self, attempt: int, why: str) -> None:
+        """Wait before the next attempt, doubling the delay each time."""
+        delay = self._retry_backoff * (2**attempt)
+        logger.warning(
+            "IAB Diligence Platform lookup failed (%s); retrying in %.2fs (attempt %d of %d)",
+            why,
+            delay,
+            attempt + 1,
+            self._max_retries + 1,
+        )
+        if delay > 0:
+            await asyncio.sleep(delay)
+
+    def _parse_chunk_response(
+        self,
+        resp: httpx.Response,
+        domains: list[str],
+        *,
+        attempts: int = 1,
+    ) -> dict[str, ApprovalRecord | None]:
+        """Turn one SGP response into per-domain records, or raise."""
 
         if resp.status_code == 404:
             # Entire batch unknown to SGP.
@@ -242,8 +320,12 @@ class SGPClient:
             )
 
         if resp.status_code in _RETRYABLE_STATUS_CODES or resp.status_code >= 500:
+            # Reached only once retries are exhausted (or disabled), so say so
+            # -- "returned 503" and "returned 503 three times" are different
+            # operational events for whoever reads this.
             raise SGPClientError(
-                f"IAB Diligence Platform returned {resp.status_code}: {resp.text}",
+                f"IAB Diligence Platform returned {resp.status_code} after "
+                f"{attempts} attempt(s): {resp.text}",
                 status_code=resp.status_code,
             )
 

--- a/src/ad_buyer/clients/sgp_client.py
+++ b/src/ad_buyer/clients/sgp_client.py
@@ -70,7 +70,13 @@ def extract_product_domain(product: dict) -> str | None:
     ``publisherId`` / ``publisher`` when those values contain a ``.``
     (i.e. look like a hostname rather than an opaque ID). Returns the
     raw value; ``SGPClient.normalize_domain`` handles cleanup.
+
+    Anything that is not a dict yields ``None`` rather than raising. Catalog
+    entries come off the wire, and an unreadable one should be reported as
+    having no derivable domain -- which the gate blocks -- not crash the tool.
     """
+    if not isinstance(product, dict):
+        return None
     for key in _DOMAIN_KEYS:
         value = product.get(key)
         if isinstance(value, str) and value:
@@ -340,7 +346,22 @@ class SGPClient:
         except ValueError as exc:
             raise SGPClientError(f"SGP response was not JSON: {exc}") from None
 
+        # Shape checks before indexing: a proxy or gateway can answer with
+        # perfectly valid JSON of the wrong type (an error array, a bare
+        # string). Reaching for ``.get`` on that raised AttributeError, which
+        # is not an SGPClientError, so it escaped the buyer-deal tools instead
+        # of failing the gate closed.
+        if not isinstance(payload, dict):
+            raise SGPClientError(
+                f"SGP response was not a JSON object (got {type(payload).__name__})"
+            )
+
         raw_records = payload.get("data") or []
+        if not isinstance(raw_records, list):
+            raise SGPClientError(
+                f"SGP response 'data' was not a list (got {type(raw_records).__name__})"
+            )
+
         by_domain: dict[str, ApprovalRecord | None] = {d: None for d in domains}
         requested = set(domains)
 

--- a/src/ad_buyer/clients/sgp_client.py
+++ b/src/ad_buyer/clients/sgp_client.py
@@ -88,20 +88,6 @@ def extract_product_domain(product: dict) -> str | None:
     return None
 
 
-def _same_site(requested: str, returned: str) -> bool:
-    """True when two hostnames are the same site, or one is a parent of the other.
-
-    Compares on a label boundary, so ``notexample.com`` never matches
-    ``example.com``. Used to pair an SGP response back to the domain that
-    was actually queried when the platform echoes a different spelling.
-    """
-    if not requested or not returned:
-        return False
-    if requested == returned:
-        return True
-    return requested.endswith("." + returned) or returned.endswith("." + requested)
-
-
 class SGPClientError(Exception):
     """Error raised by SGPClient for API or transport failures."""
 
@@ -122,6 +108,11 @@ class SGPClient:
     ``cache_ttl_seconds``. Returns a dict keyed by normalized domain; a
     value of ``None`` means the vendor is unknown to SGP (HTTP 404 or
     absent from the batch response).
+
+    Responses are paired back to the queried domain by the ``requestedDomain``
+    SGP echoes on each record, so a seller domain that is a subdomain of the
+    domain its vendor is registered under still resolves. See the
+    "Domain matching" section of docs/integration/iab-diligence-platform.md.
 
     Args:
         api_key: SGP API key with ``iab:buyerAgent`` scope.
@@ -365,60 +356,42 @@ class SGPClient:
         by_domain: dict[str, ApprovalRecord | None] = {d: None for d in domains}
         requested = set(domains)
 
-        # Pass 1: records whose echoed domain matches a requested one exactly.
-        leftover: list[tuple[str, ApprovalRecord]] = []
+        # SGP echoes the queried domain on every record it could pair, so a
+        # record says for itself which question it answers. Pairing is a lookup,
+        # not an inference: nothing here reasons about apex-vs-subdomain, and a
+        # record that does not name a domain we asked about is never attributed
+        # to one -- guessing would make an enforcing gate fail open.
         for raw in raw_records:
             try:
                 record = ApprovalRecord.model_validate(raw)
             except (ValueError, TypeError):
                 logger.warning("Skipping malformed SGP record: %r", raw)
                 continue
-            key = self.normalize_domain(record.domain) or record.domain.strip().lower()
-            if key in requested:
-                by_domain[key] = record
-            else:
-                leftover.append((key, record))
 
-        # Pass 2: SGP may answer with the vendor's canonical/apex domain for a
-        # queried subdomain (or the reverse). Resolve those against domains
-        # still unanswered so the record is not discarded -- dropping it would
-        # leave the requested domain looking UNKNOWN and, because
-        # ``check_approvals`` caches whatever lands here, would block an
-        # approved vendor for the full cache TTL.
-        #
-        # Matching is deliberately conservative: only a parent/child match on a
-        # label boundary counts. A record for an unrelated domain is never
-        # accepted as the verdict for a queried one, not even when it is the
-        # only record in the response -- attributing another vendor's approval
-        # would make this gate fail open.
-        used: set[int] = set()
-        for d in domains:
-            if by_domain[d] is not None:
+            if record.match_type == "unresolved" or not record.requested_domain:
+                # SGP itself could not tell which queried domain this answers.
+                logger.warning(
+                    "SGP returned an approval record for %r that it could not pair "
+                    "with any requested domain %s; ignoring it",
+                    record.domain,
+                    domains,
+                )
                 continue
-            candidates = [
-                (key, record, i) for i, (key, record) in enumerate(leftover) if _same_site(d, key)
-            ]
-            if not candidates:
-                continue
-            # Most specific (longest) matching domain wins. Among equally
-            # specific records a non-approval wins, so a response carrying
-            # conflicting records can never upgrade a vendor to approved.
-            key, record, index = min(
-                candidates,
-                key=lambda c: (-len(c[0]), c[1].iab_buyer_agent_approval),
-            )
-            by_domain[d] = record
-            used.add(index)
 
-        for i, (key, record) in enumerate(leftover):
-            if i in used or any(_same_site(d, key) for d in domains):
-                # Either applied, or pairable but a more specific record won.
+            key = self.normalize_domain(record.requested_domain)
+            if key not in requested:
+                logger.warning(
+                    "SGP returned an approval record echoing %r, which was not "
+                    "requested in %s; ignoring it",
+                    record.requested_domain,
+                    domains,
+                )
                 continue
-            logger.warning(
-                "SGP returned an approval record for %r that could not be paired "
-                "with any requested domain %s; ignoring it",
-                record.domain,
-                domains,
-            )
+
+            # SGP emits at most one record per requested domain, so this never
+            # overwrites a verdict already resolved for ``key``. If that invariant
+            # ever breaks, the last record in the response would win -- reintroducing
+            # the order-dependence this echo exists to remove.
+            by_domain[key] = record
 
         return by_domain

--- a/src/ad_buyer/clients/sgp_client.py
+++ b/src/ad_buyer/clients/sgp_client.py
@@ -110,9 +110,7 @@ class SGPClient:
     absent from the batch response).
 
     Responses are paired back to the queried domain by the ``requestedDomain``
-    SGP echoes on each record, so a seller domain that is a subdomain of the
-    domain its vendor is registered under still resolves. See the
-    "Domain matching" section of docs/integration/iab-diligence-platform.md.
+    SGP echoes on each record. See docs/integration/iab-diligence-platform.md.
 
     Args:
         api_key: SGP API key with ``iab:buyerAgent`` scope.
@@ -356,11 +354,8 @@ class SGPClient:
         by_domain: dict[str, ApprovalRecord | None] = {d: None for d in domains}
         requested = set(domains)
 
-        # SGP echoes the queried domain on every record it could pair, so a
-        # record says for itself which question it answers. Pairing is a lookup,
-        # not an inference: nothing here reasons about apex-vs-subdomain, and a
-        # record that does not name a domain we asked about is never attributed
-        # to one -- guessing would make an enforcing gate fail open.
+        # Every record names the domain it answers, so pairing is a lookup.
+        # A record naming nothing we asked about is never attributed to one.
         for raw in raw_records:
             try:
                 record = ApprovalRecord.model_validate(raw)
@@ -369,7 +364,6 @@ class SGPClient:
                 continue
 
             if record.match_type == "unresolved" or not record.requested_domain:
-                # SGP itself could not tell which queried domain this answers.
                 logger.warning(
                     "SGP returned an approval record for %r that it could not pair "
                     "with any requested domain %s; ignoring it",
@@ -388,10 +382,7 @@ class SGPClient:
                 )
                 continue
 
-            # SGP emits at most one record per requested domain, so this never
-            # overwrites a verdict already resolved for ``key``. If that invariant
-            # ever breaks, the last record in the response would win -- reintroducing
-            # the order-dependence this echo exists to remove.
+            # SGP emits at most one record per requested domain.
             by_domain[key] = record
 
         return by_domain

--- a/src/ad_buyer/config/settings.py
+++ b/src/ad_buyer/config/settings.py
@@ -86,7 +86,7 @@ class Settings(BaseSettings):
 
     @field_validator("sgp_unknown_vendor_policy")
     @classmethod
-    def _canonicalize_unknown_vendor_policy(cls, value: str) -> str:
+    def _canonicalize_sgp_unknown_vendor_policy(cls, value: str) -> str:
         """Lowercase the policy and reject unrecognized values at startup.
 
         ``SGP_UNKNOWN_VENDOR_POLICY=BLOCK`` resolves to ``block`` rather than

--- a/src/ad_buyer/config/settings.py
+++ b/src/ad_buyer/config/settings.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from typing import Literal
 
 from dotenv import find_dotenv
-from pydantic import field_validator
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
 # Find .env file by searching up from current working directory
@@ -73,6 +73,16 @@ class Settings(BaseSettings):
     # not in the buyer's SGP portfolio). One of: "block", "warn", "allow".
     sgp_unknown_vendor_policy: str = "block"
     sgp_cache_ttl_seconds: int = 900
+    # Per-request timeout for an approval lookup.
+    sgp_timeout_seconds: float = Field(default=15.0, gt=0)
+    # Extra attempts for transient failures (transport errors, 429/502/503/504).
+    # 0 disables retrying. Each attempt can consume the full timeout, so the
+    # worst-case wait for one batch is roughly
+    # (1 + SGP_MAX_RETRIES) * SGP_TIMEOUT_SECONDS plus backoff -- lower these
+    # if the deployment sits behind a tighter deadline.
+    sgp_max_retries: int = Field(default=2, ge=0)
+    # Base backoff, doubled per attempt (0.5 -> 1.0 -> 2.0...). 0 retries at once.
+    sgp_retry_backoff_seconds: float = Field(default=0.5, ge=0)
 
     @field_validator("sgp_unknown_vendor_policy")
     @classmethod

--- a/src/ad_buyer/config/settings.py
+++ b/src/ad_buyer/config/settings.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 from typing import Literal
 
 from dotenv import find_dotenv
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 # Find .env file by searching up from current working directory
@@ -72,6 +73,25 @@ class Settings(BaseSettings):
     # not in the buyer's SGP portfolio). One of: "block", "warn", "allow".
     sgp_unknown_vendor_policy: str = "block"
     sgp_cache_ttl_seconds: int = 900
+
+    @field_validator("sgp_unknown_vendor_policy")
+    @classmethod
+    def _canonicalize_unknown_vendor_policy(cls, value: str) -> str:
+        """Lowercase the policy and reject unrecognized values at startup.
+
+        ``SGP_UNKNOWN_VENDOR_POLICY=BLOCK`` resolves to ``block`` rather than
+        reaching the gate as an unrecognized string. A genuinely invalid value
+        fails fast here instead of being interpreted per call site.
+
+        An explicitly empty variable (``SGP_UNKNOWN_VENDOR_POLICY=``) reads as
+        "unset" and falls back to the safe default rather than failing startup;
+        every other SGP variable already treats empty as unconfigured.
+        """
+        from ..models.sgp import normalize_unknown_policy
+
+        if not value or not value.strip():
+            return "block"
+        return normalize_unknown_policy(value)
 
     def get_seller_endpoints(self) -> list[str]:
         """Parse seller endpoints from comma-separated string.

--- a/src/ad_buyer/flows/deal_booking_flow.py
+++ b/src/ad_buyer/flows/deal_booking_flow.py
@@ -160,6 +160,9 @@ def _build_sgp_client(settings: Any) -> Any | None:
         api_key=settings.sgp_api_key,
         base_url=settings.sgp_base_url,
         cache_ttl_seconds=settings.sgp_cache_ttl_seconds,
+        timeout=settings.sgp_timeout_seconds,
+        max_retries=settings.sgp_max_retries,
+        retry_backoff_seconds=settings.sgp_retry_backoff_seconds,
     )
 
 

--- a/src/ad_buyer/models/sgp.py
+++ b/src/ad_buyer/models/sgp.py
@@ -14,6 +14,33 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 
+# Accepted values for the unknown-vendor policy, shared by every caller so the
+# gate cannot disagree with itself about what a policy string means.
+#
+# This lives with the models rather than the client so that ``config.settings``
+# can validate the policy without importing ``ad_buyer.clients``, which pulls in
+# every client module -- one of which reads settings itself.
+UNKNOWN_VENDOR_POLICIES = frozenset({"block", "warn", "allow"})
+
+
+def normalize_unknown_policy(value: str) -> str:
+    """Canonicalize an unknown-vendor policy, raising on unrecognized input.
+
+    Case- and whitespace-insensitive, so ``"BLOCK"`` from an env var resolves
+    to ``"block"`` rather than silently falling through to whichever branch
+    happens to be the fallback.
+
+    Raises:
+        ValueError: if the value is not one of ``UNKNOWN_VENDOR_POLICIES``.
+    """
+    candidate = (value or "").strip().lower()
+    if candidate not in UNKNOWN_VENDOR_POLICIES:
+        raise ValueError(
+            f"Invalid sgp_unknown_policy {value!r}. "
+            f"Must be one of: {', '.join(sorted(UNKNOWN_VENDOR_POLICIES))}"
+        )
+    return candidate
+
 
 class ApprovalRecord(BaseModel):
     """A single vendor's IAB buyer-agent approval status from IAB Diligence Platform."""

--- a/src/ad_buyer/models/sgp.py
+++ b/src/ad_buyer/models/sgp.py
@@ -43,7 +43,17 @@ def normalize_unknown_policy(value: str) -> str:
 
 
 class ApprovalRecord(BaseModel):
-    """A single vendor's IAB buyer-agent approval status from IAB Diligence Platform."""
+    """A single vendor's IAB buyer-agent approval status from IAB Diligence Platform.
+
+    ``domain`` is the vendor's canonical domain as registered in SGP;
+    ``requested_domain`` is the domain from the query that this record answers,
+    echoed back in the exact spelling it was sent in. The two differ whenever a
+    seller domain is a subdomain of the domain its vendor is registered under --
+    a product on ``news.example.com`` belonging to the vendor ``example.com``.
+
+    Pair on ``requested_domain``, never on ``domain``: it is the only field that
+    says which question a record answers.
+    """
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -55,3 +65,9 @@ class ApprovalRecord(BaseModel):
     iab_buyer_agent_approved_at: datetime | None = Field(
         alias="iabBuyerAgentApprovedAt", default=None
     )
+    # Null when SGP could not pair the record with any queried domain
+    # (``match_type == "unresolved"``), or when the vendor was looked up by
+    # internal ID -- a path this client does not use.
+    requested_domain: str | None = Field(alias="requestedDomain", default=None)
+    # How SGP paired the record: "exact", "parent", "internalId", "unresolved".
+    match_type: str = Field(alias="matchType", default="")

--- a/src/ad_buyer/models/sgp.py
+++ b/src/ad_buyer/models/sgp.py
@@ -46,13 +46,9 @@ class ApprovalRecord(BaseModel):
     """A single vendor's IAB buyer-agent approval status from IAB Diligence Platform.
 
     ``domain`` is the vendor's canonical domain as registered in SGP;
-    ``requested_domain`` is the domain from the query that this record answers,
-    echoed back in the exact spelling it was sent in. The two differ whenever a
-    seller domain is a subdomain of the domain its vendor is registered under --
-    a product on ``news.example.com`` belonging to the vendor ``example.com``.
-
-    Pair on ``requested_domain``, never on ``domain``: it is the only field that
-    says which question a record answers.
+    ``requested_domain`` is the queried domain this record answers. Pair on
+    ``requested_domain`` -- it is the only field that says which question a
+    record answers.
     """
 
     model_config = ConfigDict(populate_by_name=True)
@@ -65,9 +61,7 @@ class ApprovalRecord(BaseModel):
     iab_buyer_agent_approved_at: datetime | None = Field(
         alias="iabBuyerAgentApprovedAt", default=None
     )
-    # Null when SGP could not pair the record with any queried domain
-    # (``match_type == "unresolved"``), or when the vendor was looked up by
-    # internal ID -- a path this client does not use.
+    # Null when SGP could not pair the record with a queried domain.
     requested_domain: str | None = Field(alias="requestedDomain", default=None)
     # How SGP paired the record: "exact", "parent", "internalId", "unresolved".
     match_type: str = Field(alias="matchType", default="")

--- a/src/ad_buyer/orchestration/multi_seller.py
+++ b/src/ad_buyer/orchestration/multi_seller.py
@@ -52,6 +52,7 @@ from ..models.deals import (
     QuoteRequest,
     QuoteResponse,
 )
+from ..models.sgp import normalize_unknown_policy
 from ..registry.models import AgentCard, TrustLevel
 from ..storage import audience_audit_log
 from .audience_degradation import (
@@ -89,11 +90,10 @@ def _failure_reason(
     return f"{base}: {detail}" if detail else base
 
 
-# Valid values for the orchestrator's ``sgp_unknown_policy`` (how to treat
-# sellers absent from the buyer's SGP portfolio while enforcing). Mirrors
-# the example tools' vocabulary so SGP_UNKNOWN_VENDOR_POLICY means the same
-# thing everywhere.
-_VALID_SGP_UNKNOWN_POLICIES = ("block", "warn", "allow")
+# Valid values for ``sgp_unknown_policy`` (how to treat sellers absent from
+# the buyer's SGP portfolio while enforcing) now live with the client as
+# ``UNKNOWN_VENDOR_POLICIES`` / ``normalize_unknown_policy``, so
+# SGP_UNKNOWN_VENDOR_POLICY means the same thing everywhere.
 
 
 # Error code emitted by the seller per proposal §5.7 layer 3 when the
@@ -532,14 +532,41 @@ class MultiSellerOrchestrator:
         # buyer-agent approval cannot be positively verified on the
         # buyer's SGP (IAB Diligence Platform) tenant -- and FAILS CLOSED
         # (no seller passes) when the check itself cannot complete.
-        if sgp_unknown_policy not in _VALID_SGP_UNKNOWN_POLICIES:
-            raise ValueError(
-                f"Invalid sgp_unknown_policy {sgp_unknown_policy!r}. "
-                f"Must be one of {_VALID_SGP_UNKNOWN_POLICIES}."
-            )
         self._sgp_client = sgp_client
         self._sgp_enforce = sgp_enforce
-        self._sgp_unknown_policy = sgp_unknown_policy
+        # Shared canonicalizer, so "BLOCK" from an env var resolves the same
+        # way here as in the buyer-deal tools instead of raising in one place
+        # and being reinterpreted in another.
+        self._sgp_unknown_policy = normalize_unknown_policy(sgp_unknown_policy)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def aclose(self) -> None:
+        """Release resources this orchestrator owns.
+
+        Closes the SGP client's connection pool. Idempotent and best-effort:
+        teardown must never be the thing that raises, so a failure to close is
+        logged and swallowed. Callers that build an orchestrator per process
+        can skip this; anything constructing them repeatedly should call it.
+        """
+        client = self._sgp_client
+        if client is None:
+            return
+        closer = getattr(client, "aclose", None)
+        if closer is None:
+            return
+        try:
+            await closer()
+        except Exception as exc:  # noqa: BLE001 - teardown must not raise
+            logger.warning("Failed to close the SGP client: %s", exc)
+
+    async def __aenter__(self) -> MultiSellerOrchestrator:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.aclose()
 
     # ------------------------------------------------------------------
     # Event helpers

--- a/src/ad_buyer/tools/buyer_deals/discover_inventory.py
+++ b/src/ad_buyer/tools/buyer_deals/discover_inventory.py
@@ -267,18 +267,27 @@ Returns:
         Returns ``(filtered_products, summary_counts)``. When enforcement
         is off, the product list is returned unchanged and counts are
         empty. ``summary_counts`` keys: ``not_approved``,
-        ``unknown_blocked``, ``no_domain_blocked``.
+        ``unknown_blocked``, ``no_domain_blocked``, ``unverifiable_blocked``.
         """
         product_list = products if isinstance(products, list) else [products]
         if not self._sgp_enforce or self._sgp_client is None:
             return product_list, {}
 
         filtered: list = []
-        counts = {"not_approved": 0, "unknown_blocked": 0, "no_domain_blocked": 0}
+        counts = {
+            "not_approved": 0,
+            "unknown_blocked": 0,
+            "no_domain_blocked": 0,
+            "unverifiable_blocked": 0,
+        }
 
         for product in product_list:
             if not isinstance(product, dict):
-                filtered.append(product)
+                # An entry we cannot read is an entry we cannot verify. Keeping
+                # it would let a malformed catalog row reach the agent without
+                # ever being checked, while a well-formed row merely missing a
+                # domain gets blocked -- fail closed in both cases.
+                counts["unverifiable_blocked"] += 1
                 continue
             raw_domain = extract_product_domain(product)
             if not raw_domain:
@@ -431,4 +440,6 @@ Returns:
             parts.append(f"{summary['unknown_blocked']} unknown to SGP")
         if summary.get("no_domain_blocked"):
             parts.append(f"{summary['no_domain_blocked']} missing seller domain")
+        if summary.get("unverifiable_blocked"):
+            parts.append(f"{summary['unverifiable_blocked']} unreadable")
         return f"SGP enforcement filtered {total} product(s): " + ", ".join(parts)

--- a/src/ad_buyer/tools/buyer_deals/discover_inventory.py
+++ b/src/ad_buyer/tools/buyer_deals/discover_inventory.py
@@ -14,7 +14,7 @@ from ...booking.pricing import PricingCalculator
 from ...clients.sgp_client import SGPClient, SGPClientError, extract_product_domain
 from ...clients.unified_client import UnifiedClient
 from ...models.buyer_identity import BuyerContext
-from ...models.sgp import ApprovalRecord
+from ...models.sgp import ApprovalRecord, normalize_unknown_policy
 from ...security.prompt_sanitizer import sanitize_untrusted_text
 
 logger = logging.getLogger(__name__)
@@ -117,7 +117,9 @@ Returns:
         self._buyer_context = buyer_context
         self._sgp_client = sgp_client
         self._sgp_enforce = sgp_enforce
-        self._sgp_unknown_policy = sgp_unknown_policy
+        # Validated here as well as in RequestDealTool: an unrecognized policy
+        # must not reach the filter, where "not block" previously meant "keep".
+        self._sgp_unknown_policy = normalize_unknown_policy(sgp_unknown_policy)
 
     def _run(
         self,
@@ -285,10 +287,14 @@ Returns:
             normalized = self._sgp_client.normalize_domain(raw_domain)
             record = approvals.get(normalized)
             if record is None:
-                if self._sgp_unknown_policy == "block":
-                    counts["unknown_blocked"] += 1
+                # Keep only for the two policies that explicitly permit an
+                # unknown vendor; anything else blocks. Stated positively so a
+                # future policy value defaults to excluding, not admitting.
+                if self._sgp_unknown_policy in ("warn", "allow"):
+                    filtered.append(product)
                     continue
-                filtered.append(product)
+                counts["unknown_blocked"] += 1
+                continue
             elif not record.iab_buyer_agent_approval:
                 counts["not_approved"] += 1
             else:

--- a/src/ad_buyer/tools/buyer_deals/request_deal.py
+++ b/src/ad_buyer/tools/buyer_deals/request_deal.py
@@ -23,11 +23,9 @@ from ...models.buyer_identity import (
     DealResponse,
     DealType,
 )
-from ...models.sgp import ApprovalRecord
+from ...models.sgp import ApprovalRecord, normalize_unknown_policy
 
 logger = logging.getLogger(__name__)
-
-_VALID_UNKNOWN_POLICIES = {"block", "warn", "allow"}
 
 
 class RequestDealInput(BaseModel):
@@ -143,12 +141,7 @@ Returns:
         self._sgp_client = sgp_client
         self._sgp_enforce = sgp_enforce
         self._max_cpm = max_cpm
-        if sgp_unknown_policy not in _VALID_UNKNOWN_POLICIES:
-            raise ValueError(
-                f"Invalid sgp_unknown_policy '{sgp_unknown_policy}'. "
-                f"Must be one of: {', '.join(sorted(_VALID_UNKNOWN_POLICIES))}"
-            )
-        self._sgp_unknown_policy = sgp_unknown_policy
+        self._sgp_unknown_policy = normalize_unknown_policy(sgp_unknown_policy)
 
     def _run(
         self,

--- a/src/ad_buyer/tools/buyer_deals/request_deal.py
+++ b/src/ad_buyer/tools/buyer_deals/request_deal.py
@@ -302,8 +302,9 @@ Returns:
         if not raw_domain:
             return (
                 "Deal blocked: cannot determine seller domain for IAB "
-                "Diligence Platform approval check. Add a seller_url / "
-                "publisher_domain field to the product, or disable SGP_ENFORCE.",
+                "Diligence Platform approval check. Populate the product's "
+                "`domain` field (OpenDirect Product resource), or disable "
+                "SGP_ENFORCE.",
                 None,
             )
 

--- a/tests/unit/test_orchestrator_sgp_gate.py
+++ b/tests/unit/test_orchestrator_sgp_gate.py
@@ -492,3 +492,53 @@ class TestProductionWiring:
 
         assert iface._orchestrator._sgp_enforce is True
         assert isinstance(iface._orchestrator._sgp_client, SGPClient)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: the orchestrator owns the SGP client, so it must release it
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorLifecycle:
+    @pytest.mark.asyncio
+    async def test_aclose_closes_the_sgp_client(self):
+        sgp = MagicMock()
+        sgp.aclose = AsyncMock()
+        orch, _ = _make_orchestrator([], sgp_client=sgp, sgp_enforce=True)
+
+        await orch.aclose()
+
+        sgp.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_aclose_without_a_client_is_a_noop(self):
+        orch, _ = _make_orchestrator([], sgp_client=None, sgp_enforce=False)
+        await orch.aclose()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_aclose_swallows_client_failure(self):
+        """Teardown must never be the thing that raises."""
+        sgp = MagicMock()
+        sgp.aclose = AsyncMock(side_effect=RuntimeError("pool already gone"))
+        orch, _ = _make_orchestrator([], sgp_client=sgp, sgp_enforce=True)
+
+        await orch.aclose()  # must not raise
+
+        sgp.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager_closes_the_client(self):
+        sgp = MagicMock()
+        sgp.aclose = AsyncMock()
+        orch, _ = _make_orchestrator([], sgp_client=sgp, sgp_enforce=True)
+
+        async with orch as entered:
+            assert entered is orch
+
+        sgp.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_miscased_policy_is_canonicalized(self):
+        """SGP_UNKNOWN_VENDOR_POLICY=BLOCK must resolve, not raise."""
+        orch, _ = _make_orchestrator([], sgp_enforce=True, sgp_unknown_policy="BLOCK")
+        assert orch._sgp_unknown_policy == "block"

--- a/tests/unit/test_sgp_client.py
+++ b/tests/unit/test_sgp_client.py
@@ -153,6 +153,11 @@ class TestExtractProductDomain:
     def test_no_domain_field_returns_none(self) -> None:
         assert extract_product_domain({"id": "p1", "name": "Untagged"}) is None
 
+    @pytest.mark.parametrize("value", ["a string", 42, None, ["list"], True])
+    def test_non_dict_input_returns_none_rather_than_raising(self, value) -> None:
+        """Catalog entries come off the wire; an unreadable one must not crash."""
+        assert extract_product_domain(value) is None
+
 
 # ---------------------------------------------------------------------------
 # Successful lookups
@@ -440,6 +445,54 @@ class TestDomainEchoMatching:
         assert first["news.foo.com"] is not None
         assert second["news.foo.com"] is not None
         assert second["news.foo.com"].iab_buyer_agent_approval is True
+
+
+# ---------------------------------------------------------------------------
+# Malformed response envelopes
+#
+# Valid JSON of the wrong type must surface as SGPClientError so enforcing
+# callers fail closed, rather than as an AttributeError that escapes the tool.
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedEnvelope:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("body", [[{"x": 1}], "a string", 42, True])
+    async def test_non_object_payload_raises_client_error(self, body) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=body)
+
+        client = _make_client(handler)
+        with pytest.raises(SGPClientError, match="not a JSON object"):
+            await client.check_approvals(["foo.com"])
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("data", [{"foo.com": True}, "records", 7])
+    async def test_non_list_data_raises_client_error(self, data) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"data": data})
+
+        client = _make_client(handler)
+        with pytest.raises(SGPClientError, match="'data' was not a list"):
+            await client.check_approvals(["foo.com"])
+
+    @pytest.mark.asyncio
+    async def test_missing_data_key_is_treated_as_no_records(self) -> None:
+        """An object with no `data` is a valid empty answer, not a shape error."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"status": "success"})
+
+        client = _make_client(handler)
+        assert await client.check_approvals(["foo.com"]) == {"foo.com": None}
+
+    @pytest.mark.asyncio
+    async def test_null_data_is_treated_as_no_records(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"data": None})
+
+        client = _make_client(handler)
+        assert await client.check_approvals(["foo.com"]) == {"foo.com": None}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sgp_client.py
+++ b/tests/unit/test_sgp_client.py
@@ -17,6 +17,7 @@ from ad_buyer.clients.sgp_client import (
     SGPAuthError,
     SGPClient,
     SGPClientError,
+    extract_product_domain,
 )
 
 BASE_URL = "https://sgp.test"
@@ -76,12 +77,79 @@ class TestNormalizeDomain:
             ("http://example.com", "example.com"),
             ("https://www.example.com/path?q=1", "example.com"),
             ("http://seller.example.com:8001", "seller.example.com"),
+            ("example.com.", "example.com"),
+            ("https://www.example.com./path", "example.com"),
             ("", ""),
             ("   ", ""),
         ],
     )
     def test_normalizes(self, raw: str, expected: str) -> None:
         assert SGPClient.normalize_domain(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# Product domain extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractProductDomain:
+    def test_reads_domain_from_opendirect_product_schema(self) -> None:
+        """The field the Product resource actually defines must be honored.
+
+        Regression: the extractor originally probed only deal-record and
+        SSP-connector field names, so a spec-conformant product with
+        ``domain`` populated was reported as having no seller domain and
+        blocked under SGP_ENFORCE.
+        """
+        from ad_buyer.models.opendirect import Product
+
+        # Constructed by field name (populate_by_name) rather than by wire
+        # alias, so this stays valid if the alias convention changes again.
+        product = Product(
+            id="espn-sports-pmp",
+            publisher_id="pub_espn",
+            name="ESPN Sports PMP",
+            base_price=18.5,
+            rate_type="CPM",
+            domain="espn.com",
+            available_impressions=1_000_000,
+        ).model_dump(by_alias=True)
+
+        assert extract_product_domain(product) == "espn.com"
+
+    @pytest.mark.parametrize(
+        "key",
+        ["domain", "seller_domain", "sellerDomain"],
+    )
+    def test_product_vocabulary_keys(self, key: str) -> None:
+        assert extract_product_domain({"id": "p1", key: "example.com"}) == "example.com"
+
+    @pytest.mark.parametrize(
+        "key, value",
+        [
+            ("publisherDomain", "roku.com"),
+            ("publisher_domain", "pub1.example.com"),
+            ("seller_url", "http://seller.example.com:8001"),
+        ],
+    )
+    def test_deal_and_ssp_vocabulary_keys_still_resolve(self, key: str, value: str) -> None:
+        """Connector-derived deal dicts must keep working."""
+        assert extract_product_domain({"id": "p1", key: value}) == value
+
+    def test_product_domain_preferred_over_seller_endpoint(self) -> None:
+        """`domain` identifies the vendor; `seller_url` is only a transport endpoint."""
+        product = {
+            "id": "p1",
+            "domain": "espn.com",
+            "seller_url": "http://broker.example.com:8001",
+        }
+        assert extract_product_domain(product) == "espn.com"
+
+    def test_opaque_publisher_id_is_not_a_domain(self) -> None:
+        assert extract_product_domain({"id": "p1", "publisherId": "pub_abc"}) is None
+
+    def test_no_domain_field_returns_none(self) -> None:
+        assert extract_product_domain({"id": "p1", "name": "Untagged"}) is None
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +253,191 @@ class TestUnknownVendor:
         results = await client.check_approvals(["known.com", "mystery.com"])
         assert results["known.com"] is not None
         assert results["mystery.com"] is None
+
+
+# ---------------------------------------------------------------------------
+# Response-to-request domain matching
+#
+# SGP does not guarantee it echoes the exact spelling that was queried -- it
+# may answer with the vendor's canonical/apex domain. Records must still be
+# paired back to the requested domain, or an approved vendor is reported
+# UNKNOWN and that verdict is cached for the full TTL.
+# ---------------------------------------------------------------------------
+
+
+class TestDomainEchoMatching:
+    @pytest.mark.asyncio
+    async def test_apex_echo_resolves_to_queried_subdomain(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            # Queried news.foo.com; SGP answers with the vendor's apex domain.
+            return httpx.Response(200, json=_success_body([_record("foo.com", True)]))
+
+        client = _make_client(handler)
+        results = await client.check_approvals(["news.foo.com"])
+        record = results["news.foo.com"]
+        assert record is not None, "apex echo must not be discarded"
+        assert record.iab_buyer_agent_approval is True
+
+    @pytest.mark.asyncio
+    async def test_subdomain_echo_resolves_to_queried_apex(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_success_body([_record("www2.foo.com", True)]))
+
+        client = _make_client(handler)
+        results = await client.check_approvals(["foo.com"])
+        assert results["foo.com"] is not None
+        assert results["foo.com"].iab_buyer_agent_approval is True
+
+    @pytest.mark.asyncio
+    async def test_exact_match_wins_over_suffix_match(self) -> None:
+        """An apex record must not leak onto a subdomain that got its own record."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json=_success_body(
+                    [
+                        _record("news.foo.com", True),
+                        _record("foo.com", False),
+                    ]
+                ),
+            )
+
+        client = _make_client(handler)
+        results = await client.check_approvals(["foo.com", "news.foo.com"])
+        assert results["news.foo.com"].iab_buyer_agent_approval is True
+        assert results["foo.com"].iab_buyer_agent_approval is False
+
+    @pytest.mark.asyncio
+    async def test_apex_record_covers_all_pending_subdomains(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_success_body([_record("foo.com", True)]))
+
+        client = _make_client(handler)
+        results = await client.check_approvals(["a.foo.com", "b.foo.com"])
+        assert results["a.foo.com"] is not None
+        assert results["b.foo.com"] is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("also_requested", [[], ["other.com"]])
+    async def test_suffix_match_respects_label_boundary(self, also_requested) -> None:
+        """notfoo.com must never be matched by a foo.com record.
+
+        Parametrized over a single-domain and a multi-domain request: the
+        boundary rule must hold even when the response contains exactly one
+        record, which is the shape the deal-request gate always produces.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_success_body([_record("foo.com", True)]))
+
+        client = _make_client(handler)
+        results = await client.check_approvals(["notfoo.com", *also_requested])
+        assert results["notfoo.com"] is None
+
+    @pytest.mark.asyncio
+    async def test_lone_unrelated_record_is_not_attributed(self, caplog) -> None:
+        """A one-record answer to a one-domain query must not be trusted blindly.
+
+        Regression: a "lone record answers a lone query" fallback made the
+        gate fail open -- SGP answering about any other vendor was accepted
+        as approval for the queried seller.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_success_body([_record("vendor-canonical.com", True)]))
+
+        client = _make_client(handler)
+        with caplog.at_level("WARNING"):
+            results = await client.check_approvals(["seller-alias.com"])
+        assert results["seller-alias.com"] is None
+        assert "vendor-canonical.com" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_empty_domain_record_is_not_attributed(self) -> None:
+        """A record with no domain must not be pinned onto the queried domain."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_success_body([_record("", True)]))
+
+        client = _make_client(handler)
+        results = await client.check_approvals(["foo.com"])
+        assert results["foo.com"] is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("order", [("foo.com", "b.foo.com"), ("b.foo.com", "foo.com")])
+    async def test_most_specific_parent_wins_regardless_of_response_order(self, order) -> None:
+        """Verdicts must not depend on the order records appear in the response."""
+        verdicts = {"foo.com": False, "b.foo.com": True}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json=_success_body([_record(d, verdicts[d]) for d in order]),
+            )
+
+        client = _make_client(handler)
+        results = await client.check_approvals(["a.b.foo.com"])
+        record = results["a.b.foo.com"]
+        assert record is not None
+        # b.foo.com is the more specific parent, so its verdict applies.
+        assert record.domain == "b.foo.com"
+        assert record.iab_buyer_agent_approval is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("order", [(True, False), (False, True)])
+    async def test_conflicting_duplicate_records_resolve_to_denial(self, order) -> None:
+        """Equally specific but contradictory records must not grant approval."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json=_success_body([_record("foo.com", approved) for approved in order]),
+            )
+
+        client = _make_client(handler)
+        results = await client.check_approvals(["news.foo.com"])
+        assert results["news.foo.com"] is not None
+        assert results["news.foo.com"].iab_buyer_agent_approval is False
+
+    @pytest.mark.asyncio
+    async def test_trailing_dot_fqdn_echo_matches(self) -> None:
+        """An FQDN-style echo (foo.com.) must resolve a queried foo.com."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_success_body([_record("foo.com.", True)]))
+
+        client = _make_client(handler)
+        results = await client.check_approvals(["foo.com", "other.com"])
+        assert results["foo.com"] is not None
+        assert results["other.com"] is None
+
+    @pytest.mark.asyncio
+    async def test_unmatchable_record_is_logged_not_silently_dropped(self, caplog) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_success_body([_record("stray.com", True)]))
+
+        client = _make_client(handler)
+        with caplog.at_level("WARNING"):
+            await client.check_approvals(["a.com", "b.com"])
+        assert "stray.com" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_resolved_record_is_what_gets_cached(self) -> None:
+        """Regression: an apex echo used to cache None, blocking for the TTL."""
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(200, json=_success_body([_record("foo.com", True)]))
+
+        client = _make_client(handler)
+        first = await client.check_approvals(["news.foo.com"])
+        second = await client.check_approvals(["news.foo.com"])
+        assert calls["n"] == 1, "second lookup should be served from cache"
+        assert first["news.foo.com"] is not None
+        assert second["news.foo.com"] is not None
+        assert second["news.foo.com"].iab_buyer_agent_approval is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sgp_client.py
+++ b/tests/unit/test_sgp_client.py
@@ -14,11 +14,13 @@ import httpx
 import pytest
 
 from ad_buyer.clients.sgp_client import (
+    _RETRYABLE_STATUS_CODES,
     SGPAuthError,
     SGPClient,
     SGPClientError,
     extract_product_domain,
 )
+from ad_buyer.models.sgp import normalize_unknown_policy
 
 BASE_URL = "https://sgp.test"
 
@@ -486,6 +488,170 @@ class TestErrorHandling:
         with pytest.raises(SGPClientError) as exc_info:
             await client.check_approvals(["example.com"])
         assert "ConnectError" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Retry on transient failures
+#
+# Enforcing callers fail closed when a lookup fails, so "SGP blipped for a
+# second" must not be the same event as "the vendor is not approved".
+# ---------------------------------------------------------------------------
+
+
+def _retry_client(handler, *, max_retries: int = 2) -> SGPClient:
+    """Client with instant backoff so retry tests stay fast."""
+    c = _make_client(handler)
+    c._max_retries = max_retries
+    c._retry_backoff = 0.0
+    return c
+
+
+class TestRetry:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", sorted(_RETRYABLE_STATUS_CODES))
+    async def test_retryable_status_recovers(self, status: int) -> None:
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(status, text="try later")
+            return httpx.Response(200, json=_success_body([_record("flaky.com", True)]))
+
+        client = _retry_client(handler)
+        results = await client.check_approvals(["flaky.com"])
+        assert calls["n"] == 2
+        assert results["flaky.com"] is not None
+
+    @pytest.mark.asyncio
+    async def test_transport_error_recovers(self) -> None:
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise httpx.ConnectError("connection refused")
+            return httpx.Response(200, json=_success_body([_record("flaky.com", True)]))
+
+        client = _retry_client(handler)
+        results = await client.check_approvals(["flaky.com"])
+        assert calls["n"] == 2
+        assert results["flaky.com"] is not None
+
+    @pytest.mark.asyncio
+    async def test_exhausted_retries_still_fail_closed(self) -> None:
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(503, text="down")
+
+        client = _retry_client(handler, max_retries=2)
+        with pytest.raises(SGPClientError) as exc_info:
+            await client.check_approvals(["down.com"])
+        assert calls["n"] == 3, "should attempt once plus max_retries"
+        assert exc_info.value.status_code == 503
+        assert "3 attempt" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [400, 401, 404])
+    async def test_definite_answers_are_not_retried(self, status: int) -> None:
+        """400/401/404 are verdicts, not blips — retrying only delays them."""
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(status, text="definite")
+
+        client = _retry_client(handler)
+        try:
+            await client.check_approvals(["x.com"])
+        except SGPClientError:
+            pass
+        assert calls["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_can_be_disabled(self) -> None:
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(503, text="down")
+
+        client = _retry_client(handler, max_retries=0)
+        with pytest.raises(SGPClientError):
+            await client.check_approvals(["down.com"])
+        assert calls["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_backoff_grows_and_is_awaited(self, monkeypatch) -> None:
+        slept: list[float] = []
+
+        async def fake_sleep(delay: float) -> None:
+            slept.append(delay)
+
+        monkeypatch.setattr("ad_buyer.clients.sgp_client.asyncio.sleep", fake_sleep)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, text="down")
+
+        client = _make_client(handler)
+        client._max_retries = 3
+        client._retry_backoff = 0.5
+        with pytest.raises(SGPClientError):
+            await client.check_approvals(["down.com"])
+        assert slept == [0.5, 1.0, 2.0]
+
+
+# ---------------------------------------------------------------------------
+# Unknown-vendor policy canonicalization
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeUnknownPolicy:
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("block", "block"),
+            ("BLOCK", "block"),
+            ("  Warn  ", "warn"),
+            ("Allow", "allow"),
+        ],
+    )
+    def test_canonicalizes(self, raw: str, expected: str) -> None:
+        assert normalize_unknown_policy(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["maybe", "", "  ", "blockk"])
+    def test_rejects_unrecognized(self, raw: str) -> None:
+        with pytest.raises(ValueError, match="sgp_unknown_policy"):
+            normalize_unknown_policy(raw)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_aclose_is_idempotent(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_success_body([]))
+
+        client = _make_client(handler)
+        await client.aclose()
+        await client.aclose()  # must not raise
+        assert client._http.is_closed
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager_closes(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_success_body([]))
+
+        client = _make_client(handler)
+        async with client as c:
+            assert c is client
+        assert client._http.is_closed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sgp_client.py
+++ b/tests/unit/test_sgp_client.py
@@ -416,7 +416,7 @@ class TestDomainEchoMatching:
     async def test_record_without_an_echo_is_ignored(self, caplog) -> None:
         """A record carrying no requestedDomain is not attributed to anything.
 
-        This is the shape an SGP deployment predating the echo returns. The
+        There is nothing on the record saying which query it answers, so the
         gate reports UNKNOWN and fails closed rather than guessing.
         """
         legacy = {

--- a/tests/unit/test_sgp_client.py
+++ b/tests/unit/test_sgp_client.py
@@ -53,12 +53,38 @@ def _success_body(records: list[dict]) -> dict:
     }
 
 
-def _record(domain: str, approved: bool, approved_at: str | None = "2026-03-14T12:00:00Z") -> dict:
+_UNSET = object()
+
+
+def _record(
+    domain: str,
+    approved: bool,
+    approved_at: str | None = "2026-03-14T12:00:00Z",
+    requested_domain: str | None = _UNSET,  # type: ignore[assignment]
+    match_type: str | None = None,
+) -> dict:
+    """One IabBuyerAgentResource in the shape SGP returns it.
+
+    By default the record echoes the domain it was queried with, which is what
+    SGP sends for a vendor registered under exactly the domain asked about.
+    Pass ``requested_domain`` to model a parent match (vendor at the apex,
+    query for a subdomain), or ``None`` to model a record SGP could not pair.
+    """
+    echoed = domain if requested_domain is _UNSET else requested_domain
+    if match_type is None:
+        if not echoed:
+            match_type = "unresolved"
+        elif echoed == domain:
+            match_type = "exact"
+        else:
+            match_type = "parent"
     return {
         "vendorId": hash(domain) & 0xFFFF,
         "vendorCompanyId": (hash(domain) + 1) & 0xFFFF,
         "companyName": domain.split(".")[0].title() + " Inc.",
         "domain": domain,
+        "requestedDomain": echoed,
+        "matchType": match_type,
         "iabBuyerAgentApproval": approved,
         "iabBuyerAgentApprovedAt": approved_at,
     }
@@ -273,92 +299,143 @@ class TestUnknownVendor:
 
 
 class TestDomainEchoMatching:
+    """Pairing is a lookup on the domain SGP echoes, never an inference.
+
+    Apex-versus-subdomain resolution lives on the SGP platform. What is
+    exercised here is that the client trusts ``requestedDomain`` and refuses
+    to attribute anything else.
+    """
+
     @pytest.mark.asyncio
-    async def test_apex_echo_resolves_to_queried_subdomain(self) -> None:
+    async def test_parent_echo_resolves_to_queried_subdomain(self) -> None:
+        """Vendor registered at the apex, product on a subdomain."""
+
         def handler(request: httpx.Request) -> httpx.Response:
-            # Queried news.foo.com; SGP answers with the vendor's apex domain.
-            return httpx.Response(200, json=_success_body([_record("foo.com", True)]))
+            return httpx.Response(
+                200,
+                json=_success_body([_record("foo.com", True, requested_domain="news.foo.com")]),
+            )
 
         client = _make_client(handler)
         results = await client.check_approvals(["news.foo.com"])
         record = results["news.foo.com"]
-        assert record is not None, "apex echo must not be discarded"
+        assert record is not None, "an echoed parent match must resolve"
         assert record.iab_buyer_agent_approval is True
+        assert record.domain == "foo.com"
+        assert record.match_type == "parent"
 
     @pytest.mark.asyncio
-    async def test_subdomain_echo_resolves_to_queried_apex(self) -> None:
+    async def test_exact_echo_resolves(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json=_success_body([_record("www2.foo.com", True)]))
+            return httpx.Response(200, json=_success_body([_record("foo.com", True)]))
 
         client = _make_client(handler)
         results = await client.check_approvals(["foo.com"])
         assert results["foo.com"] is not None
-        assert results["foo.com"].iab_buyer_agent_approval is True
+        assert results["foo.com"].match_type == "exact"
 
     @pytest.mark.asyncio
-    async def test_exact_match_wins_over_suffix_match(self) -> None:
-        """An apex record must not leak onto a subdomain that got its own record."""
+    async def test_one_record_per_requested_domain(self) -> None:
+        """SGP answers each queried domain separately, even for one vendor."""
 
         def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
                 json=_success_body(
                     [
-                        _record("news.foo.com", True),
-                        _record("foo.com", False),
+                        _record("foo.com", True),
+                        _record("foo.com", True, requested_domain="news.foo.com"),
                     ]
                 ),
             )
 
         client = _make_client(handler)
         results = await client.check_approvals(["foo.com", "news.foo.com"])
-        assert results["news.foo.com"].iab_buyer_agent_approval is True
-        assert results["foo.com"].iab_buyer_agent_approval is False
+        assert results["foo.com"] is not None
+        assert results["news.foo.com"] is not None
 
     @pytest.mark.asyncio
-    async def test_apex_record_covers_all_pending_subdomains(self) -> None:
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json=_success_body([_record("foo.com", True)]))
+    async def test_client_does_not_infer_a_parent_relationship(self) -> None:
+        """Without an echo naming it, a subdomain query stays UNKNOWN.
 
-        client = _make_client(handler)
-        results = await client.check_approvals(["a.foo.com", "b.foo.com"])
-        assert results["a.foo.com"] is not None
-        assert results["b.foo.com"] is not None
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("also_requested", [[], ["other.com"]])
-    async def test_suffix_match_respects_label_boundary(self, also_requested) -> None:
-        """notfoo.com must never be matched by a foo.com record.
-
-        Parametrized over a single-domain and a multi-domain request: the
-        boundary rule must hold even when the response contains exactly one
-        record, which is the shape the deal-request gate always produces.
+        The apex-to-subdomain rule is SGP's to apply. If SGP answers about
+        ``foo.com`` when ``news.foo.com`` was queried, the client must not
+        quietly decide the two are the same seller.
         """
 
         def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=_success_body([_record("foo.com", True)]))
 
         client = _make_client(handler)
-        results = await client.check_approvals(["notfoo.com", *also_requested])
-        assert results["notfoo.com"] is None
+        results = await client.check_approvals(["news.foo.com"])
+        assert results["news.foo.com"] is None
 
     @pytest.mark.asyncio
-    async def test_lone_unrelated_record_is_not_attributed(self, caplog) -> None:
-        """A one-record answer to a one-domain query must not be trusted blindly.
-
-        Regression: a "lone record answers a lone query" fallback made the
-        gate fail open -- SGP answering about any other vendor was accepted
-        as approval for the queried seller.
-        """
+    async def test_unresolved_record_is_logged_not_silently_dropped(self, caplog) -> None:
+        """SGP could not pair it, so neither does the client."""
 
         def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json=_success_body([_record("vendor-canonical.com", True)]))
+            return httpx.Response(
+                200,
+                json=_success_body([_record("stray.com", True, requested_domain=None)]),
+            )
 
         client = _make_client(handler)
         with caplog.at_level("WARNING"):
-            results = await client.check_approvals(["seller-alias.com"])
+            results = await client.check_approvals(["foo.com"])
+        assert results["foo.com"] is None
+        assert "stray.com" in caplog.text
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("also_requested", [[], ["other.com"]])
+    async def test_record_echoing_an_unrequested_domain_is_ignored(
+        self, also_requested, caplog
+    ) -> None:
+        """An echo we did not ask for is never accepted.
+
+        Parametrized over a single-domain and a multi-domain request: the rule
+        must hold even when the response contains exactly one record, which is
+        the shape the deal-request gate always produces.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json=_success_body(
+                    [_record("vendor-canonical.com", True, requested_domain="somewhere-else.com")]
+                ),
+            )
+
+        client = _make_client(handler)
+        with caplog.at_level("WARNING"):
+            results = await client.check_approvals(["seller-alias.com", *also_requested])
         assert results["seller-alias.com"] is None
-        assert "vendor-canonical.com" in caplog.text
+        assert "somewhere-else.com" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_record_without_an_echo_is_ignored(self, caplog) -> None:
+        """A record carrying no requestedDomain is not attributed to anything.
+
+        This is the shape an SGP deployment predating the echo returns. The
+        gate reports UNKNOWN and fails closed rather than guessing.
+        """
+        legacy = {
+            "vendorId": 1,
+            "vendorCompanyId": 2,
+            "companyName": "Foo Inc.",
+            "domain": "foo.com",
+            "iabBuyerAgentApproval": True,
+            "iabBuyerAgentApprovedAt": None,
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_success_body([legacy]))
+
+        client = _make_client(handler)
+        with caplog.at_level("WARNING"):
+            results = await client.check_approvals(["foo.com"])
+        assert results["foo.com"] is None
+        assert "foo.com" in caplog.text
 
     @pytest.mark.asyncio
     async def test_empty_domain_record_is_not_attributed(self) -> None:
@@ -372,47 +449,15 @@ class TestDomainEchoMatching:
         assert results["foo.com"] is None
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("order", [("foo.com", "b.foo.com"), ("b.foo.com", "foo.com")])
-    async def test_most_specific_parent_wins_regardless_of_response_order(self, order) -> None:
-        """Verdicts must not depend on the order records appear in the response."""
-        verdicts = {"foo.com": False, "b.foo.com": True}
+    @pytest.mark.parametrize("echo", ["foo.com.", "https://www.foo.com/x", "FOO.com"])
+    async def test_echo_is_normalized_before_pairing(self, echo) -> None:
+        """The echo goes through the same normalization as the query."""
 
         def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
-                json=_success_body([_record(d, verdicts[d]) for d in order]),
+                json=_success_body([_record("foo.com", True, requested_domain=echo)]),
             )
-
-        client = _make_client(handler)
-        results = await client.check_approvals(["a.b.foo.com"])
-        record = results["a.b.foo.com"]
-        assert record is not None
-        # b.foo.com is the more specific parent, so its verdict applies.
-        assert record.domain == "b.foo.com"
-        assert record.iab_buyer_agent_approval is True
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("order", [(True, False), (False, True)])
-    async def test_conflicting_duplicate_records_resolve_to_denial(self, order) -> None:
-        """Equally specific but contradictory records must not grant approval."""
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(
-                200,
-                json=_success_body([_record("foo.com", approved) for approved in order]),
-            )
-
-        client = _make_client(handler)
-        results = await client.check_approvals(["news.foo.com"])
-        assert results["news.foo.com"] is not None
-        assert results["news.foo.com"].iab_buyer_agent_approval is False
-
-    @pytest.mark.asyncio
-    async def test_trailing_dot_fqdn_echo_matches(self) -> None:
-        """An FQDN-style echo (foo.com.) must resolve a queried foo.com."""
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json=_success_body([_record("foo.com.", True)]))
 
         client = _make_client(handler)
         results = await client.check_approvals(["foo.com", "other.com"])
@@ -420,23 +465,16 @@ class TestDomainEchoMatching:
         assert results["other.com"] is None
 
     @pytest.mark.asyncio
-    async def test_unmatchable_record_is_logged_not_silently_dropped(self, caplog) -> None:
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json=_success_body([_record("stray.com", True)]))
-
-        client = _make_client(handler)
-        with caplog.at_level("WARNING"):
-            await client.check_approvals(["a.com", "b.com"])
-        assert "stray.com" in caplog.text
-
-    @pytest.mark.asyncio
     async def test_resolved_record_is_what_gets_cached(self) -> None:
-        """Regression: an apex echo used to cache None, blocking for the TTL."""
+        """Regression: a parent match used to cache None, blocking for the TTL."""
         calls = {"n": 0}
 
         def handler(request: httpx.Request) -> httpx.Response:
             calls["n"] += 1
-            return httpx.Response(200, json=_success_body([_record("foo.com", True)]))
+            return httpx.Response(
+                200,
+                json=_success_body([_record("foo.com", True, requested_domain="news.foo.com")]),
+            )
 
         client = _make_client(handler)
         first = await client.check_approvals(["news.foo.com"])

--- a/tests/unit/test_sgp_gate.py
+++ b/tests/unit/test_sgp_gate.py
@@ -659,3 +659,97 @@ async def test_discovery_no_sgp_client_pass_through(discovery_client, agency_con
     assert "Product p3" in result
     assert "SGP Approval" not in result
     assert "Total products found: 3" in result
+
+
+# ---------------------------------------------------------------------------
+# Unreadable catalog entries must not slip past enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discovery_blocks_unreadable_entries_when_enforcing(agency_context):
+    """Regression: a non-dict catalog entry used to bypass the gate entirely.
+
+    `_apply_enforcement` appended anything that was not a dict, so a malformed
+    row reached the agent unverified while a well-formed row merely missing a
+    domain was blocked.
+    """
+    from ad_buyer.clients.sgp_client import SGPClient
+    from ad_buyer.tools.buyer_deals import DiscoverInventoryTool
+
+    client = MagicMock()
+    client.search_products = AsyncMock(
+        return_value=MagicMock(
+            success=True,
+            data=[
+                "I am not a dict",
+                _product("p1", "approved.example.com"),
+            ],
+        )
+    )
+    sgp = MagicMock()
+    sgp.normalize_domain = MagicMock(side_effect=SGPClient.normalize_domain)
+    sgp.check_approvals = AsyncMock(
+        return_value={"approved.example.com": _approved("approved.example.com")}
+    )
+
+    tool = DiscoverInventoryTool(
+        client=client,
+        buyer_context=agency_context,
+        sgp_client=sgp,
+        sgp_enforce=True,
+        sgp_unknown_policy="block",
+    )
+    result = await tool._arun(query="anything")
+    assert "I am not a dict" not in result
+    assert "unreadable" in result
+    # The verifiable, approved product is untouched.
+    assert "Product p1" in result
+
+
+@pytest.mark.asyncio
+async def test_discovery_keeps_unreadable_entries_when_not_enforcing(agency_context):
+    """Annotate-only mode must not start dropping rows."""
+    from ad_buyer.tools.buyer_deals import DiscoverInventoryTool
+
+    client = MagicMock()
+    client.search_products = AsyncMock(
+        return_value=MagicMock(success=True, data=["I am not a dict"])
+    )
+    tool = DiscoverInventoryTool(
+        client=client,
+        buyer_context=agency_context,
+        sgp_client=None,
+        sgp_enforce=False,
+    )
+    result = await tool._arun(query="anything")
+    assert "I am not a dict" in result
+
+
+@pytest.mark.asyncio
+async def test_deal_gate_blocks_an_unreadable_product(agency_context):
+    """A non-dict product must be blocked by the gate, not raise AttributeError.
+
+    ``extract_product_domain`` returning None for unreadable input is what makes
+    this fail closed, so the gate needs no special case of its own.
+    """
+    mock_client = MagicMock()
+    mock_client.get_product = AsyncMock(
+        return_value=MagicMock(success=True, data="not-a-dict", error=None)
+    )
+    sgp = MagicMock()
+    sgp.normalize_domain = MagicMock(return_value="")
+    sgp.check_approvals = AsyncMock()
+
+    tool = RequestDealTool(
+        client=mock_client,
+        buyer_context=agency_context,
+        sgp_client=sgp,
+        sgp_enforce=True,
+        sgp_unknown_policy="block",
+    )
+    result = await tool._arun(product_id="prod_1", impressions=100)
+    assert "Deal blocked" in result
+    assert "seller domain" in result
+    assert "DEAL CREATED SUCCESSFULLY" not in result
+    sgp.check_approvals.assert_not_called()

--- a/tests/unit/test_sgp_gate.py
+++ b/tests/unit/test_sgp_gate.py
@@ -356,6 +356,64 @@ async def test_gate_blocks_when_sgp_answers_about_a_different_vendor(agency_cont
     assert "Unrelated Vendor Inc" not in result
 
 
+@pytest.mark.parametrize("raw, canonical", [("BLOCK", "block"), ("  Warn ", "warn")])
+def test_unknown_policy_is_canonicalized(mock_client, agency_context, raw, canonical):
+    """A mis-cased env value must resolve, not reach the gate uninterpreted."""
+    tool = RequestDealTool(
+        client=mock_client,
+        buyer_context=agency_context,
+        sgp_unknown_policy=raw,
+    )
+    assert tool._sgp_unknown_policy == canonical
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("policy", ["BLOCK", "Block"])
+async def test_discovery_does_not_fail_open_on_miscased_policy(agency_context, policy):
+    """Regression: an unrecognized policy used to mean "keep the unknown vendor".
+
+    `_apply_enforcement` branched on `== "block"`, so any other spelling fell
+    through to the append path and admitted vendors SGP could not vouch for.
+    """
+    from ad_buyer.clients.sgp_client import SGPClient
+    from ad_buyer.tools.buyer_deals import DiscoverInventoryTool
+
+    client = MagicMock()
+    client.search_products = AsyncMock(
+        return_value=MagicMock(
+            success=True,
+            data=[{"id": "p1", "name": "Unvouched Product", "domain": "unknown.example"}],
+        )
+    )
+    sgp = MagicMock()
+    sgp.normalize_domain = MagicMock(side_effect=SGPClient.normalize_domain)
+    sgp.check_approvals = AsyncMock(return_value={})  # unknown to SGP
+
+    tool = DiscoverInventoryTool(
+        client=client,
+        buyer_context=agency_context,
+        sgp_client=sgp,
+        sgp_enforce=True,
+        sgp_unknown_policy=policy,
+    )
+    assert tool._sgp_unknown_policy == "block"
+    result = await tool._arun(query="anything")
+    assert "Unvouched Product" not in result
+    assert "unknown to SGP" in result
+
+
+def test_discovery_rejects_unrecognized_policy(agency_context):
+    """Both tools must agree that an unrecognized policy is a configuration error."""
+    from ad_buyer.tools.buyer_deals import DiscoverInventoryTool
+
+    with pytest.raises(ValueError, match="sgp_unknown_policy"):
+        DiscoverInventoryTool(
+            client=MagicMock(),
+            buyer_context=agency_context,
+            sgp_unknown_policy="maybe",
+        )
+
+
 def test_invalid_unknown_policy_rejected(mock_client, agency_context):
     with pytest.raises(ValueError, match="sgp_unknown_policy"):
         RequestDealTool(

--- a/tests/unit/test_sgp_gate.py
+++ b/tests/unit/test_sgp_gate.py
@@ -27,16 +27,22 @@ def agency_context() -> BuyerContext:
 
 @pytest.fixture
 def mock_client() -> MagicMock:
-    """UnifiedClient mock that returns a product with a seller_url."""
+    """UnifiedClient mock returning a product in the canonical OpenDirect shape.
+
+    The seller domain lives in ``domain`` -- the field the OpenDirect Product
+    resource defines (see models.opendirect.Product), not ``seller_url``,
+    which on a deal record means the seller *system endpoint*.
+    """
     client = MagicMock()
     client.get_product = AsyncMock(
         return_value=MagicMock(
             success=True,
             data={
                 "id": "prod_1",
+                "publisherId": "pub_1",
                 "name": "Premium CTV",
                 "basePrice": 20.00,
-                "seller_url": "http://seller.example.com:8001",
+                "domain": "seller.example.com",
             },
         )
     )
@@ -257,6 +263,99 @@ async def test_product_without_domain_blocks_when_enforcing(agency_context):
     sgp.check_approvals.assert_not_called()
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "domain_field",
+    ["domain", "seller_domain", "publisherDomain", "publisher_domain", "seller_url"],
+)
+async def test_gate_resolves_each_supported_domain_field(domain_field, agency_context):
+    """Every documented domain key reaches the SGP lookup rather than blocking."""
+    from ad_buyer.clients.sgp_client import SGPClient
+
+    mock_client = MagicMock()
+    mock_client.get_product = AsyncMock(
+        return_value=MagicMock(
+            success=True,
+            data={
+                "id": "prod_1",
+                "publisherId": "pub_1",
+                "name": "Premium CTV",
+                "basePrice": 20.00,
+                domain_field: "seller.example.com",
+            },
+        )
+    )
+    sgp = MagicMock()
+    sgp.normalize_domain = MagicMock(side_effect=SGPClient.normalize_domain)
+    sgp.check_approvals = AsyncMock(
+        return_value={"seller.example.com": _approved("seller.example.com")}
+    )
+    tool = RequestDealTool(
+        client=mock_client,
+        buyer_context=agency_context,
+        sgp_client=sgp,
+        sgp_enforce=True,
+    )
+    result = await tool._arun(product_id="prod_1", impressions=100)
+    assert "DEAL CREATED SUCCESSFULLY" in result
+    assert "SGP: ✓" in result
+    sgp.check_approvals.assert_called_once_with(["seller.example.com"])
+
+
+@pytest.mark.asyncio
+async def test_gate_blocks_when_sgp_answers_about_a_different_vendor(agency_context):
+    """The gate must not accept an unrelated vendor's approval.
+
+    Regression: the deal gate always queries exactly one domain, so a
+    "lone record answers a lone query" fallback let SGP's answer about any
+    other vendor authorize a Deal ID for the queried seller.
+    """
+    import httpx
+
+    from ad_buyer.clients.sgp_client import SGPClient
+
+    body = {
+        "data": [
+            {
+                "vendorId": 9,
+                "vendorCompanyId": 99,
+                "companyName": "Unrelated Vendor Inc",
+                "domain": "totally-different-vendor.com",
+                "iabBuyerAgentApproval": True,
+            }
+        ]
+    }
+    sgp = SGPClient(api_key="k", base_url="https://sgp.test", timeout=5.0)
+    sgp._http = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json=body)),
+        base_url="https://sgp.test",
+    )
+
+    mock_client = MagicMock()
+    mock_client.get_product = AsyncMock(
+        return_value=MagicMock(
+            success=True,
+            data={
+                "id": "prod_1",
+                "name": "Shady Inventory",
+                "basePrice": 5.00,
+                "domain": "shady.example",
+            },
+        )
+    )
+    tool = RequestDealTool(
+        client=mock_client,
+        buyer_context=agency_context,
+        sgp_client=sgp,
+        sgp_enforce=True,
+        sgp_unknown_policy="block",
+    )
+    result = await tool._arun(product_id="prod_1", impressions=100)
+    assert "DEAL CREATED SUCCESSFULLY" not in result
+    assert "Deal blocked" in result
+    assert "Unrelated Vendor Inc" not in result
+
+
 def test_invalid_unknown_policy_rejected(mock_client, agency_context):
     with pytest.raises(ValueError, match="sgp_unknown_policy"):
         RequestDealTool(
@@ -272,6 +371,7 @@ def test_invalid_unknown_policy_rejected(mock_client, agency_context):
 
 
 def _product(product_id: str, domain: str, price: float = 20.0) -> dict:
+    """A product in the canonical OpenDirect shape: seller domain in ``domain``."""
     return {
         "id": product_id,
         "name": f"Product {product_id}",
@@ -279,7 +379,7 @@ def _product(product_id: str, domain: str, price: float = 20.0) -> dict:
         "channel": "ctv",
         "basePrice": price,
         "availableImpressions": 1_000_000,
-        "seller_url": f"http://{domain}",
+        "domain": domain,
     }
 
 
@@ -314,6 +414,51 @@ def _discovery_sgp_mock() -> MagicMock:
         }
     )
     return sgp
+
+
+@pytest.mark.asyncio
+async def test_discovery_does_not_block_spec_conformant_product(agency_context):
+    """Regression: a Product built from the OpenDirect schema must survive.
+
+    The extractor previously ignored ``domain`` -- the only domain field the
+    Product resource defines -- so enforcement filtered every conformant
+    product as "missing seller domain" and emptied the catalog.
+    """
+    from ad_buyer.clients.sgp_client import SGPClient
+    from ad_buyer.models.opendirect import Product
+    from ad_buyer.tools.buyer_deals import DiscoverInventoryTool
+
+    # Constructed by field name (populate_by_name) rather than by wire alias,
+    # so this stays valid if the alias convention changes again.
+    product = Product(
+        id="espn-sports-pmp",
+        publisher_id="pub_espn",
+        name="ESPN Sports PMP",
+        base_price=18.5,
+        rate_type="CPM",
+        domain="espn.com",
+        available_impressions=1_000_000,
+    ).model_dump(by_alias=True)
+
+    client = MagicMock()
+    client.search_products = AsyncMock(return_value=MagicMock(success=True, data=[product]))
+
+    sgp = MagicMock()
+    sgp.normalize_domain = MagicMock(side_effect=SGPClient.normalize_domain)
+    sgp.check_approvals = AsyncMock(return_value={"espn.com": _approved("espn.com")})
+
+    tool = DiscoverInventoryTool(
+        client=client,
+        buyer_context=agency_context,
+        sgp_client=sgp,
+        sgp_enforce=True,
+        sgp_unknown_policy="block",
+    )
+    result = await tool._arun(query="sports inventory")
+    assert "ESPN Sports PMP" in result
+    assert "missing seller domain" not in result
+    assert "APPROVED" in result
+    sgp.check_approvals.assert_called_once_with(["espn.com"])
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_sgp_settings_policy.py
+++ b/tests/unit/test_sgp_settings_policy.py
@@ -73,3 +73,64 @@ class TestSgpUnknownVendorPolicy:
             check=True,
         )
         assert result.stdout.strip() == "False", result.stdout
+
+
+class TestSgpRetrySettings:
+    """Retry/timeout knobs are environment variables, not code edits."""
+
+    def test_defaults(self) -> None:
+        s = Settings()
+        assert s.sgp_timeout_seconds == 15.0
+        assert s.sgp_max_retries == 2
+        assert s.sgp_retry_backoff_seconds == 0.5
+
+    def test_values_are_read_from_the_environment(self, monkeypatch) -> None:
+        monkeypatch.setenv("SGP_TIMEOUT_SECONDS", "4.5")
+        monkeypatch.setenv("SGP_MAX_RETRIES", "5")
+        monkeypatch.setenv("SGP_RETRY_BACKOFF_SECONDS", "0")
+        s = Settings()
+        assert s.sgp_timeout_seconds == 4.5
+        assert s.sgp_max_retries == 5
+        assert s.sgp_retry_backoff_seconds == 0.0
+
+    def test_retries_can_be_disabled_via_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("SGP_MAX_RETRIES", "0")
+        assert Settings().sgp_max_retries == 0
+
+    @pytest.mark.parametrize(
+        "var, value",
+        [
+            ("SGP_MAX_RETRIES", "-1"),
+            ("SGP_RETRY_BACKOFF_SECONDS", "-0.5"),
+            ("SGP_TIMEOUT_SECONDS", "0"),
+        ],
+    )
+    def test_nonsensical_values_are_rejected(self, monkeypatch, var, value) -> None:
+        """A zero timeout or negative retry budget is a config error, not a clamp."""
+        monkeypatch.setenv(var, value)
+        with pytest.raises(ValidationError):
+            Settings()
+
+    def test_settings_reach_the_constructed_client(self, monkeypatch) -> None:
+        """The whole point: editing .env must change client behavior.
+
+        Guards the wiring in ``deal_booking_flow._build_sgp_client`` -- settings
+        that exist but are never passed through would look configured and do
+        nothing.
+        """
+        from ad_buyer.flows.deal_booking_flow import _build_sgp_client
+
+        monkeypatch.setenv("SGP_ENFORCE", "true")
+        monkeypatch.setenv("SGP_API_KEY", "test-key")
+        monkeypatch.setenv("SGP_TIMEOUT_SECONDS", "3")
+        monkeypatch.setenv("SGP_MAX_RETRIES", "7")
+        monkeypatch.setenv("SGP_RETRY_BACKOFF_SECONDS", "0.25")
+        monkeypatch.setenv("SGP_CACHE_TTL_SECONDS", "60")
+
+        client = _build_sgp_client(Settings())
+
+        assert client is not None
+        assert client._timeout == 3.0
+        assert client._max_retries == 7
+        assert client._retry_backoff == 0.25
+        assert client._cache_ttl == 60

--- a/tests/unit/test_sgp_settings_policy.py
+++ b/tests/unit/test_sgp_settings_policy.py
@@ -1,0 +1,75 @@
+# Author: SafeGuard Privacy
+# Donated to IAB Tech Lab
+
+"""Tests for SGP_UNKNOWN_VENDOR_POLICY normalization at settings load.
+
+Kept out of ``test_settings_lazy_init.py`` deliberately: that module reloads
+``ad_buyer.config.settings``, which pollutes any test later in the same session
+that captured the previous ``settings`` object. These tests only construct
+``Settings`` directly, so they stay order-independent.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+from ad_buyer.config.settings import Settings
+
+
+class TestSgpUnknownVendorPolicy:
+    def test_default_is_block(self) -> None:
+        assert Settings().sgp_unknown_vendor_policy == "block"
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("block", "block"),
+            ("BLOCK", "block"),
+            ("Warn", "warn"),
+            ("  ALLOW  ", "allow"),
+        ],
+    )
+    def test_canonicalizes_case_and_whitespace(self, raw: str, expected: str) -> None:
+        assert Settings(sgp_unknown_vendor_policy=raw).sgp_unknown_vendor_policy == expected
+
+    @pytest.mark.parametrize("raw", ["", "   "])
+    def test_empty_falls_back_to_the_safe_default(self, raw: str) -> None:
+        """``SGP_UNKNOWN_VENDOR_POLICY=`` reads as unset, not as a startup error.
+
+        Every other SGP variable treats empty as unconfigured, so an empty
+        policy must not be the one thing that refuses to boot.
+        """
+        assert Settings(sgp_unknown_vendor_policy=raw).sgp_unknown_vendor_policy == "block"
+
+    def test_unrecognized_value_fails_at_load(self) -> None:
+        with pytest.raises(ValidationError, match="sgp_unknown_policy"):
+            Settings(sgp_unknown_vendor_policy="maybe")
+
+    def test_importing_settings_does_not_import_the_clients_package(self) -> None:
+        """Settings must not depend on ``ad_buyer.clients``.
+
+        The policy helper lives in ``models.sgp`` precisely to keep this edge
+        one-directional: ``clients.ucp_client`` reads settings, so a
+        settings -> clients import would be a latent circular import.
+        """
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                # `from`-import: this module swaps itself for a lazy proxy in
+                # sys.modules, so attribute access on the module object would
+                # route through the proxy instead of finding the class.
+                "import sys\n"
+                "from ad_buyer.config.settings import Settings\n"
+                "Settings()\n"
+                "print('ad_buyer.clients' in sys.modules)\n",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert result.stdout.strip() == "False", result.stdout


### PR DESCRIPTION
## Summary

Fixes how the SGP approval gate matches a seller to a vendor record, and cleans up two
things around it: retry behavior when the platform is briefly unavailable, and how the
unknown-vendor policy is parsed.

The main fix is on the canonical booking path. `MultiSellerOrchestrator` gets its lookup
domain from the seller's agent-card `url`. That's a system endpoint, and it's usually a
subdomain of whatever domain the vendor is registered under: an agent at `a2a.example.com`
for a vendor registered as `example.com`. Exact-match lookup returned UNKNOWN for all of
those, and with the default `block` policy the seller was dropped at discovery before any
quote went out. SGP now does that resolution server-side, so those sellers are gated on
their real approval status instead of on a spelling mismatch between an API endpoint and a
vendor record.

Five areas:

1. **Seller-to-vendor resolution.** SGP resolves apex vs. subdomain server-side and states
   on every record which query it answers, via `requestedDomain` and `matchType`. The client
   pairs on that instead of guessing from the canonical domain it gets back.
2. **Domain resolution** in the example tools now covers `domain`, the seller domain field on
   the OpenDirect `Product` resource, alongside the deal / SSP-connector field names already
   supported.
3. **Normalization** additionally strips a trailing FQDN dot.
4. **Transient-failure retry** gives gateway, rate-limit, and transport failures a bounded
   number of retries with backoff, so a brief SGP blip stops being indistinguishable from
   a denial.
5. **Policy handling and lifecycle** canonicalize the unknown-vendor policy in one place,
   validate it at every entry point, and give the client a cleanup path.

Adds three environment variables for the retry and timeout budget (`SGP_TIMEOUT_SECONDS`,
`SGP_MAX_RETRIES`, `SGP_RETRY_BACKOFF_SECONDS`), all with defaults matching prior behavior. The
endpoint contract gains two response fields, `requestedDomain` and `matchType`; no existing
field changed. The integration stays fully inert when `SGP_API_KEY` is empty or
`SGP_ENFORCE=false`.

## Motivation

`extract_product_domain()` probed `seller_url`, `sellerUrl`, `publisher_domain`, and
`publisherDomain`. Those names come from two adjacent vocabularies:

| Field | Where it actually appears |
|---|---|
| `seller_url` | deal records / session state (the seller *system endpoint*) |
| `publisherDomain` | Magnite and Index Exchange raw deal payloads |
| `publisher_domain` | PubMatic raw deals, CSV import alias |

The **product** vocabulary was missing: `models/opendirect.py` defines `Product.domain`,
and that field was not probed. A product populating `domain` therefore resolved to no
seller domain, which under enforcement removes it from discovery and blocks it at Deal ID
time, without SGP being consulted at all.

Separately, `_fetch_chunk()` keyed the response by the vendor's canonical domain, which is
not necessarily the domain that was queried. A product on `news.example.com` belongs to a
vendor registered as `example.com`. Those records landed under a key that was never
requested, so the queried domain resolved to UNKNOWN. Because `check_approvals()` caches per
requested domain, that verdict then persisted for `SGP_CACHE_TTL_SECONDS`.

SGP now resolves this server-side and states on every record which query it answers, so the
client pairs on that rather than inferring the relationship.

That matters most on the canonical path, which never touches `_DOMAIN_KEYS` at all.
`MultiSellerOrchestrator._filter_by_sgp_approval` has exactly one domain source, the
agent-card `url`, so every lookup in the real booking pipeline is keyed on a system endpoint.
Those hosts often carry an `api.`, `a2a.` or `agent.` prefix over the vendor's registered
domain, so exact matching failed there more often than it did on the product path.

Two further rough edges, both amplified by the orchestrator gate now sitting in front of the
canonical booking path:

`_RETRYABLE_STATUS_CODES` was declared but never acted on. The condition that referenced it
was subsumed by the `>= 500` check next to it, and nothing retried. Since an enforcing caller
fails closed on a failed lookup, and the orchestrator fails closed for **every** seller on
one `check_failed`, a single 503 was enough to stop all booking. Failing closed is correct;
doing it without a second attempt is not.

The unknown-vendor policy was interpreted independently in three places. `RequestDealTool`
raised on an unrecognized value, `MultiSellerOrchestrator` raised on its own list, and
`DiscoverInventoryTool` branched on `== "block"`, so any other spelling, `BLOCK` included,
fell through to the keep path and admitted vendors SGP had not vouched for. Nothing
lowercased the value, so a mis-cased env var was a config error rather than a synonym.

## What changed

### Domain resolution order

Product vocabulary first, then the deal / SSP-connector names:

```
domain, seller_domain, sellerDomain              # product, prefer these
publisherDomain, publisher_domain, seller_url    # deal / SSP connector
publisherId, publisher                           # only when they contain a "."
```

`sellerUrl` is dropped (unused anywhere). Each group is commented in-source with the
vocabulary it belongs to, so the connector names are not mistaken for product fields.
`seller_url` sits lowest on purpose: on a deal record it denotes the seller system endpoint,
not the vendor identity.

### Response-to-request pairing

Every record now carries the domain it answers, so pairing is a dictionary lookup:

| Field | Meaning |
|---|---|
| `requestedDomain` | The queried domain this record answers, normalized the same way the client normalizes before sending. Null when SGP could not pair it |
| `matchType` | `exact` (vendor registered under the queried domain), `parent` (queried domain is a subdomain of it), or `unresolved` (SGP could not pair the record) |

The response returns one record per requested domain rather than one per vendor, so querying
two domains that resolve to the same vendor returns two records, each naming the domain it
answers.

Records marked `unresolved`, and records echoing a domain the client did not ask about, are
logged at `WARNING` and ignored rather than dropped silently.

`_same_site()` and the two-pass resolution it supported are removed. No apex-vs-subdomain
reasoning is left on this side.

> [!IMPORTANT]
> The conservative rule is the part to look at closely. The deal-request stage always
> queries exactly one domain, and `MultiSellerOrchestrator` can too when a single seller is
> in play. A permissive "one record answers one query" fallback in that shape would let a
> record about a different vendor authorize a Deal ID, so it is deliberately absent: a record
> is never attributed to a queried domain it does not name, even as the only record in the
> response. There is a regression test asserting the gate blocks when SGP answers about
> another vendor.

### Retry on transient failures

`_RETRYABLE_STATUS_CODES` is now acted on, and covers `{429, 502, 503, 504}`. 429 is added
because rate limiting is transient by definition. Transport errors (connect, timeout, DNS,
read) retry on the same path.

| Aspect | Behavior |
|---|---|
| Attempts | `1 + SGP_MAX_RETRIES`, default `2`, so three attempts |
| Backoff | `SGP_RETRY_BACKOFF_SECONDS * 2**attempt`, base `0.5s` by default |
| Retried | transport errors, `429`, `502`, `503`, `504` |
| Never retried | `200`, `400`, `401`, `404`, which are answers rather than blips |
| On exhaustion | original failure raised as `SGPClientError`; callers still fail closed |

The budget is set through the environment, since operators tune deployments through config
rather than by editing a client class:

| Variable | Default | Purpose |
|---|---|---|
| `SGP_TIMEOUT_SECONDS` | `15.0` | Per-request timeout for one approval lookup |
| `SGP_MAX_RETRIES` | `2` | Extra attempts for transient failures; `0` disables retrying |
| `SGP_RETRY_BACKOFF_SECONDS` | `0.5` | Base backoff, doubled per attempt |

`SGP_TIMEOUT_SECONDS` closes a pre-existing gap: `_build_sgp_client` never forwarded a timeout
at all, so the gate ran on the client's 15s default with no way to change it. The equivalent
constructor arguments remain, with the same defaults, so direct callers and tests are
unaffected. Bounds are validated rather than clamped. A zero timeout or a negative retry
budget fails at settings load instead of being coerced into something that looks workable.

The batch size stays hardcoded at 10 domains per call: that is the limit SGP enforces on its
side, so exposing it would only let a deployment violate the API contract.

The exhaustion message carries the attempt count, so "returned 503" and "returned 503 after 3
attempts" are distinguishable in logs. Response handling moved to `_parse_chunk_response()` to
keep the retry loop legible.

> [!WARNING]
> **Retries multiply the worst-case wait, and this is the tradeoff to review.** The backoff
> is small, but each retry is a fresh request that can burn the full `SGP_TIMEOUT_SECONDS`. With the
> defaults (15s timeout, three attempts) a chunk that keeps timing out takes ~46s where it
> previously took 15s, and chunks of 10 domains are fetched *sequentially*, so 30 distinct
> seller domains is three chunks and up to ~140s in the pathological case. This only bites
> when SGP is timing out; a reachable SGP answers or refuses on the first attempt. Deployments
> behind a tighter deadline should lower `SGP_MAX_RETRIES`, `SGP_TIMEOUT_SECONDS`, or both.

### One vocabulary for the unknown-vendor policy

`UNKNOWN_VENDOR_POLICIES` and `normalize_unknown_policy()` now live in `models/sgp.py` and are
used by `RequestDealTool`, `DiscoverInventoryTool`, `MultiSellerOrchestrator`, and a
`field_validator` on `Settings`. The helper strips and lowercases, then rejects anything
outside the set, so `SGP_UNKNOWN_VENDOR_POLICY=BLOCK` resolves to `block` instead of being
reinterpreted per call site. The orchestrator's duplicate policy list is gone.

They sit with the models rather than with the client on purpose. `Settings` has to validate the
policy, and importing `ad_buyer.clients.sgp_client` pulls in `ad_buyer.clients.__init__` and
therefore all eight client modules, one of which (`ucp_client`) reads settings back. That
edge only worked because its settings import is function-local, so it was one hoisted import
away from a circular-import failure at startup. `models/sgp.py` depends on nothing but pydantic,
which keeps the direction one-way. A guard test asserts `ad_buyer.clients` is absent from
`sys.modules` after `Settings()` is constructed.

An explicitly empty `SGP_UNKNOWN_VENDOR_POLICY=` is treated as unset and falls back to `block`
rather than failing startup. Every other SGP variable already reads empty as unconfigured, so
the policy should not be the one that refuses to boot. A value that is genuinely unrecognized
still fails at settings load.

The discovery filter is also rewritten to state its intent positively: a product is kept
only for `warn` or `allow`, and anything else blocks.

```python
if self._sgp_unknown_policy in ("warn", "allow"):
    filtered.append(product)
    continue
counts["unknown_blocked"] += 1
```

So a policy value added later defaults to excluding an unverified vendor rather than
admitting one.

### Client lifecycle

`SGPClient.aclose()` is idempotent and the client is an async context manager, matching every
other client in `clients/`. `MultiSellerOrchestrator`, which owns the client the gate uses,
gains `aclose()` / `__aenter__` / `__aexit__`; teardown logs and swallows failures, because
cleanup must never be the thing that raises.

> [!NOTE]
> This adds the cleanup path but does not call it. The orchestrator is built lazily inside
> `DealBookingFlow._get_orchestrator()` and the chat interface, neither of which has a
> shutdown hook, and the API `lifespan` holds no handle on those instances. Wiring it would
> need an instance registry, which is a broader app-lifecycle change than this PR. The
> footprint today is one connection pool per long-lived orchestrator.

## Behavior changes

Only reachable with `SGP_ENFORCE=true` and a key configured.

- Sellers whose agent-card `url` is a subdomain of their vendor's registered domain now
  pass the orchestrator gate on their real approval status. Previously they resolved to
  UNKNOWN and were excluded at discovery under the default `block` policy.
- Products populating `domain` are now resolved and checked against SGP. Previously they
  were treated as unverifiable and excluded at discovery / blocked at request.
- An approval for a vendor registered under a parent of the queried domain now resolves, so
  it is the record, not UNKNOWN, that gets cached for `SGP_CACHE_TTL_SECONDS`.
- Verdicts no longer depend on record ordering within a response.
- A record carrying no `requestedDomain` is ignored rather than keyed on its canonical
  domain.

Unverifiable products (those populating none of the probed fields) are still excluded
under enforcement, regardless of `SGP_UNKNOWN_VENDOR_POLICY`, and still without an SGP
call. That path is unchanged; the operator-facing message now names `domain` as the field
to populate.

- A transient SGP failure now costs up to two extra attempts (default ~1.5s of added latency
  in the worst case) instead of immediately failing closed. A sustained outage still fails
  closed, just later and with the attempt count recorded.
- `SGP_UNKNOWN_VENDOR_POLICY` is now case-insensitive. Values that previously raised at
  construction (`BLOCK`, `Warn`) now work; values that are genuinely unrecognized now fail at
  settings load rather than at the first tool construction. An empty value resolves to `block`
  instead of reaching the gate uninterpreted.
- `DiscoverInventoryTool` no longer admits unknown vendors when handed an unrecognized policy.
  It blocks, matching the orchestrator and the deal-request gate.

Both `DiscoverInventoryTool` / `RequestDealTool` and the canonical
`DealBookingFlow` → `MultiSellerOrchestrator` pipeline route through
`SGPClient.check_approvals()`, so the pairing and retry rules apply to both.

## Testing

**153 passing** across the four SGP suites:

| Suite | Passing |
|---|---|
| `tests/unit/test_sgp_client.py` | 80 |
| `tests/unit/test_sgp_gate.py` | 32 |
| `tests/unit/test_orchestrator_sgp_gate.py` | 25 |
| `tests/unit/test_sgp_settings_policy.py` (new) | 16 |

The settings tests are a separate module rather than an addition to
`test_settings_lazy_init.py`, which reloads `ad_buyer.config.settings` and so pollutes any
later test holding the previous `settings` object. That fragility is pre-existing: clean
`main` fails three orchestrator tests if the reload module runs first, which alphabetical
collection ordering normally hides. The new module avoids inheriting it by only constructing
`Settings` directly. Verified order-independent in both directions.

<details>
<summary>Coverage added</summary>

Domain resolution:
- Resolution from a `Product` built via `models.opendirect` (constructed by field name, so
  it survives future alias changes)
- Each supported key resolving through the gate, parametrized
- `domain` preferred over `seller_url` when both are present
- Opaque `publisherId` (`pub_abc`) correctly not treated as a domain

Matching:
- A `parent` echo resolving a queried subdomain, and an `exact` echo resolving its own domain
- One record per requested domain when several resolve to the same vendor
- The client declining to infer a parent relationship that no echo names
- `unresolved` records logged and ignored
- A record echoing an unrequested domain ignored, parametrized over single- and
  multi-domain requests
- A record carrying no echo at all not being attributed to anything
- A record with an empty domain not being attributed
- Echo normalization: trailing-dot FQDN, scheme/`www.`, and casing
- The resolved record, not UNKNOWN, being what gets cached
- End-to-end: the deal gate blocks when SGP answers about a different vendor

Retry:
- Recovery after one transient failure, parametrized over every retryable status
- Recovery after a transport error
- Exhaustion still raising, with the attempt count asserted
- `400` / `401` / `404` taking exactly one attempt
- `max_retries=0` disabling retries
- Backoff growth asserted as `[0.5, 1.0, 2.0]` via a patched `asyncio.sleep`

Policy and lifecycle:
- Canonicalization of `BLOCK` / `  Warn  ` / `Allow`, and rejection of unrecognized values
- Discovery blocking an unknown vendor under a mis-cased policy
- Both tools agreeing that an unrecognized policy is a configuration error
- Orchestrator `aclose()` closing the client, tolerating a missing client, and swallowing a
  client failure
- Orchestrator and client async-context-manager teardown
- `aclose()` being idempotent

Settings:
- Default, case/whitespace canonicalization, and rejection of unrecognized values at load
- Empty value falling back to `block` rather than failing startup
- A guard asserting `Settings()` does not import `ad_buyer.clients`, validated by
  reintroducing the import edge and confirming that test, and only that test, fails

</details>

The behavioral tests were confirmed against the pre-change source: 10 of them fail without
the fixes (discovery fail-open, policy canonicalization and rejection, and the orchestrator
lifecycle). The retry tests are the exception. `test_sgp_client.py` imports
`normalize_unknown_policy`, so it cannot even be collected against the old module; those were
verified by direct runtime exercise instead of a red-then-green run.

Gate fixtures were rebuilt on the canonical product shape; they previously attached
`seller_url` to products, which is the deal vocabulary rather than the product one.

## Docs

`docs/integration/iab-diligence-platform.md`:

- New **Domain matching** section covering probe order, the `requestedDomain` / `matchType`
  fields, the one-directional resolution rule, how unpaired records are treated, and the
  caching consequence
- New **Transient failures and retries** section covering what is and isn't retried, attempts
  and backoff, why the defaults are what they are, and that retries change timing rather than
  any verdict, plus a warning admonition quantifying the worst-case wait and how to bound it
- Behavior-matrix note on the unverifiable-product row, and the transport-error row now reads
  "after retries"
- `SGP_UNKNOWN_VENDOR_POLICY` documented as case-insensitive, with unrecognized values failing
  at settings load
- Troubleshooting rows for the unresolved-domain and unpairable-record symptoms, for a
  batch-wide `check_failed`, and for the startup validation error
- Configuration table gains `SGP_TIMEOUT_SECONDS`, `SGP_MAX_RETRIES`, and
  `SGP_RETRY_BACKOFF_SECONDS`

`docs/guides/configuration.md`:

- Policy row updated to match, the three new variables added, and a retry note giving the
  worst-case formula and pointing at the integration guide

`.env.example` gains the three variables with inline comments covering what is and isn't
retried, that `0` disables retrying, and the worst-case arithmetic, so the tradeoff is visible
where someone is actually editing config.

Builds clean under `mkdocs build --strict`, with the new anchor and the cross-page link from
the configuration guide both verified in the generated HTML.

## Checklist

- [x] `ruff check` / `ruff format --check` clean on all touched files
- [x] SGP suites passing (153)
- [x] `mkdocs build --strict` passing
- [x] Full `tests/unit` suite green: 3411 passed / 1 skipped
- [x] No new dependencies; the three new environment variables all default to prior behavior
- [x] Inert when `SGP_API_KEY` is empty or `SGP_ENFORCE=false`
- [x] Enforcement still fails closed on a sustained SGP outage
